### PR TITLE
feat: add market-entry routing and distillation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This file is intentionally lightweight. Use concise entries that explain:
 - `evals/comparative-distillation-template.md`
 - `evals/api-supplier-selection-gpt-vs-minimax-comparative-distillation.md`
 - `evals/ai-coding-agent-market-outlook-gpt-vs-minimax-comparative-distillation.md`
+- `evals/sea-market-entry-gpt-vs-minimax-comparative-distillation.md`
 
 ### Changed
 - `SKILL.md` now adds a delivery-artifact rule: if the user's request includes `pdf`, `PDF`, or `报告`, the workflow should still produce the normal markdown report but also write a `.md` file and run `scripts/md_to_pdf.py` to render a PDF artifact when possible.
@@ -44,13 +45,18 @@ This file is intentionally lightweight. Use concise entries that explain:
 - `SKILL.md` now includes explicit trigger routing for listed-company, current-state, source-traceability, forward-looking, global-scope, decision-utility, and option-selection/shortlist cases instead of leaving those gates implicit.
 - `SKILL.md` now routes paired-report comparison work to the comparative-distillation method and template so stronger-vs-weaker report comparisons produce explicit action types.
 - `SKILL.md` now explicitly treats model/API supplier selection as both a current-state-sensitive task and a constrained-choice task, requiring a current provider snapshot before ranking.
+- `SKILL.md` now explicitly routes market-entry / regional-expansion / country-prioritization tasks as constrained-choice + decision-memo work, requiring priority-vs-alternatives, country shortlist, sequencing, and hard-gate logic rather than a market overview.
 - `SKILL.md` final discipline now adds a visible-gate check and routes rule-execution failures to `evals/rule-activation-and-execution-discipline.md`.
 - `SKILL.md` final trigger checks now require provider-selection outputs to show current provider snapshot + accessibility/compliance/SLA/data-control constraints as ranking logic when relevant.
+- `SKILL.md` final trigger checks now also require market-entry outputs to show priority-vs-alternatives, country shortlist, hub vs beachhead vs later-expansion distinctions when relevant, hard gates, and sequencing logic.
 - `references/option-selection-and-shortlist-discipline.md` now includes provider-selection heuristics for current model/API family, stale-anchor avoidance, and mainland-access / data-residency / SLA-sensitive ranking.
 - `references/decision-report-template.md` now explicitly adapts its structure for option-selection and shortlist tasks, including ranked shortlist flow, aggregation visibility, and change-the-ranking conditions.
 - `references/decision-report-template.md` now includes a stronger provider-selection structure with decision architecture, current snapshot table, ranked shortlist, and deployment archetypes.
+- `references/decision-report-template.md` now includes a dedicated market-entry structure with recommendation, why-now/why-not-now, hard gates, country shortlist, sequencing, entry archetypes, and 0-12 month milestones/KPIs.
 - `checklists/option-selection-final-audit.md` now includes a provider/vendor current-state gate covering current model family, pricing units, accessibility, data residency, and SLA/status checks.
+- `checklists/option-selection-final-audit.md` now includes a market-entry / regional-expansion gate for explicit go/not-now/phased-entry calls, country comparison units, hard gates, and sequencing-change conditions.
 - `checklists/final-audit.md` now requires a provider snapshot and ranking-level treatment of accessibility/compliance/data-residency/SLA for model/API supplier decisions.
+- `checklists/final-audit.md` now adds market-entry gates for priority-vs-alternatives, shortlist/sequencing logic, and hub-vs-beachhead separation when relevant.
 - `checklists/final-audit.md` now adds market-outlook gates for current market snapshot, drivers/blockers/scenarios/stakeholder implications, and explicit labeling of outlook numbers when evidence role matters.
 
 ### Why
@@ -63,6 +69,8 @@ This file is intentionally lightweight. Use concise entries that explain:
 - Comparative distillation needed to become a repeatable method rather than an ad-hoc discussion, so the repo now includes both a method file and a working template for paired-report comparisons.
 - The weekend destination comparison case exposed a broader missing-rule area: the repo needed general guidance for constrained choice, shortlist construction, multi-origin aggregation, and choice architecture beyond travel-specific prompting.
 - A new model/API supplier selection case exposed a more specific failure family inside constrained-choice work: stale current-state anchors, provider-encyclopedia drift, and failure to treat mainland accessibility / compliance / SLA as ranking variables.
