### PR TITLE
Require current valuation snapshot for listed company research

### DIFF
--- a/references/finance-date-discipline.md
+++ b/references/finance-date-discipline.md
@@ -62,6 +62,21 @@ Example phrasing:
 - `As of the market snapshot reviewed on 2026-03-30, ...`
 - `The reported PE appears to be TTM rather than forward PE.`
 
+### Mandatory for listed companies
+
+**For any listed-company research, a current valuation snapshot is required, not optional.**
+
+At minimum, include:
+
+- approximate current stock price
+- approximate market capitalization
+- current valuation ratios (PE, PB, PS) with basis (TTM or forward) and date
+- 52-week high/low range if relevant
+
+If this data cannot be obtained cleanly, note the limitation explicitly rather than omitting it.
+
+Do not write a listed-company investment memo without current market context. Historical financials alone are insufficient for investment analysis.
+
 ## 3. Forward-looking targets or estimates
 
 Examples:


### PR DESCRIPTION
## What
- Strengthen : add explicit mandatory requirement that any listed-company investment memo must include a current valuation snapshot (stock price, market cap, PE/PB/PS with basis and date, 52-week range). This is not optional.

## Why
An Apple report covering FY2025 financials but omitting current stock price, PE, PB, and market cap illustrates a systematic gap. For listed companies, historical reported financials alone are insufficient for investment analysis. A current market snapshot is required.