### PR TITLE
refactor: separate routing matrix from skill workflow spine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is intentionally lightweight. Use concise entries that explain:
 ## Unreleased
 
 ### Added
+- `ROUTING-MATRIX.md`
 - `references/failure-taxonomy.md`
 - `references/comparative-distillation-method.md`
 - `references/option-selection-and-shortlist-discipline.md`
@@ -31,6 +32,8 @@ This file is intentionally lightweight. Use concise entries that explain:
 - `scripts/markdown_to_html.py` pre-parse table repair now strips accidental list-prefix injection before headings/table rows (e.g. `- ##` / `- | ...`), normalizes malformed separator rows, and removes stray leading bullet-placeholder columns (e.g. `| - | # | ...`) before markdown parsing.
 - `scripts/markdown_to_html.py` table sanitization now more aggressively removes placeholder headers/columns and URL-heavy split-off metadata columns when they reduce comparison readability.
 - PDF table CSS now improves pagination and scan quality for source/info tables: header rows are repeated as table headers across page breaks, row splitting is reduced, and long URLs use softer wrap behavior to avoid severe character fragmentation.
+- `SKILL.md` now acts more clearly as the workflow spine and orchestration layer rather than the single file that carries every mature route-specific trigger; task-family routing is now centralized in `ROUTING-MATRIX.md`.
+- `ROUTING-MATRIX.md` now defines the six most mature task families (provider selection, market entry, market outlook, first-tier positioning, constrained choice, listed-company research), their required attached disciplines, their required audits, and the visible artifact contracts that final reports must satisfy.
 - `SKILL.md` now adds a delivery-artifact rule: if the user's request includes `pdf`, `PDF`, or `报告`, the workflow should still produce the normal markdown report but also write a `.md` file and run `scripts/md_to_pdf.py` to render a PDF artifact when possible.
 - Added `scripts/markdown_to_html.py`, `scripts/render_pdf.py`, and `scripts/md_to_pdf.py` to version the PDF rendering pipeline inside the repo instead of relying only on workspace-root helper scripts.
 - The PDF renderer styles were substantially upgraded: lighter cover design, cleaner heading hierarchy, improved table spacing/borders, better code/callout/blockquote styling, and proper markdown list rendering for `ul/ol` blocks.
@@ -97,6 +100,7 @@ This file is intentionally lightweight. Use concise entries that explain:
 - The same Cambricon case also exposed an auditability gap: even when reports label confirmed facts, inference, and uncertainty, they may still fail to show which load-bearing claims are direct-evidence-backed versus inference-heavy, creating source-rich but weakly-auditable conclusions.
 - Repeated MiniMax PDF samples still showed a broken-export feeling in Chinese text texture, so the rendering layer needed another narrow CJK-spacing pass separate from research-discipline changes.
 - The skill itself needed to consume those additions through clearer routing, otherwise the new evals would remain documentation instead of affecting execution.
+- The routing surface had become too diffuse inside `SKILL.md`; a dedicated routing contract was needed so mature task families could be activated, reviewed, and audited more explicitly.
 
 ## 0.4.0 - 2026-03-31
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Turn "search and summarize" into a stricter research workflow that:
 
 ## Current structure
 
-- `SKILL.md` — main skill protocol
+- `SKILL.md` — main workflow spine and orchestration rules
+- `ROUTING-MATRIX.md` — task-routing contract: primary routes, attached disciplines, audits, and visible artifact expectations
 - `references/` — supporting playbooks and templates
 - `checklists/` — execution-time audit checklists (run before delivery)
 - `examples/` — example tasks and failure cases