+- A new SEA market-entry paired case exposed another constrained-choice failure family: expansion memos can still drift into regional overviews unless the skill forces priority-vs-alternatives, country-shortlist logic, sequencing, and hard gates.
+- The GPT side of that SEA case also exposed a delivery-layer failure: citation / retrieval artifacts can leak into an otherwise strong memo, so final-delivery cleanliness must be treated as a hard gate rather than a cosmetic issue.
 - The skill itself needed to consume those additions through clearer routing, otherwise the new evals would remain documentation instead of affecting execution.
 
 ## 0.4.0 - 2026-03-31

--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ Turn "search and summarize" into a stricter research workflow that:
 - `references/comparative-distillation-method.md` — how to turn stronger paired reports into reusable rules and gates
 - `references/option-selection-and-shortlist-discipline.md` — general method for constrained choice, ranking, shortlist design, and provider-selection tasks under real constraints
 - `references/market-outlook-and-scenario-discipline.md` — routing and structure discipline for market-outlook / industry-evolution / future-12-month memo tasks
-- `checklists/option-selection-final-audit.md` — delivery gate for shortlist, ranking, constrained-choice outputs, and provider-selection current-state checks
+- `checklists/option-selection-final-audit.md` — delivery gate for shortlist, ranking, constrained-choice outputs, provider-selection current-state checks, and market-entry shortlist / sequencing gates
 - `evals/api-supplier-selection-gpt-vs-minimax-comparative-distillation.md` — worked comparative-distillation case for model/API supplier selection, current-state drift, and China-mainland deployment constraints
 - `evals/ai-coding-agent-market-outlook-gpt-vs-minimax-comparative-distillation.md` — worked comparative-distillation case for market-outlook routing, scenario structure, and stakeholder-action discipline
+- `evals/sea-market-entry-gpt-vs-minimax-comparative-distillation.md` — worked comparative-distillation case for market-entry routing, country-shortlist structure, sequencing, hard gates, and delivery-artifact leakage
 
 ## Initial references included
 
@@ -68,6 +69,7 @@ This repo should be maintained like a real project rather than a loose prompt fo
 - fast-moving products and model versions
 - vendor/tool selection
 - model/API supplier selection under deployment, compliance, and mainland-access constraints
+- market-entry / regional-expansion / country-prioritization memos under budget, localization, and compliance constraints
 - company diligence
 - technical feasibility
 - market hype vs reality

--- a/SKILL.md
+++ b/SKILL.md
@@ -100,6 +100,7 @@ At minimum, check for these trigger patterns:
 - **Market outlook / industry evolution / "未来12个月如何演化" / adoption trajectory / industry memo** -> treat as both a current-state-sensitive task and a decision-memo task; require a current market snapshot, explicit drivers/blockers, scenario structure, and stakeholder action guidance
 - **Global market / full landscape / industry-wide scope** -> explicitly test scope completeness across key geographies, segments, and regulatory regimes
 - **Recommendation / go-no-go / compare options / what should we do** -> optimize for decision utility, not just depth
+- **Market entry / regional expansion / "should we prioritize market X" / country-entry sequencing under limited budget** -> treat as both a constrained-choice task and a decision-memo task; require explicit priority vs alternatives, country shortlist, sequencing, hard gates, and entry-mode logic rather than a market overview
 
 If multiple triggers apply, route into all of them. Do not assume one checklist covers the others.
 
@@ -139,7 +140,9 @@ Read `evals/decision-utility-rubric.md` when the user needs a recommendation, pr
 Read `references/option-selection-and-shortlist-discipline.md` when the task is mainly about choosing among several plausible options under constraints (for example destination selection, vendor shortlist, office/venue choice, multi-origin meetup/location choice, or other comparison tasks where ranking and elimination matter more than background explanation).
 Run `checklists/option-selection-final-audit.md` before delivery for shortlist, ranking, destination-selection, or other constrained-choice outputs.
 For model/API supplier or provider-selection tasks, explicitly verify a current provider snapshot before broader comparison: current primary model/API family, current pricing unit, current support-region / mainland accessibility reality, current data-control posture, and current SLA / status disclosures when decision-relevant.
