### PR TITLE
fix: refine market-entry PDF layout discipline

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,6 +18,8 @@ This file tracks likely next improvements and helps keep repo evolution intentio
 - Add more examples of good and bad outputs.
 - Improve task-type guidance for company, vendor-selection, technical-feasibility, and market-outlook research.
 - Continue separating rendering-layer PDF fixes from research-discipline commits so layout failures can be traced independently.
+- Validate whether recent CJK text-rhythm tweaks actually reduce the "broken export / OCR-like spacing" feel in Chinese-heavy PDFs before making larger visual changes.
+- Add one more real-case pass on market-entry memo information design so recommendation, hard gates, shortlist, and phased-entry blocks become easier to scan in PDF output.
 
 ### P3
 - Consider scripts for normalizing evidence and claim records only after the protocol is stable.

--- a/evals/minimax-sea-memo-pdf-layout-case.md
+++ b/evals/minimax-sea-memo-pdf-layout-case.md
@@ -1,0 +1,120 @@
+# MiniMax SEA Memo PDF Layout Case
+
+## Case identity
+
+- **Task type:** PDF delivery / rendering-layer + information-design review
+- **Artifact:** MiniMax-generated PDF for a SEA market-entry decision memo
+- **Date:** 2026-04-03
+- **Why this case matters:** 该案例同时暴露了 PDF 渲染硬伤与 decision-memo 信息设计不足，适合作为“哪些该归入 pipeline、哪些该归入输出模板”的分流样本。
+
+---
+
+## Observed failure families
+
+### 1. CJK rendering / spacing failure
+
+Visible symptoms:
+- Chinese characters appeared visually torn apart or over-spaced
+- headings such as `决 策 备 忘录` and `进 ⼊ 东 南 亚 市 场` looked broken
+- the PDF felt closer to a damaged export or OCR-like artifact than to a polished memo
+
+Why it matters:
+- this is a first-glance trust failure
+- readers lose confidence before engaging the reasoning
+- even strong content looks unfinished when the base text texture is visibly broken
+
+Likely home:
+- `scripts/markdown_to_html.py`
+- PDF rendering / CSS / text-normalization pipeline
+
+---
+
+### 2. Weak scan anchors
+
+Visible symptoms:
+- section headings existed but did not create strong visual anchors
+- the page still felt like continuous explanation rather than decision blocks
+- the eye could not quickly isolate recommendation, hard gates, shortlist, and execution path
+
+Why it matters:
+- decision memos should support 30-second scan, 2-minute framework read, and 5-10 minute deeper review
+- without strong anchors, the memo behaves like a long report even if the headings are technically present
+
+Likely home:
+- `references/report-template.md`
+- `references/decision-report-template.md`
+- secondarily CSS / heading spacing in the PDF pipeline
+
+---
+
+### 3. Country analysis as prose rather than shortlist object
+
+Visible symptoms:
+- country sections were readable but still felt like topic exposition
+- comparison logic was not visually amplified
+- table usage did not clearly outperform plain prose in scan efficiency
+
+Why it matters:
+- multi-country entry memos need comparison-first layout, not country-tour layout
+- if the page does not make ranking legible, the memo underperforms as decision support
+
+Likely home:
+- `references/report-template.md`
+- `references/decision-report-template.md`
+- `checklists/option-selection-final-audit.md`
+
+---
+
+### 4. Hard gates not visually isolated
+
+Visible symptoms:
+- conditions for entry existed in substance, but were not elevated into a clear block
+- the reader had to read through prose to understand what would make the answer become `not now`
+
+Why it matters:
+- for go/no-go work, gates should not be buried inside analysis
+- they should survive skim reading and executive discussion
+
+Likely home:
+- `references/report-template.md`
+- `references/decision-report-template.md`
+- final-audit gates
+
+---
+
+## Distilled conclusion
+
+This case should not be reduced to “the PDF looked ugly.”
+
+It exposed two distinct repair tracks:
+
+1. **Rendering-layer failure**
+   - CJK spacing / text texture / page rhythm / weak visual anchors
+2. **Information-design failure**
+   - recommendation, hard gates, shortlist, and sequencing were not sufficiently elevated into typed memo blocks
+
+The right response is to keep those two tracks separate:
+- pipeline fixes should make the PDF look stable and readable
+- template/checklist fixes should make the memo behave like a decision artifact instead of a long regional overview
+
+---
+
+## Candidate actions
+
+| # | Candidate action | Failure family | Action type | Proposed home |
+|---|---|---|---|---|
+| 1 | Improve CJK text rhythm defaults and paragraph/list spacing in PDF rendering | output structure / information density | TEMPLATE_CHANGE | `scripts/markdown_to_html.py` |
+| 2 | Add explicit market-entry memo formatting discipline to the default report template | decision utility / output structure | NEW_RULE | `references/report-template.md` |
+| 3 | Keep hard gates, shortlist, and phased-entry logic as visible blocks rather than prose | decision utility / execution failure | CHECKLIST_HARDENING | `references/decision-report-template.md` + `checklists/final-audit.md` |
+
+---
+
+## Final judgment
+
+The biggest lesson from this PDF is not “make it prettier.”
+
+It is:
+- first, make the PDF stop looking broken
+- second, make the page layout serve the decision
+
+A decision memo that looks like a damaged export and reads like a long market explainer is failing both the rendering layer and the decision-support layer.

