### PR TITLE
eval+rule: add MiniMax report case and mandatory listed-company opening snapshot

### DIFF
--- a/evals/minimax-company-report-case.md
+++ b/evals/minimax-company-report-case.md
@@ -1,0 +1,91 @@
+# MiniMax Company Report Eval
+
+**Date:** 2026-03-31
+**Model:** Minimax (MiniMax-M2)
+**Source:** User-provided PDF from a Minimax-generated deep research report on MiniMax
+
+## Research question
+MiniMax company deep research report (Chinese, structured format)
+
+## What went well
+
+### 1. Active listing-state awareness (positive behavior change)
+The report explicitly flagged in its research note:
+> "⚠ 因 MiniMax 已于 2026 年 1 月 9 日港交所上市（代号 00100）"
+
+This is a meaningful improvement over earlier listed-company cases (Moore Threads). The model recognized the listing event and called it out in the research scope section — unlike Moore Threads reports which froze at Pre-IPO language.
+
+### 2. Research scope statement
+The opening research note included data-source disclosure (招股书、港交所公告、多方媒体报道) and a datafreshness caveat. This is consistent with the source-quality discipline.
+
+### 3. Inference label used in competitive pressure section
+Section 4.4 used "Likely Inference + Risk Factor" label when discussing DeepSeek's impact on the "六小虎" group. This matches the skill's inference-labeling requirement.
+
+### 4. Time layering in financing table
+The financing table separated rounds by date and gave specific amounts, matching the finance-date discipline for historical milestone separation.
+
+---
+
+## What went wrong
+
+### 1. Report is structurally incomplete (戛然而止)
+The report terminates mid-sentence at section "5.2 主要应用场景" with no:
+- Chapter 6: Financial depth (post-IPO audited or interim results)
+- Chapter 7: Risk analysis
+- Chapter 8: Bull/Bear logic
+
+This is a structural failure — a listed-company deep research report without financial analysis or bull/bear framing is incomplete by the skill's own output standards.
+
+### 2. Listed-company current market snapshot missing (rule existed but not followed)
+`references/finance-date-discipline.md` already mandates: "For any listed-company research, a current valuation snapshot is required, not optional." The report is about a listed company (MiniMax, HK00100, listed 2026-01-09) but has no current stock price, market cap, or post-IPO trading data anywhere.
+
+This means the existing rule was either:
+- not triggered (compaction didn't retain it), or
+- not followed despite being in the skill
+
+The report relied entirely on pre-IPO prospectus data for financial figures.
+
+### 3. Source citation at generic level, not claim-level
+All claims cited sources like "招股书披露" or "MiniMax官网" without:
+- specific section/chapter or page number
+- direct URL
+- publication date
+
+Readers cannot verify any individual claim. This is the same failure mode documented in `source-traceability-moore-threads-case.md` — the model improved source awareness but not citation granularity.
+
+### 4. Ranking claims without evidence chain
+The report stated:
+- "全球唯一四"进入第一梯队的大模型公司之一
+- "第一梯队"是谁/什么机构划分的？没有任何证据
+
+These are marketing-level ranking assertions. The skill's `references/ranking-and-current-claims-discipline.md` and the Xiaomi update case (`ranking-and-current-claims-xiaomi-update-case.md`) both address this failure mode. It is present here again.
+
+### 5. Competitive positioning lacks quantitative backing
+Section 4.2 describes differentiation qualitatively ("多模态先驱者"、"出海成绩突出") but provides no specific metrics:
+- No user growth trend for Starfield/Talkie vs competitors
+- No market share data for video generation
+- No revenue breakdown by segment
+
+---
+
+## Failure modes summary
+
+| Failure | Severity | Related skill rule or prior eval |
+|---------|----------|----------------------------------|
+| Listed company report with no current market snapshot | High | `finance-date-discipline.md` — rule existed |
+| Source citation at document level, not claim level | Medium | `source-traceability-moore-threads-case.md` |
+| Ranking claims ("全球唯一四") lack evidence | Medium | `ranking-and-current-claims-xiaomi-update-case.md` |
+| Report structurally incomplete (no financial, risk, bull/bear) | High | SKILL.md output standards |
+| Report戛然而止 at section 5.2 | Medium | — possibly upload artifact issue |
+
+---
+
+## Lessons
+
+1. **Listing-state awareness improved**: The model correctly identified the listing event. This is a genuine behavior improvement over the Moore Threads case. The awareness exists; enforcement is the gap.
+
+2. **Knowing a rule ≠ following it**: The current market snapshot rule was in the skill but not triggered. This suggests compaction or execution routing dropped it. The fix should be structural (checklist-level enforcement), not just adding more prose rules.
+
+3. **Incomplete reports**: If the report generation was interrupted (API error) rather than an artifact upload issue, the skill's stop conditions may need review. If it was allowed to terminate at "5.2" without hitting a stop condition, the completion gate needs tightening.
+
+4. **Eval conclusion**: Add this as a mixed-behavior case — positive on listing-state awareness, negative on execution follow-through. The listing-state awareness improvement is worth codifying as a behavior the skill should reinforce.

--- a/references/corporate-status-and-listing-state-discipline.md
+++ b/references/corporate-status-and-listing-state-discipline.md
@@ -131,6 +131,24 @@ If you conclude the company is listed, the report should usually make visible at
 - listing date or current trading context
 - what source confirms listed/trading status
 
+### Mandatory opening snapshot for listed companies
+
+**For any listed-company research, the report opening must contain a current market data block, not just a status note.**
+
+At minimum, this block must include:
+- current stock price (or most recent trading day's close) with date
+- approximate market capitalization
+- current key valuation ratios (PE, PB, PS) with TTM/forward basis and date
+- 52-week high/low range if relevant
+
+This is required even if the rest of the analysis relies on prospectus data. A listed-company report that opens with only IPO prospectus language and zero current market data is structurally incomplete.
+
+If the exchange is a recent listing (within approximately 12 months), note the post-IPO trading range and any available early-market price data.
+
+If current market data cannot be obtained, explicitly state the limitation in the opening rather than silently omitting it.
+
+**Why this matters:** An investor reading a listed-company report needs the current market context to understand whether historical financials are relevant to the present valuation. Omitting this creates a false impression that pre-IPO financials tell the full story.
+
 ## If not yet listed
 
 If the company is still in process, say what stage it is actually in.


### PR DESCRIPTION
## Summary
Adds a new eval case from a Minimax-generated MiniMax company report and strengthens the corporate-status discipline with a mandatory opening-market-snapshot rule for listed companies.

## Changes

### eval:  (new file)
Mixed-behavior case from a real Minimax deep-research output:
- **Positive:** model correctly identified the 2026-01-09 HKEX listing in research scope (genuine behavior improvement over Moore Threads reports)
- **Negative:** zero current stock price/market cap despite company being listed; report structurally incomplete (ends at section 5.2); claim-level citation missing; ranking claims ("全球唯一四") lack evidence
- Key lesson: listing-state awareness exists in the model but enforcement is inconsistent — the rule existed in finance-date-discipline but was not triggered

### rule: 
New section **Mandatory opening snapshot for listed companies**:
- Requires report opening to include: current stock price (with date), market cap, key valuation ratios (PE/PB/PS with TTM/forward basis), 52-week range if relevant
- Applies even when the rest of the analysis uses prospectus data
- Covers recent listings (~12 months) with post-IPO trading range note
- Required even when current market data is partial — state limitations explicitly rather than omitting

## Why both together
The eval documents that the model knew about the listing (research note included it) but did not produce the corresponding market-data block. The rule addition makes the opening-snapshot requirement explicit at the listing-state level, complementing the existing finance-date-discipline rule which focuses on numeric discipline in financial sections.

## Testing
- Eval file created from real report artifact; case patterns cross-referenced against existing evals (Moore Threads listing, Xiaomi ranking)
- Rule addition is additive and consistent with existing listing-state and finance-date disciplines