+For market-entry / regional-expansion / country-prioritization tasks, explicitly verify the decision architecture before broader analysis: what the real choice is, what the priority is relative to alternatives, whether the question is about a regional hub vs first revenue beachhead vs later expansion market, what hard gates exist, and what sequencing logic would make the recommendation operational.
 Use `references/decision-report-template.md` with the provider-selection structure when the task is choosing a core model/API supplier under real deployment constraints.
+Use `references/decision-report-template.md` with the market-entry structure when the task is deciding whether to prioritize a country or region under real budget, compliance, and localization constraints.
 Read `references/comparative-distillation-method.md` when comparing paired reports (for example GPT vs Minimax on the same topic) to distill reusable skill improvements rather than just judge which output is better.
 Use `evals/comparative-distillation-template.md` to record each paired-report comparison so every extracted pattern ends in `NEW_RULE`, `CHECKLIST_HARDENING`, `TEMPLATE_CHANGE`, or `NO_ACTION`.
 
@@ -413,6 +416,7 @@ Use these final trigger checks:
 - if this was a listed-company or investment-style report, the output should visibly show listed-company discipline
 - if this was a current-state-sensitive task, the output should visibly show a current snapshot or freshness verification
 - if this was a model/API supplier or provider-selection task, the output should visibly show a current provider snapshot and should treat accessibility / compliance / SLA / data-control constraints as part of ranking logic when relevant
+- if this was a market-entry / regional-expansion / country-prioritization task, the output should visibly show priority vs alternatives, a country shortlist, a distinction between regional hub vs first beachhead vs later expansion market when relevant, hard gates, and sequencing logic rather than a generic market overview
 - if this was a structured or claim-heavy memo, the output should visibly show source traceability in the body, not only in a source appendix
 - if this included forecasts, roadmap claims, estimates, or target prices, the output should visibly show forward-looking discipline
 - if this claimed broad global or full-landscape scope, the output should visibly show scope completeness or clearly state scope limits

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -41,6 +41,8 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] option-selection final audit was run for shortlist, ranking, or constrained-choice outputs
 - [ ] for model/API/provider selection tasks, a current provider snapshot was verified before ranking or recommendation
 - [ ] for China-mainland deployment decisions, accessibility, compliance, data residency, and SLA were treated as part of ranking logic when relevant
+- [ ] for market-entry / regional-expansion / country-prioritization tasks, priority relative to alternatives, country shortlist, hard gates, and sequencing logic are explicit rather than implied
+- [ ] for market-entry / regional-expansion / country-prioritization tasks, regional hub vs first beachhead vs later expansion market are separated when relevant
 - [ ] for market-outlook / industry-evolution tasks, a current market snapshot was verified before forward-looking sections
 - [ ] for market-outlook / industry-evolution tasks, drivers, blockers, scenarios, and stakeholder implications are explicit rather than implied
 
@@ -62,6 +64,11 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] when volume/scale growth is reported, profitability and cash flow signals are checked
 - [ ] if both positive (scale up) and negative (margin down) signals exist in the same period, they are presented together in one sentence or adjacent bullets — not separated in different sections
 - [ ] reader does not have to connect the dots themselves
+
+## Delivery cleanliness
+
+- [ ] no citation artifacts, retrieval syntax, placeholder entities, or rendering residues leak into the final report body
+- [ ] markdown / PDF delivery does not expose internal labels, raw template markers, or unfinished placeholders
 
 ## Quality bar
 

--- a/checklists/option-selection-final-audit.md
+++ b/checklists/option-selection-final-audit.md
@@ -39,6 +39,15 @@ Run this checklist before delivery.
 - [ ] support regions, mainland-China accessibility, signing/payment reality, data residency, and SLA/status are treated as ranking variables when relevant, not buried as footnotes
 - [ ] if a key provider fact could not be confirmed, it is marked unknown rather than filled with likely-but-stale prior knowledge
 
+## Market-entry / regional-expansion gate
+
+- [ ] for market-entry, country-prioritization, or regional-expansion tasks, the report states whether the recommendation is `go`, `not now`, `pilot only`, or phased entry
+- [ ] the report makes priority relative to realistic alternatives visible rather than assuming the target market should be first by default
+- [ ] the report distinguishes regional hub, first revenue beachhead, and later expansion market when those roles differ
+- [ ] countries/markets are compared using one visible comparison unit rather than free-form country notes
+- [ ] hard gates (budget, product architecture, compliance readiness, channel readiness, localization burden, or similar) are explicit
+- [ ] the report names what would change the entry sequencing or turn `go` into `not now`
+
 ## Shortlist structure
 
 - [ ] the shortlist or ranking appears before long option-by-option detail