--- a/references/report-template.md
+++ b/references/report-template.md
@@ -161,6 +161,37 @@ If quantitative outlook numbers appear in such reports, label them clearly as on
 
 Do not let readers mistake scenario math for reported market fact.
 
+## Market-entry / go-no-go memo formatting discipline
+
+When the task is about market entry, regional expansion, country prioritization, or go/no-go judgment, do not format the report like a long regional backgrounder.
+
+The page should help a decision-maker scan in this order:
+
+1. recommendation
+2. hard gates
+3. shortlist / priority order
+4. why the top path wins
+5. what would change the decision
+
+Formatting discipline for these cases:
+
+- **Do not open with a dense paragraph summary.** Use short bullets or compact decision blocks.
+- **Pull hard gates into their own block.** Do not bury budget, deployment, compliance, or localization gates inside long prose.
+- **Use one visible comparison unit across countries.** Avoid free-form country notes as the primary structure.
+- **Separate market roles visually when relevant:** regional hub, first revenue beachhead, later expansion market.
+- **Keep country notes subordinate to the shortlist logic.** The report should feel like narrowing, not touring.
+- **If milestones / KPIs / phased rollout are included, present them as a sequence block, not scattered commentary.**
+
+Bad pattern:
+- a long "市场分析" section followed by a recommendation paragraph at the end
+
+Better pattern:
+- recommendation block
+- hard-gate block
+- country shortlist table
+- phased entry path
+- change-the-decision conditions
+
 ## Table formatting discipline
 
 When building tables with multi-dimensional comparisons (e.g., product category across multiple attributes):

--- a/scripts/markdown_to_html.py
+++ b/scripts/markdown_to_html.py
@@ -48,7 +48,7 @@ html {
 body {
   font-family: "PingFang SC", "Hiragino Sans GB", "STHeiti", "Heiti SC", "Microsoft YaHei", "Noto Sans CJK SC", Arial, sans-serif;
   font-size: 10.2pt;
-  line-height: 1.76;
+  line-height: 1.82;
   color: var(--color-text);
   margin: 0;
   padding: 0;
@@ -61,6 +61,7 @@ body {
   word-break: normal;
   line-break: strict;
   text-spacing: none;
+  text-rendering: optimizeLegibility;
 }
 
 /* ── Cover ── */
@@ -170,9 +171,13 @@ h4 {
 
 /* ── Paragraphs / text rhythm ── */
 p {
-  margin: 0 0 8pt;
+  margin: 0 0 9pt;
   orphans: 3;
   widows: 3;
+}
+
+p + p {
+  margin-top: 1pt;
 }
 
 strong { color: var(--color-title); }
@@ -180,12 +185,12 @@ a { color: var(--color-primary); text-decoration: none; }
 
 /* ── Lists ── */
 ul, ol {
-  margin: 6pt 0 12pt 1.35em;
+  margin: 7pt 0 13pt 1.35em;
   padding: 0;
 }
 
 li {
-  margin: 0 0 4pt;
+  margin: 0 0 5pt;
   padding-left: 1pt;
 }
 
@@ -422,11 +427,21 @@ pre code {
 blockquote {
   border-left: 3pt solid #93c5fd;
   background: #f8fafc;
-  padding: 7pt 11pt;
-  margin: 10pt 0;
+  padding: 9pt 11pt;
+  margin: 11pt 0 13pt;
   color: var(--color-subtitle);
   font-style: normal;
   border-radius: 0 6pt 6pt 0;
+}
+
+.decision-strip {
+  display: block;
+  margin: 10pt 0 14pt;
+  padding: 10pt 12pt;
+  border-radius: 8pt;
+  border: 1px solid #dbe4f0;
+  background: #f8fbff;
+  page-break-inside: avoid;
 }
 """
 


### PR DESCRIPTION
## Summary
- add a MiniMax SEA memo PDF layout eval that separates rendering-layer failures from memo information-design failures
- add market-entry / go-no-go memo formatting guidance to the default report template
- make conservative PDF rhythm tweaks for Chinese-heavy reports (body line-height, paragraph/list spacing, blockquote spacing, text rendering)
- update the roadmap with follow-up validation targets for CJK text rhythm and scan-friendly market-entry memo blocks

## Why
The latest MiniMax SEA memo exposed two different failure families that should not be mixed together:
1. PDF/rendering failures, especially the broken-export / OCR-like CJK spacing feel
2. decision-memo information-design failures, where recommendation, hard gates, shortlist, and phased-entry logic were not visually elevated enough

This PR keeps those two tracks explicit while making a small, focused rendering pass instead of another large grab-bag layout change.

## Files touched
- `references/report-template.md`
- `scripts/markdown_to_html.py`
- `evals/minimax-sea-memo-pdf-layout-case.md`
- `ROADMAP.md`
