### PR TITLE
feat: auto-render PDF when report requests imply it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This file is intentionally lightweight. Use concise entries that explain:
 - `evals/api-supplier-selection-gpt-vs-minimax-comparative-distillation.md`
 
 ### Changed
+- `SKILL.md` now adds a delivery-artifact rule: if the user's request includes `pdf`, `PDF`, or `报告`, the workflow should still produce the normal markdown report but also write a `.md` file and run `/Users/mn/.openclaw/workspace/md_to_pdf.py` to render a PDF artifact when possible.
 - `README.md` now points to the failure-taxonomy document so the current eval set can be interpreted as recurring failure families rather than a flat list of isolated cases.
 - `README.md` now describes `evals/` as containing case evals, rubrics, and meta-evals rather than only lightweight prompts.
 - `README.md` now points to the comparative-distillation method as the standard way to turn paired-report comparisons into reusable improvements.

--- a/SKILL.md
+++ b/SKILL.md
@@ -279,6 +279,22 @@ Always make clear:
 - what is inferred
 - what remains unresolved
 
+## Delivery artifact rule
+
+Default delivery stays as text / markdown.
+
+If the user's request includes `pdf`, `PDF`, or `报告`, treat that as a PDF-output request in addition to the normal report delivery.
+
+In that case:
+
+1. write the final report to a `.md` file first
+2. convert it with `/Users/mn/.openclaw/workspace/md_to_pdf.py`
+3. deliver or attach the generated PDF when the surface supports files
+
+Do not skip the markdown file. The PDF is a rendered artifact, not the source of truth.
+
+If PDF rendering fails, still deliver the markdown/text report and explicitly say the PDF export failed.
+
 ## Research depth
 
 This skill defaults to deep research quality.


### PR DESCRIPTION
## Summary
Add a delivery-artifact rule to `deep-research` so PDF export is automatically attempted when the user's request strongly implies a report artifact.

## What changed
- Updated `SKILL.md`
- keep normal delivery as text / markdown by default
- if the request includes `pdf`, `PDF`, or `报告`, treat it as a PDF-output request as well
- require the workflow to:
1. write the final report to a `.md` file first
2. run `/Users/mn/.openclaw/workspace/md_to_pdf.py`
3. deliver/attach the generated PDF when possible
- if PDF rendering fails, still deliver the markdown/text report and explicitly surface the export failure
- Updated `CHANGELOG.md` to record the new delivery-artifact behavior

## Why
Previously, the repo had a working local markdown → PDF pipeline, but not a reliable execution-time trigger for when that pipeline should run.

This caused an execution gap:
- PDF generation was supported
- but research runs still defaulted to plain markdown/text unless the extra render step was manually invoked

This PR closes that gap by adding a lightweight trigger rule:
- default behavior remains unchanged for normal research
- report-like requests that include `pdf` / `PDF` / `报告` now also trigger PDF rendering
## Impact
- makes PDF output behavior more automatic without forcing PDF generation for every research task
- preserves markdown as the source-of-truth artifact
- degrades safely when rendering fails

## Notes
The current trigger is intentionally broad because the user explicitly chose this behavior.
If it proves too aggressive, it can later be narrowed to `pdf/PDF`-only or to a more explicit export-intent rule.