--- a/evals/sea-market-entry-gpt-vs-minimax-comparative-distillation.md
+++ b/evals/sea-market-entry-gpt-vs-minimax-comparative-distillation.md
@@ -1,0 +1,334 @@
+# SEA Market Entry — GPT vs MiniMax Comparative Distillation
+
+## Case identity
+
+- **Task type:** market entry / regional expansion / go-no-go memo / constrained-choice task
+- **User objective:** 判断一家中国 AI SaaS 创业公司是否应优先进入东南亚市场，并明确优先级、进入顺序、进入方式与关键门槛
+- **Compared outputs:** GPT report vs MiniMax report on the same topic
+- **Research date context:** 2026-04-03
+- **Distillation goal:** 提炼可复用、可审计、可执行的结构性差异，并将其归因为 `NEW_RULE` / `CHECKLIST_HARDENING` / `TEMPLATE_CHANGE` / `NO_ACTION`
+
+---
+
+## Prompt shape
+
+This was not a generic Southeast Asia market overview.
+
+It was effectively a **market-entry memo for a resource-constrained Chinese AI SaaS startup** with all of these properties at once:
+
+- constrained-choice
+- go/no-go / prioritization
+- regional-expansion sequencing
+- current-state-sensitive
+- compliance-sensitive
+- partially quantitative
+- action-oriented
+
+That means the output should optimize for:
+
+- decision architecture
+- priority relative to alternatives
+- country shortlist logic
+- hard gates
+- sequencing and entry mode
+- explicit uncertainty about what would change the recommendation
+
+It should **not** drift into a region overview with a recommendation attached afterward.
+
+---
+
+## Compared outputs at a glance
+
+### GPT output
+More clearly behaved like an actual **market-entry decision memo**.
+
+Visible strengths:
+
+- recommendation as an operating path rather than a stance
+- explicit phased entry and country sequencing
+- hard gates (budget / deployment architecture)
+- more visible country-shortlist structure
+- KPI / milestone / scenario framing
+- stronger sense of priority under resource constraints
+
+Visible weaknesses:
+
+- some evidence / citation artifacts leaked into the final delivery (`entity...` style residue)
+- some models and estimates looked more precise than the evidence base warranted unless carefully labeled
+- stronger Singapore-first logic may still partially reflect regional-HQ default bias unless tied more clearly to beachhead economics
+
+### MiniMax output
+The weaker output in this pair.
+
+Visible strengths:
+
+- recognized that the question was not just whether SEA is interesting, but under what conditions and with what entry logic
+- identified real constraints such as localization, regulation, payment systems, and competitive timing
+- offered a cautious and plausible high-level judgment rather than naive expansion enthusiasm
+
+Visible weaknesses:
+
+- drifted back toward a structured market overview with recommendation flavor rather than a tightly constrained choice memo
+- country analysis was useful but less visibly driven by one comparison unit
+- hard gates were present conceptually but not converted into operational go/no-go thresholds
+- recommendation was less clearly written as sequencing, operating path, and decision logic
+
+---
+
+## Six-dimension comparison
+
+### 1. Current-state discipline
+
+**Winner: GPT**
+
+GPT more clearly treated current conditions as the base state for a decision: current demand proxies, current infrastructure investment, current regulation posture, and current product/deployment implications all visibly fed the recommendation.
+
+MiniMax included many current facts, but they did not as clearly form the memo skeleton. The output remained closer to a region scan with current facts mixed in.
+
+**Distilled conclusion:**  
+For market-entry tasks, current-state discipline must not stop at a few recent facts. It has to anchor the recommendation and the sequencing logic.
+
+**Candidate action:** `CHECKLIST_HARDENING`
+
+---
+
+### 2. Numerical and date discipline
+
+**Winner: GPT**
+
+GPT used TAM / SAM / SOM, scenario framing, quarterly split, CAC / payback / ARR targets, and budget thresholds to make the recommendation operational.
+
+MiniMax used numbers more as support material than as the load-bearing spine of the memo.
+
+This case also reveals a caution: GPT-style planning models can look highly rigorous while still relying on proxies and assumptions. The right lesson is not “use more numbers”; it is “label the role of each number.”
+
+**Distilled conclusion:**  
+Market-entry memos need visible labeling for observed metrics, proxies, assumptions, and planning-model outputs.
+
+**Candidate action:** `NEW_RULE`
+
+---
+
+### 3. Source traceability and evidence weighting
+
+**Winner: GPT (but with a new failure)**
+
+GPT more clearly suggested distinct evidence layers: institutional market data, regulatory constraints, adoption surveys, and planning assumptions. But the final delivery leaked citation artifacts, which is a separate hard failure.
+
+MiniMax had the more basic weakness: major claims and numeric ranges often read as if they were equally grounded, even when they were likely a mixture of sourced facts, heuristics, and synthesis.
+
+**Distilled conclusion:**  
+For market-entry memos, evidence layering needs to be more visible in-body; and any citation/retrieval artifact leakage should count as a final-delivery failure.
+
+**Candidate action:** `CHECKLIST_HARDENING`
+
+---
+
+### 4. Forward-looking claim discipline
+
+**Winner: GPT**
+
+GPT more clearly answered the actual action question over the next 12 months: what to do first, what to delay, what gates matter, and what targets would count as success.
+
+MiniMax did include a recommendation, but it was less visibly tied to phased execution, milestone logic, or ranking-reversal conditions.
+
+**Distilled conclusion:**  
+For market-entry / regional-expansion tasks, the future-facing logic should be written as phased sequencing + gates + change conditions, not only as a cautious recommendation paragraph.
+
+**Candidate action:** `TEMPLATE_CHANGE`
+
+---
+
+### 5. Structural readability and information density
+
+**Winner: GPT**
+
+GPT more clearly grouped the memo into high-utility blocks: recommendation, country order, market sizing, customer profile, competition, compliance, GTM path, milestones, and financial scenarios.
+
+MiniMax was structurally cleaner than a generic article, but its middle sections still read more like topic exposition than shortlist architecture.
+
+**Distilled conclusion:**  
+Market-entry reports should use typed decision blocks rather than long country-by-country exposition.
+
+**Candidate action:** `TEMPLATE_CHANGE`
+
+---
+
+### 6. Decision usefulness
+
+**Winner: GPT**
+
+This was the largest gap.
+
+GPT more clearly answered:
+
+- whether to prioritize SEA now
+- what the first sequence should be
+- what the hard gates are
+- how to know if the move is working
+- what should happen if the company lacks the needed budget or deployment readiness
+
+MiniMax gave a plausible judgment but remained less operational: informative, but weaker as a resource-allocation memo.
+
+**Distilled conclusion:**  
+The central gap in this case is not knowledge coverage. It is stronger **entry-decision architecture**.
+
+**Candidate action:** `NEW_RULE` + `CHECKLIST_HARDENING`
+
+---
+
+## Core distilled findings
+
+### Finding 1
+For market-entry tasks, the output must explicitly answer not just whether to enter, but whether the recommendation is:
+
+- `go`
+- `not now`
+- `pilot only`
+- `phased entry`
+
+A vague “有条件进入” is not enough unless the conditions are turned into visible hard gates.
+
+**Action type:** `CHECKLIST_HARDENING`
+
+---
+
+### Finding 2
+The report should explicitly distinguish these roles when relevant:
+
+- regional hub
+- first revenue beachhead
+- later expansion market
+
+Otherwise the phrase “priority country” becomes structurally ambiguous.
+
+**Action type:** `NEW_RULE`
+
+---
+
+### Finding 3
+Country analysis should use one visible comparison unit across the shortlist, rather than free-form country notes.
+
+Useful columns or decision variables often include:
+
+- demand / monetization quality
+- compliance friction
+- sales / channel friction
+- localization burden
+- suitability as first beachhead
+- recommended entry motion
+
+**Action type:** `NEW_RULE`
+
+---
+
+### Finding 4
+Hard gates should be explicit and operational, not only qualitative.
+
+Examples:
+
+- minimum 12-month budget
+- deployment / data-isolation capability
+- compliance package readiness
+- channel readiness
+- language/localization readiness
+
+**Action type:** `TEMPLATE_CHANGE`
+
+---
+
+### Finding 5
+Scenario models, TAM / SAM / SOM, KPI plans, and financial targets improve decision usefulness, but they also create a risk of **professional-looking model drift** unless each number is labeled by evidence role.
+
+**Action type:** `CHECKLIST_HARDENING`
+
+---
+
+### Finding 6
+Citation / retrieval / placeholder artifacts in final delivery should be treated as hard fails, even when the underlying analysis is strong.
+
+**Action type:** `CHECKLIST_HARDENING`
+
+---
+
+## Candidate-action summary
+
+| # | Candidate action | Failure family | Action type | Proposed home |
+|---|---|---|---|---|
+| 1 | Add explicit market-entry trigger routing for go/no-go / regional expansion / country prioritization tasks | rule activation / execution failure | NEW_RULE | `SKILL.md` |
+| 2 | Add a dedicated market-entry memo structure with recommendation, hard gates, country shortlist, sequencing, and milestones | decision utility / output structure | TEMPLATE_CHANGE | `references/decision-report-template.md` |
+| 3 | Require market-entry reports to distinguish regional hub vs first revenue beachhead vs later expansion market when relevant | constrained-choice / choice architecture | NEW_RULE | `references/decision-report-template.md` + `checklists/option-selection-final-audit.md` |
+| 4 | Require one visible comparison unit across countries/markets in a shortlist | constrained-choice / output structure | NEW_RULE | `references/option-selection-and-shortlist-discipline.md` |
+| 5 | Require explicit hard gates and priority relative to alternatives in market-entry outputs | decision utility / rule activation | CHECKLIST_HARDENING | `checklists/final-audit.md` + `checklists/option-selection-final-audit.md` |
+| 6 | Treat citation/retrieval artifact leakage as a final-delivery failure | source traceability / execution failure | CHECKLIST_HARDENING | `checklists/final-audit.md` |
+
+---
+
+## Triage notes
+
+### Candidate 1
+- **Why it matters:** without dedicated routing, reports drift into regional backgrounders even when the real question is entry sequencing under constraints
+- **Why it is reusable:** applies to country expansion, cross-border SaaS GTM, regional prioritization, and go/no-go tasks beyond SEA
+- **Why this home is best:** this is primarily a trigger / routing problem
+- **Promotion status:** `PROMOTE_NOW`
+
+### Candidate 2
+- **Why it matters:** this was one of the clearest structural differences in the pair
+- **Why it is reusable:** market-entry memos recur and need a stronger skeleton than generic decision memos
+- **Why this home is best:** the issue is memo architecture, not source discovery
+- **Promotion status:** `PROMOTE_NOW`
+
+### Candidate 3
+- **Why it matters:** many regional-expansion memos collapse different market roles into one sloppy “priority country” label
+- **Why it is reusable:** the same distinction applies in Europe, LatAm, MENA, and multi-country rollouts generally
+- **Why this home is best:** it belongs both in structure and in delivery-time audit
+- **Promotion status:** `PROMOTE_NOW`
+
+### Candidate 4
+- **Why it matters:** free-form country notes feel rich but often hide weak ranking logic
+- **Why it is reusable:** any multi-country market-entry memo benefits from a unified comparison unit
+- **Why this home is best:** this is part of constrained-choice methodology, not a SEA-specific patch
+- **Promotion status:** `PROMOTE_NOW`
+
+### Candidate 5
+- **Why it matters:** a recommendation without explicit gates or priority context is easy to misread as generic growth enthusiasm
+- **Why it is reusable:** applies to most international-expansion and market-prioritization work
+- **Why this home is best:** this is a final-delivery gate, not just prose advice
+- **Promotion status:** `PROMOTE_NOW`
+
+### Candidate 6
+- **Why it matters:** artifact leakage makes an otherwise strong memo unshippable
+- **Why it is reusable:** the same failure can recur in PDFs, markdown, and claim-rich outputs
+- **Why this home is best:** it should fail the final audit regardless of how good the analysis is
+- **Promotion status:** `PROMOTE_NOW`
+
+---
+
+## Things explicitly rejected
+
+| Observation | Why rejected |
+|---|---|
+| GPT sounded more executive-ready | tone preference only unless tied to decision utility |
+| New Singapore-first advice should become the default rule | too case-specific; could overfit to one regional-expansion pattern |
+| MiniMax was just weaker overall | too vague to become a reusable rule |
+
+---
+
+## Final judgment
+
+The stronger report won mainly because it behaved more like a **resource-allocation memo** and less like a regional market overview.
+
+The most important lesson is not “GPT knew more SEA facts.” It is that a better market-entry output should visibly show:
+
+- the real choice being made
+- priority relative to alternatives
+- country shortlist logic
+- hard gates
+- sequencing
+- what changes the decision
+
+This case is best understood as a mix of:
+
+- **missing trigger hardness** for market-entry routing
+- **template weakness** for expansion-sequencing memo structure
+- **execution weakness** when reports drift back into overview mode or leak delivery artifacts

