### PR TITLE
fix: tighten cjk pdf text spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ This file is intentionally lightweight. Use concise entries that explain:
 - `references/source-traceability-and-claim-citation.md` now adds a mixed-evidence weighting section for tier / positioning memos so traceability does not stop at bibliography theater.
 - `checklists/source-traceability.md` now requires load-bearing positioning judgments to show direct-evidence-vs-inference weighting in the body and prevents self-tests / roadmap reporting / valuation signals from silently carrying primary-evidence weight.
 - `references/report-template.md` now adds a required load-bearing evidence note for mixed-evidence positioning judgments.
+- `scripts/markdown_to_html.py` now uses stricter CJK-friendly line-breaking defaults (`word-break: keep-all`, `overflow-wrap: normal`, `text-autospace: no-autospace`) for body text and comparison blocks to reduce the broken-export / torn-character feel in Chinese PDFs.
+- `scripts/markdown_to_html.py` text normalization now more aggressively repairs broken CJK spacing around punctuation and separators (including `%`, `·`, `—`, `…`) before markdown parsing.
 - `references/option-selection-and-shortlist-discipline.md` now includes provider-selection heuristics for current model/API family, stale-anchor avoidance, and mainland-access / data-residency / SLA-sensitive ranking.
 - `references/decision-report-template.md` now explicitly adapts its structure for option-selection and shortlist tasks, including ranked shortlist flow, aggregation visibility, and change-the-ranking conditions.
 - `references/decision-report-template.md` now includes a stronger provider-selection structure with decision architecture, current snapshot table, ranked shortlist, and deployment archetypes.
@@ -93,6 +95,7 @@ This file is intentionally lightweight. Use concise entries that explain:
 - A new multi-origin meetup-city paired case exposed a different constrained-choice execution gap: reports can know they are doing selection work yet still hide quantitative-role labeling, fairness measurement, shortlist-construction logic, and ranking-reversal conditions.
 - A new Cambricon first-tier positioning case exposed another ranking failure family: reports can define multiple dimensions and still collapse them into a polished but weakly-auditable prestige label, especially when global vs domestic scope, current vs roadmap products, and direct evidence vs inference are mixed.
 - The same Cambricon case also exposed an auditability gap: even when reports label confirmed facts, inference, and uncertainty, they may still fail to show which load-bearing claims are direct-evidence-backed versus inference-heavy, creating source-rich but weakly-auditable conclusions.
+- Repeated MiniMax PDF samples still showed a broken-export feeling in Chinese text texture, so the rendering layer needed another narrow CJK-spacing pass separate from research-discipline changes.
 - The skill itself needed to consume those additions through clearer routing, otherwise the new evals would remain documentation instead of affecting execution.
 
 ## 0.4.0 - 2026-03-31

--- a/scripts/markdown_to_html.py
+++ b/scripts/markdown_to_html.py
@@ -55,13 +55,21 @@ body {
   font-feature-settings: "kern" 1, "liga" 1;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  -webkit-text-size-adjust: 100%;
   hyphens: none;
   letter-spacing: 0;
   word-spacing: 0;
   word-break: normal;
+  overflow-wrap: normal;
   line-break: strict;
   text-spacing: none;
+  text-autospace: no-autospace;
   text-rendering: optimizeLegibility;
+}
+
+p, li, blockquote, td, th, h1, h2, h3, h4, .table-card-value, .exec-box, .callout {
+  word-break: keep-all;
+  overflow-wrap: normal;
 }
 
 /* ── Cover ── */
@@ -551,10 +559,12 @@ def normalize_text_for_pdf(text):
 
     # Stronger CJK spacing repair, especially for broken headings/metadata lines.
     text = re.sub(rf'([{cjk}])\s+([{cjk}])', r'\1\2', text)
-    text = re.sub(rf'([{cjk}])\s+([，。！？；：、）】》])', r'\1\2', text)
+    text = re.sub(rf'([{cjk}])\s+([，。！？；：、）】》％%])', r'\1\2', text)
     text = re.sub(rf'([（【《])\s+([{cjk}])', r'\1\2', text)
+    text = re.sub(rf'([{cjk}])\s+([·—…])\s*([{cjk}])', r'\1\2\3', text)
     text = re.sub(rf'([{cjk}])\s+([A-Za-z0-9])', r'\1 \2', text)
     text = re.sub(rf'([A-Za-z0-9])\s+([{cjk}])', r'\1 \2', text)
+    text = re.sub(r'(?m)^((?:[A-Z][A-Za-z\-]+\s*[:：]\s*)+)(.+)$', lambda m: re.sub(r'\s{2,}', ' ', m.group(1)).strip() + ' ' + m.group(2).strip(), text)
 
     # Normalize bullets/odd line starts that often confuse markdown parsers.
     text = re.sub(r'(?m)^[\x00-\x08\x0b\x0c\x0e-\x1f\u2022\u25aa\u25cf\uf0b7]\s*', '- ', text)


### PR DESCRIPTION
## Summary
- tighten CJK-oriented line-breaking defaults in the PDF HTML renderer
- add a narrow text-normalization pass for broken Chinese spacing around punctuation and separators

## What changed
- `scripts/markdown_to_html.py`
  - use stricter CJK-friendly defaults such as `word-break: keep-all`, `overflow-wrap: normal`, and `text-autospace: no-autospace`
  - apply stronger spacing repair around `%`, `·`, `—`, and `…`
- `CHANGELOG.md`
  - record this rendering-layer fix separately from research-discipline changes

## Why
Repeated MiniMax PDF samples still showed a broken-export / torn-character feel in Chinese text.
This PR keeps the fix narrow and isolated to the rendering layer.

It does **not** change research discipline, routing, templates, or eval logic.
