### PR TITLE
docs: harden chinese final-delivery coherence

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -190,6 +190,7 @@ Current responsibilities include:
 - table handling and placeholder cleanup
 - PDF rendering
 - print styling and CJK readability adjustments
+- preserving target-language coherence for load-bearing structural labels in final artifacts
 
 This layer should be treated as a delivery subsystem, not as part of core research reasoning.
 
@@ -273,3 +274,4 @@ When making future changes, prefer this order of questions:
 Place the change in the narrowest layer that fully explains the problem.
 
 Do not default to expanding `SKILL.md` unless the change truly belongs to the workflow spine.
+to the workflow spine.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,9 @@ This file is intentionally lightweight. Use concise entries that explain:
 - `checklists/final-audit.md` now adds market-entry gates for priority-vs-alternatives, shortlist/sequencing logic, and hub-vs-beachhead separation when relevant.
 - `checklists/final-audit.md` now adds market-outlook gates for current market snapshot, drivers/blockers/scenarios/stakeholder implications, and explicit labeling of outlook numbers when evidence role matters.
 - `checklists/final-audit.md` now also requires constrained-choice reports with composite scoring to label key quantitative inputs by evidence role when that distinction affects trust in the recommendation.
+- `checklists/final-audit.md` now hardens market-entry audit gates around explicit `go` / `not now` / `pilot only` / `phased entry` resolution, visible why-this-option-wins logic, KPI/milestone triggers, and ranking-change conditions.
+- `checklists/final-audit.md` now explicitly treats mixed evidence-layer vs modeling-layer labeling as an audit issue, so reports do not stop at `confirmed / inference / unknown` when important numbers are really proxies, assumptions, or planning-model outputs.
+- `checklists/final-audit.md` now adds a target-language coherence gate: Chinese final reports should use Chinese load-bearing structural labels unless bilingual output was explicitly requested, and mixed-language evidence buckets count as a delivery failure.
 
 ### Why
 - A real MiniMax SEA memo PDF failure showed five delivery-layer issues that must be handled in rendering: comparison tables degrading in structure, source tables breaking poorly across pages, internal generator hints leaking into final output, placeholder/header residues, and poor horizontal-space usage.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Use real tasks and real failures.
 - when a repeated task family needs clearer activation, strengthen `ROUTING-MATRIX.md`
 - when the task shape is right but the method is weak, improve `references/`
 - when the method exists but the final output still leaks failures, harden `checklists/`
+- when the report is analytically fine but final delivery mixes target languages in load-bearing labels, treat that as a delivery-coherence failure rather than a translation nit
 - when the failure is still unclear, add or refine `evals/`
 - when the content is right but the export is broken, fix `scripts/`
 

--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -16,6 +16,7 @@ For every task:
 3. attach the required secondary disciplines
 4. make the route visible in the final artifact
 5. run the required audits before delivery
+6. ensure target-language coherence in the final artifact when the report is user-facing
 
 If multiple routes apply, choose one primary route and attach the others as secondary disciplines.
 
@@ -375,6 +376,12 @@ Before delivery, ask:
 
 1. did the correct route fire?
 2. did the required secondary disciplines attach?
+3. is the route visibly executed in the final artifact?
+
+A route only counts if the final report visibly satisfies its artifact contract.
+
+If the route is implicit in reasoning but not visible in delivery, treat that as an execution failure.
+dary disciplines attach?
 3. is the route visibly executed in the final artifact?
 
 A route only counts if the final report visibly satisfies its artifact contract.

--- a/SKILL.md
+++ b/SKILL.md
@@ -62,6 +62,7 @@ Apply these when the route requires them:
 - forward-looking claims discipline
 - quantitative role labeling
 - delivery cleanliness
+- target-language coherence for final delivery when the report is user-facing
 
 Do not assume these are implied. If the route needs them, make them visible in the final output.
 
@@ -258,6 +259,13 @@ A strong final answer should:
 - answer the actual question, not just summarize the topic
 - show how the conclusion was formed
 - separate fact from inference
+- surface counter-evidence
+- state confidence clearly
+- explain what is still missing
+- help the user decide what to do next
+
+If confidence is limited, say exactly why.
+
 - surface counter-evidence
 - state confidence clearly
 - explain what is still missing

--- a/SYSTEM-MAP.md
+++ b/SYSTEM-MAP.md
@@ -295,7 +295,8 @@ Preserves the report’s intended structure and readability when converted into 
 ### First place to change
 - scripts/rendering layer if the report logic is sound but the export is broken
 - final-audit gates if known delivery failures are not being caught before export
