### PR TITLE
Add four execution-time checklists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ This file is intentionally lightweight. Use concise entries that explain:
 - `evals/apple-product-and-valuation-case.md`
 - `evals/apple-product-roadmap-and-investment-case.md`
 - `evals/industry-landscape-depth-case.md`
+- `checklists/listed-company-report.md`
+- `checklists/source-traceability.md`
+- `checklists/forward-looking-claims.md`
+- `checklists/final-audit.md`
 
 ### Changed
 - `SKILL.md` now routes market-size and market-share style work to dedicated sizing/share-discipline guidance.
@@ -41,6 +45,7 @@ This file is intentionally lightweight. Use concise entries that explain:
 - An Apple report exposed two additional failure modes: (1) using stale product generations as current when iPhone 17, M5, and Apple Watch 11 have all shipped, and (2) omitting current valuation snapshot entirely for a listed-company investment memo.
 - A later Apple product roadmap + investment analysis report showed source traceability was still missing, forward-looking claims lacked reasoning chains, marketing language was not separated from facts, and product analysis was mixed with investment advice without proper boundaries.
 - An AI industry value-chain report exposed a different depth failure mode: broad coverage and plausible synthesis, but still more like a high-quality landscape briefing than true deep research with prioritized variables, value-accrual analysis, and counter-evidence.
+- After systematic review, the skill had grown to the point where key execution rules (listed-company fields, source traceability, forward-looking claims, final audit) were buried in prose and not reliably enforced. Four execution-time checklists were added as a lightweight anti-forgetting structure: each replaces prose guidance with a concrete run-before-delivery checklist.
 
 ### Process
 - Future meaningful repo changes should include:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Turn "search and summarize" into a stricter research workflow that:
 
 - `SKILL.md` — main skill protocol
 - `references/` — supporting playbooks and templates
+- `checklists/` — execution-time audit checklists (run before delivery)
 - `examples/` — example tasks and failure cases
 - `evals/` — lightweight regression/evaluation prompts
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -35,17 +35,17 @@ Never present inference as confirmed fact.
 Before searching, identify:
 
 - the main question
-- the user’s likely decision or use case
+- the user's likely decision or use case
 - the required depth
 - the time horizon if relevant
 - whether the user wants explanation, recommendation, comparison, or diligence
 
-If the user’s wording is broad, anchor on the most decision-relevant interpretation instead of drifting into general background.
+If the user's wording is broad, anchor on the most decision-relevant interpretation instead of drifting into general background.
 
 Examples:
 
-- “Research AI coding agents” may really mean market entry, competitive positioning, or vendor selection.
-- “Research this company” may really mean partnership diligence, investment risk, or product comparison.
+- "Research AI coding agents" may really mean market entry, competitive positioning, or vendor selection.
+- "Research this company" may really mean partnership diligence, investment risk, or product comparison.
 
 ## Step 2: Classify the task type
 
@@ -110,10 +110,15 @@ For every important claim, capture:
 Read `references/source-quality.md` when source ranking is ambiguous.
 Read `references/claim-matrix.md` when the task has multiple important conclusions, conflicting evidence, or high stakes.
 Read `references/finance-date-discipline.md` when the task involves company research, financial performance, valuation, guidance, delivery volumes, or other time-sensitive numeric claims.
+Read `checklists/listed-company-report.md` for listed-company research - applies the required fields gate before delivery.
+
 Read `references/market-sizing-and-share-discipline.md` when the task involves market size, TAM/SAM/SOM, market-share estimates, competitive-position sizing, or any numeric mapping from company data to broader market claims.
 Read `references/ranking-and-current-claims-discipline.md` when the task involves rankings, share rankings, category leadership, "No.1" claims, streak claims, current-position claims, or other time-sensitive comparative statements.
 Read `references/corporate-status-and-listing-state-discipline.md` when the task involves whether a company is private, filed, approved, registered, listed, trading, delisted, or otherwise in a changing capital-markets state.
 Read `references/source-traceability-and-claim-citation.md` when the task requires structured claims, investment memos, competitive analysis, or any output where readers need to audit which specific source supports which conclusion. Specifically required when the output includes CONFIRMED / LIKELY / UNCERTAIN labels.