--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -1,0 +1,382 @@
+# Routing Matrix
+
+Use this file to route deep-research tasks into the correct research disciplines, audits, and visible report structures.
+
+This file exists to reduce two failure modes:
+
+1. the right rule exists but does not activate
+2. the report seems informed by the rule but does not visibly execute it
+
+## Global rule
+
+For every task:
+
+1. identify the real decision, judgment, or diligence goal
+2. choose one primary route
+3. attach the required secondary disciplines
+4. make the route visible in the final artifact
+5. run the required audits before delivery
+
+If multiple routes apply, choose one primary route and attach the others as secondary disciplines.
+
+Use the smallest complete set:
+
+- one primary route
+- up to 2–3 secondary disciplines
+
+Do not activate everything. Activate the smallest set that produces a decision-useful, auditable, current, and clean final artifact.
+
+---
+
+## Route: Provider / Vendor Selection
+
+### Trigger
+Use when the task is mainly about:
+
+- model/API supplier selection
+- vendor shortlist
+- platform choice
+- provider comparison under deployment constraints
+
+### Read
+- `references/option-selection-and-shortlist-discipline.md`
+- `references/source-traceability-and-claim-citation.md`
+- `references/decision-report-template.md`
+
+### Attach
+- current-state verification
+- source traceability
+- quantitative role labeling when pricing, benchmarks, or scoring matter
+
+### Audit
+- `checklists/option-selection-final-audit.md`
+- `checklists/source-traceability.md`
+- `checklists/final-audit.md`
+
+### Visible artifact contract
+The final report should visibly show:
+
+- current provider snapshot
+- decision criteria / ranking logic
+- ranked shortlist
+- why the top option wins
+- why the runner-up remains credible
+- why other options lose
+- accessibility / compliance / data-control / SLA treatment when relevant
+
+### Hard fail
+Fail if the report:
+
+- compares stale anchor products or models without current verification
+- treats mainland accessibility / compliance / SLA as side notes instead of ranking logic
+- becomes a vendor overview instead of a choice memo
+
+---
+
+## Route: Market Entry / Regional Expansion
+
+### Trigger
+Use when the task is mainly about:
+
+- whether to enter a market
+- whether to prioritize a country or region
+- market-entry sequencing
+- regional expansion under constrained budget
+- go / no-go / pilot-only expansion decisions
+
+### Read
+- `references/option-selection-and-shortlist-discipline.md`
+- `references/decision-report-template.md`
+- `references/source-traceability-and-claim-citation.md`
+
+### Attach
+- current-state verification
+- source traceability
+- quantitative role labeling when TAM/SAM/SOM, proxies, or scoring matter
+
+### Audit
+- `checklists/option-selection-final-audit.md`
+- `checklists/source-traceability.md`
+- `checklists/final-audit.md`
+
+### Visible artifact contract
+The final report should visibly show:
+
+- explicit recommendation: `go` / `not now` / `pilot only` / phased entry
+- priority relative to alternatives
+- country shortlist
+- hard gates
+- sequencing logic
+- recommended entry motion
+- distinction between:
+  - regional hub
+  - first revenue beachhead
+  - later expansion market
+
+### Hard fail
+Fail if the report:
+
+- drifts into a generic market overview
+- gives country notes without a unified comparison unit
+- recommends expansion without hard gates or sequencing logic
+- collapses hub / beachhead / later expansion market into one vague “best market”
+
+---
+
+## Route: Market Outlook / Industry Evolution
+
+### Trigger
+Use when the task is mainly about:
+
+- how a market will evolve
+- next 6–12 month outlook
+- adoption trajectory
+- industry evolution
+- scenario memo
+
+### Read
+- `references/market-outlook-and-scenario-discipline.md`
+- `references/decision-report-template.md`
+- `references/source-traceability-and-claim-citation.md`
+
+### Attach
+- current-state verification
+- forward-looking claims discipline
+- source traceability
+- quantitative role labeling when forecasts or scenario math appear
+
+### Audit
+- `checklists/forward-looking-claims.md`
+- `checklists/source-traceability.md`
+- `checklists/final-audit.md`
+
+### Visible artifact contract
+The final report should visibly show:
+
+- current market snapshot
+- key drivers of change
+- key blockers or friction points
+- base case
+- alternative scenarios
+- stakeholder implications
+- monitoring signals
+- what would change the conclusion
+
+### Hard fail
+Fail if the report:
+
+- remains an industry overview instead of an outlook memo
+- mixes observed facts with scenario assumptions
+- gives forecasts without visible scenario structure
+- hides stakeholder implications inside generic narrative
+
+---
+
+## Route: First-tier / Top-tier / Competitive Positioning
+
+### Trigger
+Use when the task is mainly about:
+
+- whether a company belongs in the top tier / first tier
+- global-vs-domestic standing
+- multidimensional competitive positioning
+- prestige-label justification
+
+### Read
+- `references/ranking-and-current-claims-discipline.md`
+- `references/source-traceability-and-claim-citation.md`
+- `references/decision-report-template.md`
+
+### Attach
+- current-state verification
+- source traceability
+- evidence-weight separation
+
+### Audit
+- `checklists/source-traceability.md`
+- `checklists/final-audit.md`
+
+### Visible artifact contract
+The final report should visibly show:
+
+- scope
+- metric
+- timeframe
+- dimension-level conclusions
+- evidence-strength separation
+- explicit overall-label gate
+
+### Hard fail
+Fail if the report:
+
+- uses `第一梯队` / `top-tier` loosely
+- collapses multiple dimensions into a prestige label without aggregation logic
+- treats direct evidence, roadmap claims, valuation signals, and ecosystem anecdotes as equally strong
+
+---
+
+## Route: Constrained Choice / Shortlist / Option Selection
+
+### Trigger
+Use when the task is mainly about:
+
+- choosing among several plausible options
+- ranking or shortlist construction
+- destination / venue / city / office / vendor choice
+- practical decision memo under constraints
+
+### Read
+- `references/option-selection-and-shortlist-discipline.md`
+- `references/decision-report-template.md`
+
+### Attach
+- quantitative role labeling when scores, proxies, or modeled comparisons appear
+
+### Audit
+- `checklists/option-selection-final-audit.md`
+- `checklists/final-audit.md`
+
+### Visible artifact contract
+The final report should visibly show:
+
+- decision architecture
+- shortlist construction logic
+- comparison unit
+- final ranking or selection
+- why the top option wins
+- why the runner-up remains credible
+- ranking-reversal conditions
+- hidden operational burdens when relevant
+
+### Hard fail
+Fail if the report:
+
+- gives a recommendation without showing how the shortlist was built
+- uses numbers without labeling observed fact / proxy / assumption / model output
+- turns the task into descriptive option blurbs instead of a true choice memo
+
+---
+
+## Route: Listed Company / Investment-style Research
+
+### Trigger
+Use when the task is mainly about:
+
+- listed companies
+- valuation / market cap / growth / guidance
+- investment memo style judgments
+- equity-style diligence
+
+### Read
+- `references/finance-date-discipline.md`
+- `references/market-sizing-and-share-discipline.md` when share/size claims matter
+- `references/source-traceability-and-claim-citation.md`
+
+### Attach
+- current-state verification
+- forward-looking claims discipline when forecasts appear
+- source traceability
+
+### Audit
+- `checklists/listed-company-report.md`
+- `checklists/source-traceability.md`
+- `checklists/final-audit.md`
+
+### Visible artifact contract
+The final report should visibly show:
+
+- current business snapshot
+- current financial or market snapshot
+- clearly dated key numbers
+- separation of reported facts vs estimates
+- risks and counter-evidence
+- uncertainty around forward views
+
+### Hard fail
+Fail if the report:
+
+- mixes reported metrics and forward estimates without clear labels
+- uses undated financial numbers
+- makes market-position claims without scope
+- lets valuation narrative substitute for business evidence
+
+---
+
+## Cross-cutting disciplines
+
+### Current-state verification
+Attach when the task involves current products, pricing, versions, company status, provider state, rankings, or other fast-moving facts.
+
+Visible sign:
+- a clearly current snapshot or freshness check
+
+Fail if:
+- likely-but-stale knowledge substitutes for verification
+
+### Source traceability
+Attach when the task is structured, claim-heavy, investment-relevant, or recommendation-heavy.
+
+Visible sign:
+- major claims are auditable in the body, not only in the source appendix
+
+Fail if:
+- key conclusions cannot be traced to identifiable evidence
+
+### Forward-looking claims discipline
+Attach when the task includes forecasts, roadmap claims, target dates, expected pricing, or expected market evolution.
+
+Visible sign:
+- forward-looking claims are labeled by source role and uncertainty
+
+Fail if:
+- `预计` / `expected` / `likely` appears without source role or confidence framing
+
+### Quantitative role labeling
+Attach when the task uses proxies, scorecards, market sizing, scenario math, or composite scoring.
+
+Visible sign:
+- important numbers are labeled as observed fact / proxy / assumption / model output / illustrative calculation
+
+Fail if:
+- internally generated estimates appear as if they were observed facts
+
+### Delivery cleanliness
+Attach when the output is intended for user-facing delivery, especially PDF.
+
+Visible sign:
+- no citation artifacts
+- no placeholder residue
+- no template markers
+- no rendering leakage
+
+Fail if:
+- the report body exposes internal syntax, parser debris, or generator hints
+
+---
+
+## Routing priority
+
+If multiple primary-looking routes apply, use this order:
+
+1. listed-company / investment-style
+2. market entry / regional expansion
+3. provider / vendor selection
+4. first-tier / competitive positioning
+5. market outlook / industry evolution
+6. constrained choice / shortlist
+
+Choose the route that most strongly determines report structure and audit burden.
+
+---
+
+## Final check
+
+Before delivery, ask:
+
+1. did the correct route fire?
+2. did the required secondary disciplines attach?
+3. is the route visibly executed in the final artifact?
+
+A route only counts if the final report visibly satisfies its artifact contract.
+
+If the route is implicit in reasoning but not visible in delivery, treat that as an execution failure.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deep-research
-description: Conduct structured multi-step research for complex questions, decision support, market/company/technical analysis, competitive scans, and fact-checked briefings. Use when the user needs more than a quick answer and the task benefits from explicit planning, source comparison, verification, counter-evidence, uncertainty handling, and a structured final report. Especially use when the goal is to support a decision, compare alternatives, understand a market/company/product, assess feasibility, or produce a source-backed research memo.
+description: Conduct structured multi-step research for complex questions, decision support, market/company/technical analysis, competitive scans, and fact-checked briefings. Use when the user needs more than a quick answer and the task benefits from explicit planning, source comparison, verification, counter-evidence, uncertainty handling, and a structured final report.
 ---
 
 # Deep Research