-- templates only when the information design itself is unsuitable, not merely the renderer
+- templates when the information design or target-language labeling contract is unclear
+- routing/workflow layer when target-language coherence should have been a visible delivery discipline but did not activate
 
 ---
 

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -55,6 +55,8 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] exact figures are used when source provides them; "约" only when source itself rounds
 - [ ] quantitative outlook numbers are labeled as observed / inferred / scenario assumption / illustrative calculation when the distinction matters
 - [ ] for constrained-choice / shortlist reports that use composite scoring, important quantitative inputs are labeled as observed fact / proxy / assumption / model output when the distinction affects trust in the recommendation
+- [ ] when evidence buckets are used, the report does not stop at `confirmed / inference / unknown` if important numbers still function as proxy / assumption / planning-model output
+- [ ] heuristic timing, cost, payback, or ROI-style claims are not written as if they were directly observed facts when they are closer to assumptions or planning-model outputs
 
 ## Market position and ranking claims
 
@@ -73,6 +75,11 @@ This is the last gate before the report goes to the user. If any item fails, rev
 
 - [ ] no citation artifacts, retrieval syntax, placeholder entities, or rendering residues leak into the final report body
 - [ ] markdown / PDF delivery does not expose internal labels, raw template markers, or unfinished placeholders
+
+## Quality bar
+
+A report that fails this checklist is not ready for delivery, regardless of length or apparent polish.
+tput does not show CJK spacing degradation or broken-export text rhythm severe enough to reduce professional readability
 
 ## Quality bar
 

