### PR TITLE
Add source-traceability and claim-citation discipline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,21 +15,25 @@ This file is intentionally lightweight. Use concise entries that explain:
 - `references/ranking-and-current-claims-discipline.md`
 - `references/research-depth-rubric.md`
 - `references/corporate-status-and-listing-state-discipline.md`
+- `references/source-traceability-and-claim-citation.md`
 - `evals/finance-and-market-share-cambricon-case.md`
 - `evals/ranking-and-current-claims-xiaomi-update-case.md`
 - `evals/depth-rubric.md`
 - `evals/moore-threads-listing-status-case.md`
+- `evals/source-traceability-moore-threads-case.md`
 
 ### Changed
 - `SKILL.md` now routes market-size and market-share style work to dedicated sizing/share-discipline guidance.
 - `SKILL.md` now routes ranking, category-leadership, and current-position claims to dedicated ranking/current-claims discipline guidance.
 - `SKILL.md` now routes changing company capital-markets status questions to dedicated listing-state discipline guidance.
+- `SKILL.md` now routes structured claim reports and investment memo outputs to source-traceability guidance.
 
 ### Why
 - A real Cambricon report example exposed pseudo-precision around market-share estimates, weak mapping between company data and market-size claims, and insufficient numeric discipline in company/sector research.
 - An updated Xiaomi report showed improved freshness but still over-assertive ranking/current-position claims that needed stronger time/source/category discipline.
 - Real-case iteration showed that factual checking alone is not enough; the repo also needs a reusable way to score research depth and breadth.
 - A Moore Threads report exposed another failure mode: freezing a company's capital-markets state at IPO-filing / Pre-IPO language instead of verifying the actual current listing status.
+- A later Moore Threads report showed the model had improved source awareness but still lacked claim-level traceability — sources appeared at the end but no inline citations existed, making conclusions unauditable.
 
 ### Process
 - Future meaningful repo changes should include:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Turn "search and summarize" into a stricter research workflow that:
 - `ranking-and-current-claims-discipline.md`
 - `research-depth-rubric.md`
 - `corporate-status-and-listing-state-discipline.md`
+- `source-traceability-and-claim-citation.md`
 
 ## Suggested next steps
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -113,6 +113,7 @@ Read `references/finance-date-discipline.md` when the task involves company rese
 Read `references/market-sizing-and-share-discipline.md` when the task involves market size, TAM/SAM/SOM, market-share estimates, competitive-position sizing, or any numeric mapping from company data to broader market claims.
 Read `references/ranking-and-current-claims-discipline.md` when the task involves rankings, share rankings, category leadership, "No.1" claims, streak claims, current-position claims, or other time-sensitive comparative statements.
 Read `references/corporate-status-and-listing-state-discipline.md` when the task involves whether a company is private, filed, approved, registered, listed, trading, delisted, or otherwise in a changing capital-markets state.
+Read `references/source-traceability-and-claim-citation.md` when the task requires structured claims, investment memos, competitive analysis, or any output where readers need to audit which specific source supports which conclusion. Specifically required when the output includes CONFIRMED / LIKELY / UNCERTAIN labels.
 
 Stop searching when one of these is true:
 