--- a/references/decision-report-template.md
+++ b/references/decision-report-template.md
@@ -83,6 +83,31 @@ In these provider-selection cases, the report should explicitly show current-sta
 - current data-control / retention posture
 - current SLA / status / enterprise controls when decision-relevant
 
+For market-entry / regional-expansion / country-prioritization tasks, prefer this stronger structure:
+
+1. Executive summary
+2. What is the real decision?
+3. Recommendation
+4. Why now / why not now
+5. Hard gates
+6. Country shortlist with unified comparison unit
+7. Recommended sequencing
+8. Recommended entry archetypes
+9. Why the top option wins
+10. Why the runner-up remains credible
+11. Why the other options lose
+12. Risks / what changes the decision
+13. 0-12 month milestones or KPIs
+14. Sources
+
+In these market-entry cases:
+- do not let the report become a regional market overview with a recommendation attached at the end
+- explicitly separate regional hub, first revenue beachhead, and later expansion market when those roles differ
+- make priority relative to alternatives visible (for example domestic market vs SEA, or SEA vs other expansion regions)
+- show the few hard gates that could turn `go` into `not now` or `pilot only`
+- use one comparison unit across countries or candidate markets rather than free-form prose by country
+- if TAM / SAM / SOM, scenario models, or KPI plans are used, label observed numbers vs proxies vs assumptions vs planning-model outputs
+
 Do not give every option equal narrative weight if the user's real need is to choose.
 
 ## Executive summary