@@ -21,52 +21,51 @@ Never present inference as confirmed fact.
 
 ## Workflow
 
-1. Clarify the real objective.
-2. Classify the task type.
-3. Produce a short research plan.
-4. Define evidence standards and stop conditions.
-5. Collect and compare sources.
-6. Run a mid-research review.
-7. Search for counter-evidence.
-8. Synthesize findings into a decision-oriented report.
+1. clarify the real objective
+2. classify the task
+3. produce a compact research plan
+4. define evidence standards and stop conditions
+5. collect and compare sources
+6. run a mid-research review
+7. search for counter-evidence
+8. synthesize into a decision-oriented report
 
-## Step 1: Clarify the real objective
+## Routing rule
 
-Before searching, identify:
+Before deep collection, determine:
 
-- the main question
-- the user's likely decision or use case
-- the required depth
-- the time horizon if relevant
-- whether the user wants explanation, recommendation, comparison, or diligence
+- the primary route
+- the required secondary disciplines
+- the visible artifact contract the final report must satisfy
 
-If the user's wording is broad, anchor on the most decision-relevant interpretation instead of drifting into general background.
+Read `ROUTING-MATRIX.md` to select:
 
-Examples:
+- the primary route
+- required secondary disciplines
+- required audits
+- visible output structure
 