--- a/evals/japan-vs-china-vs-sea-market-entry-comparative-distillation.md
+++ b/evals/japan-vs-china-vs-sea-market-entry-comparative-distillation.md
@@ -1,0 +1,188 @@
+# Japan vs China Focus vs Southeast Asia Expansion — Comparative Distillation
+
+## Case identity
+
+- **Task type:** market entry / regional expansion / constrained-choice memo / prioritization under resource constraints
+- **User objective:** 判断一家资源有限的中国 AI Agent 创业公司在未来 12 个月内，是否应该优先进入日本市场，而不是继续深耕中国或优先进入东南亚
+- **Observed output:** MiniMax-generated Chinese PDF memo
+- **Research date context:** 2026-04-03
+- **Distillation goal:** 提炼这类 market-entry 输出在 decision utility、evidence-role labeling、delivery-language consistency、以及 PDF cleanliness 上的可复用规则
+
+---
+
+## Why this case matters
+
+This case matters because the output did **not** fail in the most basic way.
+
+The model did not completely misunderstand the task. It recognized that this was a prioritization problem, compared China / Southeast Asia / Japan, and produced an explicit ranking.
+
+That makes the case more valuable than a trivial failure. The real question is why a recommendation-shaped market-entry report can still fall short of a truly auditable operating memo.
+
+This case also exposed a separate final-delivery issue: a Chinese report can still leak load-bearing English labels such as `Confirmed Facts`, `Likely Inference`, and `Unknown`, even when the rest of the memo is in Chinese.
+
+---
+
+## Core judgment
+
+MiniMax partially routed the task correctly: the report behaved more like a prioritization memo than a single-country overview.
+
+However, the final output still remained closer to a **structured regional analysis with recommendation** than to a **hard operating decision memo**.
+
+The most important gap was not whether it had a conclusion, but whether it translated that conclusion into:
+
+- visible resource-allocation logic
+- explicit hard gates
+- sequencing and milestone logic
+- ranking-change conditions
+- final-delivery coherence in the target language
+
+---
+
+## What the output got right
+
+### 1. It recognized the task as a comparative prioritization problem
+The report did not only analyze Japan. It compared Japan against continued China focus and Southeast Asia pilot expansion.
+
+### 2. It produced an explicit ranking
+The report clearly stated a current ranking: China first, Southeast Asia second, Japan third.
+
+### 3. It used a visible comparison frame
+Demand, compliance, localization, sales motion, deployment constraints, and payback speed were all treated as comparison dimensions.
+
+### 4. It attempted evidence bucketing
+The report tried to distinguish stronger evidence from inference and unknowns, which is better than writing every claim in one flat register.
+
+---
+
+## Main failure modes
+
+### 1. Decision-memo under-specification
+The recommendation existed, but it was still too soft as an operating memo.
+
+Missing or weak elements included:
+- explicit hard gates
+- milestone-triggered re-evaluation
+- ranking-reversal conditions
+- more concrete 0-12 month operating path
+
+### 2. Choice-architecture softness
+The ranking was visible, but not fully auditable.
+
+The report did not clearly show:
+- why Southeast Asia beats Japan now
+- what conditions would move Japan upward
+- how to distinguish first revenue beachhead, regional hub, and later expansion market
+
+### 3. Number-role ambiguity
+Some time / cost / ROI-like claims read as if they were observed facts, but likely function more as heuristics, assumptions, or planning-model outputs.
+
+This creates a professional-looking memo that can still overstate certainty.
+
+### 4. Delivery-language inconsistency
+The final report was written in Chinese, but still used load-bearing English evidence labels such as:
+- `Confirmed Facts`
+- `Likely Inference`
+- `Unknown`
+
+This should be treated as a delivery-quality failure, not a cosmetic preference.
+
+### 5. PDF rendering / CJK broken-export failure
+The final PDF still showed obvious CJK spacing degradation and broken-export text rhythm. This remains a final-delivery hard fail.
+
+---
+
+## Distilled lessons
+
+### Lesson 1 — market-entry outputs must show operating-path logic, not only recommendation flavor
+For market-entry / regional-expansion tasks, a visible recommendation is not enough. The memo should explicitly show:
+
+- `go` / `not now` / `pilot only` / `phased entry`
+- priority relative to alternatives
+- why the top option wins
+- why the runner-up remains credible
+- hard gates
+- sequencing
+- KPI / milestone triggers
+- what changes the ranking
+
+**Candidate action:** `CHECKLIST_HARDENING`
+
+---
+
+### Lesson 2 — evidence-layer labeling and planning-layer labeling should be separate
+This case shows that reports can partially distinguish facts from inference while still failing to show the role of important numbers.
+
+The output should distinguish:
+
+**Evidence layer**
+- 已确认事实
+- 推断
+- 未知事项
+
+**Modeling layer**
+- 观察值
+- 代理指标
+- 假设
+- 规划模型输出
+
+**Candidate action:** `CHECKLIST_HARDENING`
+
+---
+
+### Lesson 3 — target-language coherence needs to be audited explicitly
+If the final report is in Chinese, section anchors, evidence buckets, callout labels, and other load-bearing structural labels should default to Chinese unless bilingual output is explicitly requested.
+
+Preferred labels for Chinese reports include:
+- 已确认事实
+- 推断
+- 未知事项
+- 观察值
+- 代理指标
+- 假设
+- 规划模型输出
+
+**Candidate action:** `NEW_RULE` + `CHECKLIST_HARDENING`
+
+---
+
+### Lesson 4 — PDF cleanliness and language consistency belong to the same final-delivery layer
+This case confirms that mixed-language structural labels and broken CJK PDF texture should both be treated as final-artifact coherence failures.
+
+They are not separate from delivery quality; they are delivery quality.
+
+**Candidate action:** `CHECKLIST_HARDENING`
+
+---
+
+## Candidate-action summary
+
+| # | Candidate action | Failure family | Action type | Proposed home |
+|---|---|---|---|---|
+| 1 | Require market-entry outputs to show explicit decision status, hard gates, sequencing, and ranking-change logic | decision utility / operating-path under-specification | CHECKLIST_HARDENING | `checklists/final-audit.md` |
+| 2 | Require visible separation between evidence-layer labels and modeling-layer number-role labels | evidence weighting / planning-model traceability | CHECKLIST_HARDENING | `checklists/final-audit.md` |
+| 3 | Add target-language consistency gate for load-bearing structural labels in final reports | delivery-language coherence | NEW_RULE + CHECKLIST_HARDENING | `references/report-template.md` + `checklists/final-audit.md` |
+| 4 | Treat mixed-language structural labels and CJK broken-export texture as final-delivery coherence failures | delivery cleanliness / final artifact quality | CHECKLIST_HARDENING | `checklists/final-audit.md` |
+
+---
+
+## Things explicitly rejected
+
+| Observation | Why rejected |
+|---|---|
+| MiniMax understood the task, so no routing change is needed | partial success still left major execution and delivery failures |
+| English evidence labels are harmless if the report is mostly Chinese | the labels are load-bearing structure, so language inconsistency weakens final-artifact coherence |
+| This is only a PDF rendering problem | the case also exposed decision-utility softness and language-layer inconsistency |
+
+---
+
+## Final judgment
+
+This case is useful because it exposed a more advanced failure family than generic overview drift.
+
+The model can now produce a recommendation-shaped market-entry report, but still often stops short of a fully auditable operating memo. It also showed that a report can partially improve in structure while still failing final delivery through:
+
+- number-role ambiguity
+- mixed-language structural labeling
+- CJK broken-export PDF texture
+
+The right response is not only to harden market-entry decision architecture, but also to add an explicit audit rule for **target-language coherence in final delivery**.