--- a/references/option-selection-and-shortlist-discipline.md
+++ b/references/option-selection-and-shortlist-discipline.md
@@ -292,6 +292,15 @@ When the task involves model/API provider selection, also ask:
 - Is the report comparing providers using a current snapshot, or using stale flagship anchors?
 - Is the output becoming a vendor encyclopedia instead of a ranked provider-choice memo?
 
+When the task involves market entry / regional expansion / country prioritization, also ask:
+
+- Is the real choice whether to enter now, delay, pilot, or sequence entry over phases?
+- What is the realistic alternative to this market or region, and is the report comparing against it explicitly?
+- Are regional hub, first revenue beachhead, and later expansion market being confused into one vague "priority market" label?
+- Is one visible comparison unit being used across candidate countries, or has the report drifted into free-form country notes?
+- Which hard gates would actually block entry: budget, data/deployment architecture, compliance readiness, channel readiness, language / localization readiness, or something else?
+- Does the report show why the top entry sequence wins and what would reverse that sequence?
+
 ---
 
 ## Output discipline


### PR DESCRIPTION
## Summary
- add a worked comparative-distillation eval for the SEA market-entry GPT vs MiniMax case
- route market-entry / regional-expansion / country-prioritization tasks as constrained-choice + decision-memo work
- add a dedicated market-entry memo structure with hard gates, country shortlist, sequencing, and milestones
- harden final-audit and option-selection gates for hub vs beachhead distinctions, explicit go/not-now/phased-entry calls, and delivery-artifact leakage

## Why
This paired case exposed a recurring failure mode in expansion memos: they can still drift into regional overviews unless the skill forces priority-vs-alternatives, country-shortlist logic, sequencing, and hard gates.

It also exposed a delivery-layer failure on the stronger GPT side: citation / retrieval artifacts can leak into an otherwise strong memo, so final-delivery cleanliness should be treated as a hard gate rather than a cosmetic issue.

## Files touched
- `SKILL.md`
- `references/decision-report-template.md`
- `references/option-selection-and-shortlist-discipline.md`
- `checklists/final-audit.md`
- `checklists/option-selection-final-audit.md`
- `evals/sea-market-entry-gpt-vs-minimax-comparative-distillation.md`
- `README.md`
- `CHANGELOG.md`