+Run `checklists/source-traceability.md` before delivery if the output is a structured or investment-relevant memo.
+
+Read `checklists/forward-looking-claims.md` when the task involves product release timelines, pricing forecasts, forward financial estimates, or any forward-looking statements.
 
 Stop searching when one of these is true:
 
@@ -349,12 +354,8 @@ When the topic changes over time, explicitly include the time dimension:
 
 ## Final discipline
 
-Before delivering the final report, check:
+Before delivering the final report, run `checklists/final-audit.md`.
 
-- Did I answer the user’s real objective?
-- Did I rely too much on one narrative or one source chain?
-- Did I test my main conclusion against counter-evidence?
-- Did I clearly separate confirmed facts, inference, and uncertainty?
-- Did I give the user a useful bottom line rather than just a long summary?
+It checks: real objective answered, evidence quality, counter-evidence, uncertainty honesty, completeness, and recall discipline.
 
-If not, revise before answering.
+A report that fails the final audit checklist is not ready for delivery.

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -1,0 +1,44 @@
+# Final Audit Checklist
+
+Run through every item before delivering any deep research output.
+
+This is the last gate before the report goes to the user. If any item fails, revise before delivery.
+
+## Core question answered
+
+- [ ] the report answers the user's actual question, not just the general topic
+- [ ] the most important 2-3 variables are clearly stated and supported
+- [ ] the bottom line is clear and actionable
+
+## Evidence quality
+
+- [ ] no major claim rests on a single weak source
+- [ ] evidence hierarchy is visible: confirmed facts, well-supported inferences, and weak claims are not mixed
+- [ ] key numbers are sourced and dated
+
+## Counter-evidence
+
+- [ ] the strongest argument against the main conclusion is present
+- [ ] competing explanations are noted where relevant
+- [ ] limitations and risks are explicit, not buried
+
+## Uncertainty
+
+- [ ] what could not be verified is stated explicitly
+- [ ] confidence levels match evidence quality
+- [ ] the report does not claim more certainty than the evidence supports
+
+## Completeness
+
+- [ ] the report does not leave a strong impression while having weak substance
+- [ ] every section either adds decision-relevant information or is cut
+
+## Recall discipline
+
+- [ ] current-state verification was run for fast-moving topics
+- [ ] listing status and financial snapshot were verified for listed companies
+- [ ] source traceability was applied for structured or investment-relevant outputs
+
+## Quality bar
+
+A report that fails this checklist is not ready for delivery, regardless of length or apparent polish.

--- a/checklists/forward-looking-claims.md
+++ b/checklists/forward-looking-claims.md
@@ -1,0 +1,43 @@
+# Forward-Looking Claims Checklist
+
+Use this checklist when the research involves predictions, forecasts, release timelines, pricing projections, or forward-looking statements.
+
+Run through every item before delivering the final report.
+
+## Claim identification
+
+- [ ] every forward-looking claim is identified and clearly labeled
+- [ ] claims labeled "confirmed" vs "expected" vs "speculated" vs "inferred" are used accurately and consistently
+
+## Assumption documentation
+
+- [ ] each prediction has at least one documented key assumption
+- [ ] each assumption is stated explicitly, not buried in prose
+- [ ] the evidence for each assumption is noted (prior pattern, official announcement, analyst projection, etc.)
+
+## Failure conditions
+
+- [ ] each prediction has at least one stated condition under which it would not hold
+- [ ] failure conditions are practical, not generic disclaimers
+
+## Evidence quality
+
+- [ ] predictions are not presented as confirmed facts
+- [ ] announcements are clearly distinguished from shipped or commercially available products
+- [ ] pricing projections are labeled as sourced, estimated, or assumed
+- [ ] historical accuracy of similar predictions is noted where relevant
+
+## Source type for predictions
+
+- [ ] predictions sourced from official announcements are labeled as such
+- [ ] predictions from analyst estimates are labeled as consensus or individual analyst
+- [ ] predictions from media synthesis or speculation are labeled as such
+
+## Completeness
+
+- [ ] all predictions are listed with their confidence label, assumption, and failure condition
+- [ ] predictions with no clear basis are labeled `[UN]` or removed
+
+## Flags
+
+If a key prediction cannot be verified and has weak supporting evidence, lower its confidence or remove it before delivery.