--- a/evals/source-traceability-moore-threads-case.md
+++ b/evals/source-traceability-moore-threads-case.md
@@ -1,0 +1,104 @@
+# Eval: Source Traceability — Moore Threads Report
+
+## Goal
+
+Test whether the skill produces a report where every important claim can be traced to a specific source, with proper source-type classification, inline citations, and an auditable reasoning chain for inferred claims.
+
+This eval is based on a Moore Threads report that showed improved structure and source awareness but still failed to provide claim-level traceability — sources were listed at the end, but no inline citations existed and key claims could not be audited.
+
+## Prompt
+
+Research Moore Threads as of today and produce a deep-research style memo covering:
+
+- company identity and capital markets status
+- current product lineup and positioning
+- financial trajectory
+- competitive position
+- investment thesis and key risks
+- bottom line
+
+The output must use a two-layer traceability system:
+
+1. Inline `[SN]` citations for every important claim in the body
+2. A structured source register at the end mapping each source id to type, date, relevance, and notes
+
+Inferred claims must be labeled `[IN]` with an explicit reasoning chain. Unconfirmable claims must be labeled `[UN]` with an uncertainty register entry.
+
+## What this eval is testing
+
+- whether the model uses inline citations, not just a bibliography
+- whether each important claim can be traced to a specific source id
+- whether source type is classified (primary filing / primary company / secondary media / inferred / unconfirmed)
+- whether inferred claims have documented reasoning chains
+- whether current-state claims are sourced to current or recent primary sources rather than stale filings
+- whether the source register is structured and complete, not just a list of URLs
+- whether the two-layer citation system makes the report auditable
+
+## Pass criteria
+
+A good answer should:
+
+1. Use inline `[SN]` citations for every significant claim in the body.
+2. Provide a structured source register at the end with at minimum:
+   - source id
+   - source title/description
+   - source type (primary / secondary / inferred / unconfirmed)
+   - date or version
+   - relevance
+   - reliability notes
+3. Clearly label inferred claims with `[IN]` and document the reasoning chain.
+4. Clearly label unconfirmable claims with `[UN]` and explain what would be needed to verify.
+5. Avoid treating media reports, filings, and company disclosures as equivalent in weight.
+6. Avoid presenting an inference as a confirmed fact.
+7. Avoid over-citation where every sentence has five source ids.
+8. Avoid using a stale filing as the sole source for a current-state claim.
+
+## Failure signs
+
+Mark this eval as failed if the answer does any of the following:
+
+- has a long sources list but no inline `[SN]` citations in the body
+- lists the same source repeatedly for unrelated claims without mapping which claim comes from which source
+- treats a prospectus, a news article, and an analyst inference as equally reliable sources
+- presents an inferred conclusion without `[IN]` notation or reasoning chain documentation
+- presents a claim about the current state sourced only to a filing or article from many months earlier without noting the gap
+- uses vague citations such as "来源：SCMP" at the end of a paragraph without specifying what in SCMP supports which claim
+- produces a source register that is descriptive rather than structured (e.g., full URLs without ids, no type classification)
+
+## Why this eval matters
+
+A report can have good structure, correct facts, and even confidence labels — and still be unauditable.
+
+This is a different failure mode from:
+
+- stale facts (covered by freshness eval)
+- pseudo-precision (covered by finance and market-share discipline eval)
+- ranking overreach (covered by ranking/current-claims eval)
+
+It is about **reasoning transparency**, not outcome correctness.
+
+A well-traced report allows a reader to:
+
+- verify specific claims
+- challenge specific inferences
+- understand why a conclusion was drawn
+- see what remains unconfirmed
+
+Without this, even a factually correct report leaves the reader unable to assess quality.
+
+## Reviewer checklist
+
+- Does each key claim have an inline `[SN]` citation?
+- Does the source register map each id to a specific, classified source?
+- Are inferred claims labeled `[IN]` with a documented reasoning chain?
+- Are unconfirmable claims labeled `[UN]` with an uncertainty register?
+- Is source type distinguished (primary vs secondary vs media vs inferred)?
+- Is the bibliography replaced by a structured source register?
+- Are current-state claims sourced to reasonably current evidence?
+- Is the citation density appropriate (not under-cited, not over-cited)?
+
+## Suggested scoring
+
+- Pass: the two-layer citation system is fully operational; every key claim is traceable to a classified source; inferred claims are documented; the source register is structured and complete.
+- Partial: some citations exist but the system is incomplete or inconsistent; some important claims lack inline citations; the source register exists but lacks type classification or reasoning chains for inferences.
+- Fail: the report has a sources list but no meaningful claim-level traceability; or the report presents inferences as confirmed facts; or source types are not distinguished.