-- "Research AI coding agents" may really mean market entry, competitive positioning, or vendor selection.
-- "Research this company" may really mean partnership diligence, investment risk, or product comparison.
+Use one primary route plus only the smallest necessary supporting set.
 
-## Step 2: Classify the task type
+If multiple routes apply, choose the route that most strongly determines:
 
-Choose the closest task type before collecting sources. If unclear, make a reasonable choice and proceed.
+- report structure
+- evidence burden
+- audit burden
 
-Common task types:
+## Core shared disciplines
 
-- market or industry research
-- company or startup analysis
-- product or competitor analysis
-- technical feasibility
-- regulatory or policy scan
-- people or background research
-- buy/build/partner decision
-- vendor or tool selection
+Apply these when the route requires them:
 
-Use the task type to shape subquestions, source priorities, and report structure.
+- current-state verification
+- source traceability
+- forward-looking claims discipline
+- quantitative role labeling
+- delivery cleanliness
 
-Read `references/task-types.md` when the task needs a domain-specific question set.
+Do not assume these are implied. If the route needs them, make them visible in the final output.
 
-## Step 3: Produce a short research plan
+## Research plan
 
 Before searching, write a compact internal plan with:
 
@@ -80,31 +79,9 @@ Before searching, write a compact internal plan with:
 - stop conditions
 - what would count as a strong answer
 
-Prefer a small number of high-value questions over a large list of generic ones.
+Prefer a small number of high-value questions over a long list of generic ones.
 
-A strong plan focuses on what would change the final conclusion, not just what is interesting.
-
-## Step 4: Define evidence standards and stop conditions
-
-Set a quality bar before gathering sources.
-
-Before searching deeply, decide which gates must fire for this task. Do not leave this implicit.
-
-At minimum, check for these trigger patterns:
-
-- **Listed company / public equity / valuation / investment memo** -> run listed-company discipline and require a current market snapshot before delivery
-- **Current products / latest model / current lineup / pricing / release cycle / rankings / market position** -> run current-state verification before broader analysis
-- **"First-tier" / "top-tier" / global-vs-domestic positioning / multidimensional competitive standing / whether company X really belongs in the top group** -> treat as a definition-sensitive constrained-judgment task; require explicit scope, metric, timeframe, dimension-level conclusions, and an overall-label gate before using tier language
-- **Model/API supplier selection / vendor shortlist / provider choice / platform choice under deployment constraints** -> treat as both a current-state-sensitive task and a constrained-choice task; require a current provider snapshot before ranking or recommendation
-- **Structured memo / investment case / comparative report / claim-labeled output** -> run source-traceability discipline
-- **Dimension-by-dimension judgment with mixed evidence quality (for example official specs + self-tests + market anecdotes + roadmap reporting + valuation signals)** -> run source-traceability discipline with explicit evidence-weight separation for load-bearing claims
-- **Forecast / roadmap / guidance / consensus / target price / launch timing / "预计" style claims** -> run forward-looking-claims discipline
-- **Market outlook / industry evolution / "未来12个月如何演化" / adoption trajectory / industry memo** -> treat as both a current-state-sensitive task and a decision-memo task; require a current market snapshot, explicit drivers/blockers, scenario structure, and stakeholder action guidance
-- **Global market / full landscape / industry-wide scope** -> explicitly test scope completeness across key geographies, segments, and regulatory regimes
-- **Recommendation / go-no-go / compare options / what should we do** -> optimize for decision utility, not just depth
-- **Market entry / regional expansion / "should we prioritize market X" / country-entry sequencing under limited budget** -> treat as both a constrained-choice task and a decision-memo task; require explicit priority vs alternatives, country shortlist, sequencing, hard gates, and entry-mode logic rather than a market overview
-
-If multiple triggers apply, route into all of them. Do not assume one checklist covers the others.
+## Evidence standards
 
 For key claims, prefer:
 