--- a/references/decision-report-template.md
+++ b/references/decision-report-template.md
@@ -132,8 +132,11 @@ In these market-entry cases:
 - explicitly separate regional hub, first revenue beachhead, and later expansion market when those roles differ
 - make priority relative to alternatives visible (for example domestic market vs SEA, or SEA vs other expansion regions)
 - show the few hard gates that could turn `go` into `not now` or `pilot only`
+- show why the top option wins, why the runner-up remains credible, and what would change the ranking
+- make KPI / milestone triggers visible when they are part of the operating path
 - use one comparison unit across countries or candidate markets rather than free-form prose by country
 - if TAM / SAM / SOM, scenario models, or KPI plans are used, label observed numbers vs proxies vs assumptions vs planning-model outputs
+- if the final memo is written in Chinese, keep load-bearing labels in Chinese too rather than leaking English evidence buckets into the body
 
 Do not give every option equal narrative weight if the user's real need is to choose.
 

--- a/references/report-template.md
+++ b/references/report-template.md
@@ -92,13 +92,27 @@ A good report should let the reader quickly answer:
 
 ## Required evidence-tier legend
 
-At the top of every report, include a brief legend defining evidence confidence levels. Use this format:
+At the top of every report, include a brief legend defining evidence confidence levels.
+
+If the final report is written in Chinese, keep the legend in Chinese too. Do not mix a Chinese body with accidental English evidence buckets unless bilingual output was explicitly requested.
+
+Preferred Chinese format:
 
 ```
 证据分级：
-[CONF] = 来自监管披露/年报/官方发布
-[LIKELY] = 来自权威机构或媒体（可能为二手）
-[UNCERTAIN] = 行业认知缺乏统一口径或无法验证
+[已确认事实] = 来自监管披露 / 年报 / 官方发布
+[推断] = 来自权威机构或媒体，或基于多项证据的合理归纳
+[未知事项] = 行业缺乏统一口径，或公开信息暂时无法验证
+```
+
+If the report also needs number-role labeling, add a second compact legend such as:
+
+```
+数字角色：
+[观察值] = 公开披露或原始材料直接给出的数值
+[代理指标] = 因主指标缺失而使用的替代观察量
+[假设] = 用于推演的前提条件，并非已观测事实
+[规划模型输出] = 基于假设或代理指标计算出的结果
 ```
 
 This makes your labeling system interpretable to the reader and enforces discipline on the model side.
@@ -210,5 +224,8 @@ When building tables with multi-dimensional comparisons (e.g., product category 
 - **Use `<br>` (line break) within a cell when a single attribute has multiple sub-points.** For example, a cell for "发热原理" that needs to list "燃烧烟草 (600-900°C) + 雾化器 + 口腔黏膜" should be written in markdown as one cell using `<br>`: `燃烧烟草 (600-900°C)<br>雾化器加热<br>口腔黏膜吸收`.
 - **Avoid using `|` inside cell content** — if a cell requires listing multiple items separated by pipes, use commas or `<br>` instead.
 - **Wide tables with many columns are hard to read in PDF.** Consider splitting a wide table into two separate tables grouped by theme (e.g., one table for product attributes, another for commercial metrics).
+
+When in doubt: write for the reader who will skim the table, not for the analyst who already knows the data.
+ct attributes, another for commercial metrics).
 
 When in doubt: write for the reader who will skim the table, not for the analyst who already knows the data.


### PR DESCRIPTION
## Summary
- add a new comparative-distillation eval for the Japan vs China vs SEA market-entry case
- harden final-audit gates around market-entry operating-path logic and evidence/model-role labeling
- add explicit target-language coherence rules across templates, routing/workflow docs, and repo architecture/system-map notes

## Why
A recent MiniMax-generated Chinese market-entry PDF showed a subtler delivery failure family: the analysis could partially behave like a prioritization memo while still leaking English load-bearing labels such as "Confirmed Facts" / "Likely Inference" / "Unknown" into a Chinese final artifact.

This PR treats that as a final-delivery coherence issue rather than a cosmetic translation preference, and also tightens the decision-memo/audit contract around hard gates, ranking-change logic, and KPI-triggered re-evaluation.