--- a/checklists/listed-company-report.md
+++ b/checklists/listed-company-report.md
@@ -1,0 +1,45 @@
+# Listed Company Report Checklist
+
+Use this checklist when the research is about a publicly listed company.
+
+Run through every item before delivering the final report.
+
+## Market snapshot
+
+- [ ] current stock price with date and source
+- [ ] approximate market capitalization
+- [ ] PE (TTM or forward) with basis and date
+- [ ] PB with basis and date
+- [ ] PS with basis and date
+- [ ] 52-week high/low range with source
+
+## Reporting discipline
+
+- [ ] latest full-year financial figures are sourced from annual report, earnings release, or filed disclosure
+- [ ] financial figures are labeled by type: audited annual / interim / earnings release / analyst consensus / inferred
+- [ ] historical reported facts are separated from current market snapshot
+- [ ] forward-looking targets or estimates are clearly labeled as such, not presented as confirmed facts
+
+## Current product lineup
+
+- [ ] current flagship product generation verified (not stale)
+- [ ] current pricing or price range verified with date
+- [ ] latest major announcement or release confirmed
+- [ ] product lifecycle stage: announced / pre-order / shipping / discontinued
+
+## Listing status
+
+- [ ] listing exchange and ticker confirmed
+- [ ] current trading status: actively trading / suspended / delisted / in process
+- [ ] if IPO pending or in process, current stage: filed / accepted / under review / approved / issued
+
+## Key numbers are complete
+
+- [ ] revenue with period and growth rate
+- [ ] gross margin or net margin where relevant
+- [ ] operating cash flow direction noted
+- [ ] segment breakdown if multi-segment business
+
+## Flags
+
+If any item above is unchecked or uncertain, note the limitation explicitly in the report before delivery.

--- a/checklists/source-traceability.md
+++ b/checklists/source-traceability.md
@@ -1,0 +1,34 @@
+# Source Traceability Checklist
+
+Use this checklist when the output includes confidence labels (confirmed / likely / uncertain) or is structured as a research memo.
+
+Run through every item before delivering the final report.
+
+## Inline citations
+
+- [ ] every important claim in the body text has a source id in `[SN]` format
+- [ ] each `[SN]` maps to a single specific source, not a generic "multiple sources"
+- [ ] inferred claims use `[IN]` with a documented reasoning chain in the register
+- [ ] unconfirmable claims use `[UN]` and are listed in the uncertainty register
+
+## Source register
+
+- [ ] source register is present and structured (not a loose bibliography)
+- [ ] every source id in the register has: title/description, source type, date/version, relevance, reliability notes
+- [ ] no source id is listed but never cited in the body
+
+## Source type discipline
+
+- [ ] primary sources (official filings, company disclosures, primary documents) are distinguished from secondary (media, analyst reports)
+- [ ] inferred claims are labeled `[IN]` and not presented as confirmed facts
+- [ ] no source is given higher weight than its type warrants
+
+## Completeness
+
+- [ ] no key claim is left without a traceable source
+- [ ] the report reads as auditable — a reader can follow any claim back to a specific source entry
+- [ ] the register does not contain sources that are not actually cited
+
+## Flags
+
+If any item above is not satisfied, revise the report before delivery. A report without traceability is not a sufficient output of this skill.


### PR DESCRIPTION
## What
- Add  — required fields gate for listed-company research
- Add  — claim-level citation audit before delivery
- Add  — prediction assumptions and failure conditions
- Add  — final gate before any delivery
- Update  to route to these checklists at appropriate workflow steps
- Update  to include the  directory
- Update 

## Why
After systematic review, key execution rules (listed-company fields, source traceability, forward-looking claims, final audit) were buried in prose and not reliably enforced during output. The checklist layer converts these from "guidance prose" to "run before delivery" checkpoints, directly addressing the "already said but not followed" failure mode.

## Files
- SKILL.md
- README.md
- CHANGELOG.md
- checklists/listed-company-report.md
- checklists/source-traceability.md
- checklists/forward-looking-claims.md
- checklists/final-audit.md