@@ -127,26 +104,9 @@ For every important claim, capture:
 
 Read `references/source-quality.md` when source ranking is ambiguous.
 Read `references/claim-matrix.md` when the task has multiple important conclusions, conflicting evidence, or high stakes.
-Read `references/finance-date-discipline.md` when the task involves company research, financial performance, valuation, guidance, delivery volumes, or other time-sensitive numeric claims.
-Read `checklists/listed-company-report.md` for listed-company research - applies the required fields gate before delivery.
-
-Read `references/market-sizing-and-share-discipline.md` when the task involves market size, TAM/SAM/SOM, market-share estimates, competitive-position sizing, or any numeric mapping from company data to broader market claims.
-Read `references/ranking-and-current-claims-discipline.md` when the task involves rankings, share rankings, category leadership, "No.1" claims, streak claims, current-position claims, first-tier / top-tier labels, multidimensional competitive positioning, or other time-sensitive comparative statements.
-Read `references/corporate-status-and-listing-state-discipline.md` when the task involves whether a company is private, filed, approved, registered, listed, trading, delisted, or otherwise in a changing capital-markets state.
-Read `references/source-traceability-and-claim-citation.md` when the task requires structured claims, investment memos, competitive analysis, or any output where readers need to audit which specific source supports which conclusion. Specifically required when the output includes CONFIRMED / LIKELY / UNCERTAIN labels.
-Run `checklists/source-traceability.md` before delivery if the output is a structured or investment-relevant memo.
-
-Read `checklists/forward-looking-claims.md` when the task involves product release timelines, pricing forecasts, forward financial estimates, or any forward-looking statements.
-Read `evals/global-market-scope-completeness-case.md` as a coverage discipline check when the task claims global, full-landscape, or industry-wide scope.
-Read `evals/decision-utility-rubric.md` when the user needs a recommendation, prioritization, vendor choice, go/no-go, or other action-guiding conclusion.
-Read `references/option-selection-and-shortlist-discipline.md` when the task is mainly about choosing among several plausible options under constraints (for example destination selection, vendor shortlist, office/venue choice, multi-origin meetup/location choice, or other comparison tasks where ranking and elimination matter more than background explanation).
-Run `checklists/option-selection-final-audit.md` before delivery for shortlist, ranking, destination-selection, or other constrained-choice outputs.
-For model/API supplier or provider-selection tasks, explicitly verify a current provider snapshot before broader comparison: current primary model/API family, current pricing unit, current support-region / mainland accessibility reality, current data-control posture, and current SLA / status disclosures when decision-relevant.
-For market-entry / regional-expansion / country-prioritization tasks, explicitly verify the decision architecture before broader analysis: what the real choice is, what the priority is relative to alternatives, whether the question is about a regional hub vs first revenue beachhead vs later expansion market, what hard gates exist, and what sequencing logic would make the recommendation operational.
-Use `references/decision-report-template.md` with the provider-selection structure when the task is choosing a core model/API supplier under real deployment constraints.
-Use `references/decision-report-template.md` with the market-entry structure when the task is deciding whether to prioritize a country or region under real budget, compliance, and localization constraints.
-Read `references/comparative-distillation-method.md` when comparing paired reports (for example GPT vs Minimax on the same topic) to distill reusable skill improvements rather than just judge which output is better.
-Use `evals/comparative-distillation-template.md` to record each paired-report comparison so every extracted pattern ends in `NEW_RULE`, `CHECKLIST_HARDENING`, `TEMPLATE_CHANGE`, or `NO_ACTION`.
+Read `references/task-types.md` when the task needs a domain-specific question set.
+Read `references/comparative-distillation-method.md` when comparing paired reports to turn stronger-vs-weaker outputs into reusable changes.
+Use `evals/comparative-distillation-template.md` to record paired-report comparisons so extracted patterns land as `NEW_RULE`, `CHECKLIST_HARDENING`, `TEMPLATE_CHANGE`, or `NO_ACTION`.
 
 Stop searching when one of these is true:
 