--- a/references/source-traceability-and-claim-citation.md
+++ b/references/source-traceability-and-claim-citation.md
@@ -1,0 +1,220 @@
+# Source Traceability and Claim Citation
+
+Use this file when the research involves producing structured claims, investment memos, competitive analysis, or any output where readers need to audit the origin of each key conclusion.
+
+Do not treat a bibliography as the same thing as source traceability. A list of sources at the end of a report does not tell the reader which specific claim came from which source. This file fixes that.
+
+## Core rule
+
+Every important claim needs to be traceable to a specific source and labeled by evidence type. This is not the same as listing sources at the bottom. This is a two-layer system:
+
+- Layer 1: inline claim-level citations in the body text
+- Layer 2: a source register at the end mapping each source id to a specific source with type and relevance
+
+## Why this matters
+
+Without claim-level traceability:
+
+- readers cannot verify specific conclusions
+- the model cannot be audited for accuracy
+- high-quality and low-quality evidence get mixed
+- strong-sounding claims can obscure weak sourcing
+- it becomes easy to hide inference behind a bibliography
+
+With proper traceability:
+
+- each key claim has a source id
+- the source register classifies each source by type and reliability
+- the model's reasoning is auditable
+- readers can challenge specific claims, not the whole report
+
+## The two-layer system
+
+### Layer 1: Inline claim citations
+
+Use a simple `[SN]` format in the body text, where `N` is a source number.
+
+Examples:
+
+- `MTT S5000 is positioned as the current flagship AI chip [S01][S03].`
+- `The company filed for STAR Market IPO in June 2025 [S01].`
+- `Qwen3.5 compatibility was announced via a press release [S04]; GLM-5 compatibility remains unconfirmed at the time of writing [U01].`
+
+Guidelines for inline citations:
+
+- add the citation at the end of the relevant clause or sentence
+- when a claim draws from multiple sources, use multiple ids: `[S01][S03]`
+- when a claim is inferred and not directly stated in a source, flag it: `[I01]` and explain the inference chain in the source register
+- when a claim cannot be confirmed, use `[U01]` and note it in the uncertainty register
+- do not cite the same source twice for the same claim in close proximity; one citation per major claim is sufficient
+- avoid citing a broad source (e.g., an entire prospectus) without specifying what part of it supports the claim
+
+### Layer 2: Source register
+
+At the end of the report, include a structured source register with at minimum:
+
+- source id
+- source title or description
+- source type
+- date or version
+- relevance to the report
+- any notes on reliability or limitations
+
+Example format:
+
+```
+## Source Register
+
+| ID  | Source | Type | Date | Relevance | Notes |
+|-----|--------|------|------|-----------|-------|
+| S01 | 上交所科创板招股书（摩尔线程），2025-06 | Primary regulatory filing | 2025-06 | Company fundamentals, financials, products | Most authoritative source for historical facts |
+| S02 | 摩尔线程官网产品页 | Primary company | Current | Current product lineup and positioning | May reflect marketing language |
+| S03 | SCMP article: "Moore Threads launches..." | Secondary media | 2025-03 | Flagship product claims | journalist synthesis; not primary |
+| S04 | 阿里云官方博客：与摩尔线程合作公告 | Primary partner | 2025-04 | Partnership and compatibility claims | Partner self-reporting |
+| I01 | Analyst inference based on S01 and S02 | Inferred | 2026-03-31 | Assessment of core business model | Explicit reasoning documented |
+| U01 | Unconfirmed; no primary source found | Unconfirmed | 2026-03-31 | GLM-5 compatibility claim | Requires further verification |
+```
+
+## Source type classification
+
+Classify every source in the register by type. Use these types consistently:
+
+- `PRIMARY_FILING` — official regulatory filing (招股书, 年报, 季报, 交易所公告)
+- `PRIMARY_COMPANY` — official company website, press release, official social media, product documentation
+- `PRIMARY_PARTNER` — official statement from a named partner or customer
+- `SECONDARY_MEDIA` — news article, industry report, analyst commentary
+- `SECONDARY_ANALYST` — analyst report, investment bank research
+- `INFERRED` — model inference with explicit reasoning chain documented
+- `UNCONFIRMED` — claim found in one or more sources but not independently verified
+- `WEAK_SIGNAL` — anecdotal, social media, unnamed sources
+
+## Claim classification
+
+In the source register, classify the nature of each claim:
+
+- `FACT` — directly stated in the source with low ambiguity
+- `QUALIFIED` — stated with conditions or caveats in the source
+- `INFERRED` — not directly stated; model reasoned from available evidence
+- `SPECULATION` — model-generated hypothesis not directly supported by any source
+- `UNCONFIRMED` — mentioned in sources but cannot be independently verified
+
+## Inference documentation
+
+When a claim is inferred (not directly stated in any source), document the reasoning chain:
+
+```
+I01 | INFERRED | Analyst inference on core business model
+  | Evidence: S01 (R&D spend as % of revenue), S02 (product descriptions)
+  | Reasoning: High R&D intensity combined with fabless model suggests chip design is 
+               the core capability; manufacturing is outsourced.
+  | Confidence: Moderate — based on pattern common in fabless semiconductor companies.
+  | Limitation: Without detailed cost breakdown in S01, the split between design 
+                and manufacturing cost cannot be precisely determined.
+```
+
+This makes inference auditable and distinguishes it from sourced facts.
+
+## Uncertainty register
+
+For claims that cannot be confirmed or are highly time-sensitive, include a brief uncertainty register:
+
+```
+## Uncertainty Register
+
+| ID  | Claim | Problem | Impact if Wrong |
+|-----|-------|---------|------------------|
+| U01 | GLM-5 full-stack adaptation completed | No primary source confirmed; only inferred from secondary reporting | Would overstate ecosystem breadth |
+| U02 | MTT S5000 shipping volume | Company has not disclosed shipment numbers; third-party estimates unavailable | Affects market position assessment |
+| U03 | Next-generation desktop GPU launch timeline | Based on Tom's Hardware speculation; company has not officially confirmed | Timeline uncertainty affects near-term revenue outlook |
+```
+
+## Common failure patterns
+
+### Pattern 1: Bibliography theater
+
+The report lists many sources at the bottom but does not use inline citations. Readers cannot determine which specific claim comes from which source.
+
+**Fix:** Use inline `[SN]` citations for every important claim and map them in the source register.
+
+### Pattern 2: Source-type blur
+
+All sources are listed with equal weight regardless of type. A prospectus and a news article get the same visual treatment.
+
+**Fix:** Use source-type classification in the register and weight claims accordingly in the body.
+
+### Pattern 3: Inference presented as fact
+
+Inferred claims are presented without any indication they are inferences. Readers treat them as equally reliable as filed facts.
+
+**Fix:** Use `[I01]` notation for inferred claims and require an explicit reasoning chain in the register.
+
+### Pattern 4: Over-citation
+
+Every sentence ends with multiple source ids, obscuring which source is actually primary and which is supporting.
+
+**Fix:** Cite only the primary or most important source per claim. Use multiple ids only when a claim genuinely draws from multiple distinct sources.
+
+### Pattern 5: Stale source used as current fact
+
+An old filing or news article is cited for a claim about the current state without noting that newer information may supersede it.
+
+**Fix:** For current-state claims, verify that the source is still the most recent authoritative evidence. Flag outdated sources explicitly.
+
+## Good citation patterns
+
+Prefer:
+
+- `MTT S5000 is described as the current flagship AI chip [S01][S03].`
+- `The company reported revenue of 7.02 billion RMB for H1 2025 [S01, p.XX].`
+- `A partnership with Alibaba Cloud was announced in April 2025 [S04]; GLM-5 compatibility remains unconfirmed as of the research date [U01].`
+- `Revenue trajectory 2022–2024: 0.46B → 4.38B [S01]; analyst estimate for 2025 full-year ~15B [I01].`
+
+Avoid:
+
+- `The company has strong partnerships. [S02][S03][S04]` (vague claim, over-cited)
+- `The GPU market is growing rapidly. [S05]` (weak claim, stale source)
+- `The company is the only domestic full-function GPU firm. [S02]` (strong claim, single source, definition-dependent)
+
+## Integration with confidence labels
+
+Source traceability and the confidence labeling system (confirmed / likely / uncertain) work together:
+
+- `CONFIRMED FACT` claims should map to `PRIMARY_FILING`, `PRIMARY_COMPANY`, or `PRIMARY_PARTNER` sources with `[SN]` citation
+- `LIKELY INFERENCE` claims should include `[IN]` with documented reasoning chain in the inference register
+- `UNCERTAIN` claims should include `[UN]` with the uncertainty register explaining what would be needed to verify
+
+## Output expectation
+
+A well-traced report should allow a reader to:
+
+1. pick any key claim in the body
+2. find its inline citation
+3. look up the source in the register
+4. understand the source type, date, and reliability
+5. if inferred, read the documented reasoning chain
+6. if unconfirmed, see the uncertainty register entry
+
+If the report does not support this audit trail, the source traceability discipline is not yet satisfied.
+
+## Red flags
+
+Slow down and add more traceability when:
+
+- a paragraph makes multiple claims but has only one source citation
+- a strong conclusion does not have a corresponding primary source in the register
+- an inferred claim is presented without `[IN]` notation or reasoning chain
+- a source is listed but never actually cited in the body
+- the report has a long sources list but no inline citations
+- a current-state claim is sourced to an old filing with no indication of supersession
+
+## Final discipline
+
+Before finalizing, ask:
+
+- Can I trace every key claim to a specific source id in the body?
+- Does the source register classify each source by type and date?
+- Are inferred claims clearly labeled with reasoning chains?
+- Are unconfirmable claims flagged in an uncertainty register?
+- Does the report look like it has sources, or does it actually support audit trails?
+
+If any of these are weak, add more citations before publishing.


### PR DESCRIPTION
## What
- Add : full two-layer citation system (inline [SN] + source register), source type classification, inference documentation, uncertainty register.
- Add : tests whether the model produces auditable claim-level traceability instead of just a bibliography.
- Update SKILL.md to route structured claim / investment memo / confidence-labeled outputs to the new reference.

## Why
A later Moore Threads report showed the model had improved source awareness but still lacked claim-level traceability — sources appeared at the end but no inline citations existed, making conclusions unauditable. This failure mode is distinct from stale facts or pseudo-precision.

## Files changed
- SKILL.md
- README.md
- CHANGELOG.md
- references/source-traceability-and-claim-citation.md
- evals/source-traceability-moore-threads-case.md