@@ -156,184 +116,100 @@ Stop searching when one of these is true:
 
 Do not keep searching just to make the report longer.
 
-## Step 5: Collect and compare sources
+## Tool strategy
 
-Start lightweight.
+Use tools deliberately.
 
-- Use `web_search` to discover candidate sources.
-- Use `web_fetch` for readable extraction.
-- Use `browser` only when a page is dynamic or fetch fails.
+- `web_search`: discover candidate sources and comparison angles
+- `web_fetch`: extract readable page content
+- `browser`: handle dynamic pages or failed fetches
+- `sessions_spawn`: split clearly separable tracks only
+- final synthesis: always perform one parent-level reconciliation pass
 
-Avoid browsing loops with weak information gain.
-
-Prioritize source diversity over source count. A few independent, high-quality sources are better than many repetitive summaries.
-
-When comparing sources, pay attention to:
-
-- independence
-- recency
-- directness
-- measurement vs opinion
-- whether a source is repeating another source
-
-For time-sensitive topics, prefer current sources over older authoritative summaries if the newer material changes the picture.
+Avoid unnecessary browsing loops, repetitive searches, or unstructured parallel runs.
 
 ## Current-state verification
 
-When the task involves products, model versions, device lineups, pricing, packaging, regulations, company status, leadership, rankings, release cycles, or any fast-moving topic, verify the current state before forming conclusions.
+When the task is time-sensitive, verify the current state before forming conclusions.
 
-Do not rely on prior knowledge, stale summaries, or model memory for current-state facts.
+Typical triggers include:
 
-Before writing the report, explicitly verify when relevant:
-
-- latest product generation or version
-- current product lineup
-- current pricing or packaging
-- current company positioning
-- most recent major announcement or release
-- whether newer information supersedes older sources
-
-Prefer current-state checks in this order:
-
-1. official current product or company pages
-2. official announcements, press releases, or release notes
-3. current docs, changelogs, or support pages
-4. reputable reporting only after checking primary sources
-
-For fast-moving topics, search with freshness-first patterns such as:
-
-- `[topic] official`
-- `[topic] latest`
-- `[topic] current`
-- `[topic] current lineup`
-- `[topic] release date`
-- `[topic] pricing`
-- `site:<official-domain> [topic]`
-
-If the current state cannot be verified, say so clearly instead of filling gaps with likely-but-stale knowledge.
-
-For fast-moving company or investment research, produce a short current snapshot before broader analysis. When relevant, verify and separate:
-
-- current product lineup
-- current strategic framing
-- latest reported financial disclosure
+- latest products or versions
+- current pricing
+- current provider state
+- current company status
 - current market snapshot
-- forward-looking targets or estimates
+- current rankings or positioning
 
-Do not merge reported facts, current market data, and forward-looking numbers into one undifferentiated narrative.
+If current state cannot be verified, say so clearly instead of filling gaps with likely-but-stale knowledge.
 
-For market-outlook / industry-evolution tasks, the opening snapshot should be visibly tailored to decision use, not just recency. When relevant, verify and separate:
+Route-specific current-state requirements are defined in `ROUTING-MATRIX.md`.
 
-- current market baseline and scope
-- current product / pricing / policy changes that alter the next-12-month view
-- current adoption bottlenecks or enabling infrastructure
-- explicit drivers of change vs blockers of change
-- what is observed now vs what is scenario logic for the next 6-12 months
+## Mid-research review
 
-If the task asks how a market will evolve, do not let the report remain a background industry overview. Force a transition from current snapshot -> scenarios -> stakeholder implications.
-
-## Step 6: Run a mid-research review
-
-After the first meaningful batch of evidence, pause and reassess.
-
-Write a short internal review covering:
+After the first meaningful batch of evidence, pause and reassess:
 
 - current best answer
 - strongest evidence so far
 - key missing evidence
-- which subquestions matter less than expected
 - whether the search strategy should change
-- whether parallelization is now justified
-
-Use this step to cut low-value branches and sharpen high-value ones.
+- whether low-value branches should be cut
 
 Do not continue gathering information blindly once the shape of the answer is clear.
 
-## Step 7: Search for counter-evidence
+## Counter-evidence
 
-For every high-impact conclusion, actively look for evidence that could weaken or overturn it.
+For every load-bearing conclusion, actively look for evidence that could weaken or overturn it.
 
-At minimum, do one of:
+At minimum, check for:
 
-- look for direct criticism or failure cases
-- look for competing explanations
-- look for contradictory primary or independent sources
-- look for edge cases, legal issues, security issues, user complaints, or failed rollouts
-- look for reasons the conclusion may only hold in one market, segment, or timeframe
+- direct criticism or failure cases
+- contradictory primary evidence
+- competing explanations
+- edge cases, legal constraints, operational failures, or user complaints
 
 Read `references/counter-evidence.md` when the topic is contentious, commercial, fast-moving, or high stakes.
 
 Never treat the first plausible story as the final one.
 
-## Step 8: Synthesize into a decision-oriented report
+## Synthesis
 
-Use the report structure in `references/report-template.md` by default.
-Read `references/decision-report-template.md` when the user needs a recommendation, go/no-go view, comparison, or action plan.
-For market-outlook / industry-evolution tasks, prefer the decision-report structure over a generic industry overview. These tasks should visibly show: current snapshot, key drivers and blockers, scenario structure, stakeholder implications, and what would change the view.
+Use `references/report-template.md` by default.
+
+Use `references/decision-report-template.md` when the task needs:
+
+- recommendation
+- go / no-go view
+- prioritization
+- comparison
+- action guidance
+
+The report should not just summarize the topic. It should help the user decide, judge, or verify what matters next.
 
 For most tasks, include:
 
-1. Executive summary
-2. What matters most
-3. Key findings
-4. Detailed analysis
-5. Risks and counter-evidence
-6. Uncertainty and missing evidence
-7. Bottom line
-8. Sources
+1. executive summary
+2. what matters most
+3. key findings
+4. detailed analysis
+5. risks and counter-evidence
+6. uncertainty and missing evidence
+7. bottom line
+8. sources
 
-When useful, also include:
+## Delivery rule
 
-- recommendation
-- alternatives considered
-- what could change the conclusion
-- next checks
-- near-term outlook
+Default delivery stays as text or markdown.
 
-Always make clear:
-
-- what is directly supported
-- what is inferred
-- what remains unresolved
-
-## Delivery artifact rule
-
-Default delivery stays as text / markdown.
-
-If the user's request includes `pdf`, `PDF`, or `报告`, treat that as a PDF-output request in addition to the normal report delivery.
-
-In that case:
+If the user's request includes `pdf`, `PDF`, or `报告`, also produce a PDF artifact:
 
 1. write the final report to a `.md` file first
-2. convert it with `scripts/md_to_pdf.py` (resolve relative to the skill directory)
-3. deliver or attach the generated PDF when the surface supports files
+2. convert it with `scripts/md_to_pdf.py`
+3. deliver the PDF when the surface supports files
 
-Do not skip the markdown file. The PDF is a rendered artifact, not the source of truth.
+The markdown file remains the source of truth.
 
-If PDF rendering fails, still deliver the markdown/text report and explicitly say the PDF export failed.
-
-## Research depth
-
-This skill defaults to deep research quality.
-
-Do not switch between multiple research modes by default. Instead, keep the research discipline consistent and adapt only:
-
-- the breadth of background detail
-- the number of secondary branches explored
-- the length of the final report
-
-Even when answering more compactly, keep the core workflow:
-
-- clarify the real objective
-- classify the task type
-- produce a research plan
-- compare sources
-- test key conclusions with counter-evidence
-- separate fact from inference
-- state uncertainty clearly
-- deliver a decision-oriented synthesis
-
-If the user explicitly asks for a faster or lighter answer, compress the presentation rather than dropping core research discipline.
+If PDF rendering fails, still deliver the markdown or text report and explicitly say the PDF export failed.
 
 ## Parallelization
 
@@ -349,32 +225,31 @@ Good examples:
 
 When parallelizing:
 
-- split into 2-4 tracks
+- split into 2–4 tracks
 - keep each track narrow
 - require structured findings, not polished prose
 - require explicit source URLs
 - require separation of confirmed facts vs inference
 - reserve final synthesis for the parent agent
 
-For each track, define:
+Read `references/parallel-research.md` when the task clearly benefits from multi-track work. Keep rate-limit risk in mind and prefer small batches over naive full parallelism.
 
-- track name
-- exact question
-- preferred source types
-- required outputs
+## Final discipline
 
+Before delivery:
 
-## Tool strategy
+1. run the route-specific audits required by `ROUTING-MATRIX.md`
+2. run `checklists/final-audit.md`
+3. confirm that the selected route is visibly executed in the final artifact
 
-Use tools deliberately.
+A report that sounds informed but does not visibly satisfy the selected route’s artifact contract is not ready.
 
-- `web_search`: discover candidate sources and comparison angles
-- `web_fetch`: extract readable page content
-- `browser`: handle dynamic pages or failed fetches
-- `sessions_spawn`: split clearly separable tracks only
-- final synthesis: always perform one parent-level reconciliation pass
+If the failure seems to be:
+- missing rule
+- missing trigger
+- or execution drift
 
-Avoid unnecessary browsing loops, repetitive searches, or unstructured parallel runs.
+use `evals/rule-activation-and-execution-discipline.md`.
 
 ## Output quality bar
 
@@ -389,44 +264,3 @@ A strong final answer should:
 - help the user decide what to do next
 
 If confidence is limited, say exactly why.
-
-## Domain adaptation
-
-Adjust source preference by topic:
-
-- companies or startups: official site, filings, product docs, pricing, careers, credible press
-- software or tools: docs, repo, changelog, issue tracker, benchmarks, user complaints
-- markets: official datasets, regulator or institution reports, strong industry analysis
-- regulation: regulator publications, law text, consultation documents, legal analysis
-- people or background: primary profiles, official bios, direct publications, reputable reporting
-
-When the topic changes over time, explicitly include the time dimension:
-
-- recent changes
-- momentum
-- inflection points
-- near-term outlook
-
-## Final discipline
-
-Before delivering the final report, run `checklists/final-audit.md`.
-
-Then ask one more question: did the correct gates actually fire for this task?
-
-Use these final trigger checks:
-
-- if this was a listed-company or investment-style report, the output should visibly show listed-company discipline
-- if this was a current-state-sensitive task, the output should visibly show a current snapshot or freshness verification
-- if this was a model/API supplier or provider-selection task, the output should visibly show a current provider snapshot and should treat accessibility / compliance / SLA / data-control constraints as part of ranking logic when relevant
-- if this was a market-entry / regional-expansion / country-prioritization task, the output should visibly show priority vs alternatives, a country shortlist, a distinction between regional hub vs first beachhead vs later expansion market when relevant, hard gates, and sequencing logic rather than a generic market overview
-- if this was a structured or claim-heavy memo, the output should visibly show source traceability in the body, not only in a source appendix
-- if this was a first-tier / top-tier / multidimensional positioning judgment, the output should visibly show scope, metric, timeframe, dimension-level conclusions, and the rule for when an overall label is allowed instead of collapsing everything into one vague tier tag
-- if this included forecasts, roadmap claims, estimates, or target prices, the output should visibly show forward-looking discipline
-- if this claimed broad global or full-landscape scope, the output should visibly show scope completeness or clearly state scope limits
-- if this was meant to support a decision, the output should visibly help the reader choose, prioritize, or decide what to verify next
-
-If the report appears to know the rule but not execute it reliably, use `evals/rule-activation-and-execution-discipline.md` to diagnose whether the problem is a missing rule, missing trigger, or execution failure.
-
-It checks: real objective answered, evidence quality, counter-evidence, uncertainty honesty, completeness, recall discipline, and whether the right delivery-time gates actually became visible in the report.
-
-A report that fails the final audit checklist is not ready for delivery.


### PR DESCRIPTION
## Summary
This PR refactors the entry layer of the `deep-research` skill.

Instead of continuing to grow all mature task-family routing inside `SKILL.md`, this change splits routing into a dedicated `ROUTING-MATRIX.md` and keeps `SKILL.md` focused on the shared workflow spine, tool strategy, delivery rule, and final discipline.

## What changed
- added `ROUTING-MATRIX.md`
- moved mature task-family routing into a dedicated routing contract
- reduced `SKILL.md` into a workflow/orchestration spine
- updated `README.md` to reflect the new structure
- updated `CHANGELOG.md` to record the routing-layer refactor

## Included routes
`ROUTING-MATRIX.md` currently covers the six most mature task families:

- provider / vendor selection
- market entry / regional expansion
- market outlook / industry evolution
- first-tier / competitive positioning
- constrained choice / shortlist
- listed-company / investment-style research

Each route now defines:

- trigger
- required reads
- attached disciplines
- required audits
- visible artifact contract
- hard fail patterns

## Why
The skill had reached the point where mature route-specific logic was becoming too diffuse inside `SKILL.md`.

This created two recurring risks:

1. the right rule existed but did not activate reliably
2. the report appeared informed by the rule but did not visibly execute it in the final artifact

This refactor creates a dedicated routing surface so task-family activation, review, and audit expectations are more explicit.

## Non-goals
This PR does **not**:

- add new research capabilities
- change the underlying research workflow
- restructure references/checklists directories
- change PDF/rendering pipeline behavior

## Review focus
Please review for:

- whether the six selected routes are the right first-class set
- whether visible artifact contracts are concrete enough to audit
- whether `SKILL.md` is now meaningfully thinner without losing execution clarity
- whether any mature route logic still belongs in the matrix rather than the main skill file
