### PR TITLE
docs: harden mid-research review and counter-evidence execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This file is intentionally lightweight. Use concise entries that explain:
 ## Unreleased
 
 ### Added
+- `references/mid-research-review.md`
+- `checklists/mid-research-review-audit.md`
 - `ARCHITECTURE.md`
 - `SYSTEM-MAP.md`
 - `ROUTING-MATRIX.md`
@@ -30,6 +32,9 @@ This file is intentionally lightweight. Use concise entries that explain:
 - `evals/cambricon-evidence-weighting-and-traceability-case.md`
 
 ### Changed
+- Added explicit mid-research review discipline so early evidence batches must visibly narrow, redirect, continue, or stop the search path.
+- Strengthened counter-evidence discipline by tying it to load-bearing conclusions rather than generic end-of-report risk language.
+- Hardened final-audit expectations around weakening logic and intentional stopping behavior.
 - `scripts/markdown_to_html.py` table routing now keeps comparison-heavy blocks in compact tables (including anchor-column split sub-tables) instead of leaking toward vertical card-like degradation; it also strips internal render-hint text from final HTML.
 - `scripts/markdown_to_html.py` pre-parse table repair now strips accidental list-prefix injection before headings/table rows (e.g. `- ##` / `- | ...`), normalizes malformed separator rows, and removes stray leading bullet-placeholder columns (e.g. `| - | # | ...`) before markdown parsing.
 - `scripts/markdown_to_html.py` table sanitization now more aggressively removes placeholder headers/columns and URL-heavy split-off metadata columns when they reduce comparison readability.

--- a/SKILL.md
+++ b/SKILL.md
@@ -27,6 +27,8 @@ Never present inference as confirmed fact.
 4. define evidence standards and stop conditions
 5. collect and compare sources
 6. run a mid-research review
+   - read `references/mid-research-review.md` once the first meaningful evidence batch is in hand
+   - the review must visibly confirm, narrow, redirect, or stop the research path
 7. search for counter-evidence
 8. synthesize into a decision-oriented report
 
@@ -259,13 +261,6 @@ A strong final answer should:
 - answer the actual question, not just summarize the topic
 - show how the conclusion was formed
 - separate fact from inference
-- surface counter-evidence
-- state confidence clearly
-- explain what is still missing
-- help the user decide what to do next
-
-If confidence is limited, say exactly why.
-
 - surface counter-evidence
 - state confidence clearly
 - explain what is still missing

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -28,6 +28,15 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] confidence levels match evidence quality
 - [ ] the report does not claim more certainty than the evidence supports
 
+## Counter-evidence and review integrity
+
+- [ ] the report's load-bearing conclusions are visibly pressure-tested rather than only supported
+- [ ] there is visible counter-evidence handling for the main recommendation, ranking, or prioritization
+- [ ] the report shows what weakens the conclusion, not just what supports it
+- [ ] where uncertainty remains, it changes confidence, timing, ranking, or action in a visible way
+- [ ] if alternatives remain credible, the report explains why they did not win now
+- [ ] there is visible evidence that the research was narrowed, redirected, or stopped intentionally rather than merely exhausted
+
 ## Completeness
 
 - [ ] the report does not leave a strong impression while having weak substance
@@ -79,8 +88,5 @@ This is the last gate before the report goes to the user. If any item fails, rev
 ## Quality bar
 
 A report that fails this checklist is not ready for delivery, regardless of length or apparent polish.
-tput does not show CJK spacing degradation or broken-export text rhythm severe enough to reduce professional readability
 
-## Quality bar
-
-A report that fails this checklist is not ready for delivery, regardless of length or apparent polish.
+CJK spacing degradation or broken-export text rhythm should not be severe enough to reduce professional readability.

--- a/checklists/mid-research-review-audit.md
+++ b/checklists/mid-research-review-audit.md
@@ -1,0 +1,23 @@
+# Mid-Research Review Audit
+
+## Core gate
+
+A mid-research review is not complete unless it visibly confirms, narrows, redirects, or stops the research path.
+
+## Checklist
+
+- Is there a visible current best answer?
+- Is there a visible statement of the strongest evidence so far?
+- Is there a visible statement of missing evidence that still matters?
+- Are low-value branches explicitly cut, downgraded, or reframed?
+- Is the search path explicitly continued, narrowed, redirected, or stopped?
+- Is there a visible stop-or-continue judgment?
+- Does the review reduce drift, repetition, or over-expansion?
+
+## Hard fail signs
+
+- The review is only a recap.
+- The search continues despite obvious repetition.
+- The report stays broad even though the objective required narrowing.
+- No distinction is made between strongest evidence and accumulated material.
+- No stop-or-continue logic is visible.

--- a/references/counter-evidence.md
+++ b/references/counter-evidence.md
@@ -26,6 +26,21 @@ Always run a counter-evidence pass when the research involves:
 - practical regulatory interpretation
 - predictions or recommendations
 
+## Load-bearing conclusions
+
+Counter-evidence discipline should focus first on load-bearing conclusions rather than every sentence.
+
+Typical load-bearing conclusions include:
+
+- the main answer in the executive summary
+- the recommendation
+- the priority ranking
+- go / not now / pilot only / phased-entry judgments
+- why the top option wins
+- any overall label that compresses multiple dimensions into one judgment
+
+If a conclusion materially determines the user's decision or interpretation, it is probably load-bearing.
+
 ## Common counter-evidence angles
 
 Check for:

--- a/references/mid-research-review.md
+++ b/references/mid-research-review.md
@@ -1,0 +1,85 @@
+# Mid-Research Review
+
+## Purpose
+
+Mid-research review exists to control the research path before synthesis, not to recap collected material.
+
+Its job is to decide whether the research should:
+
+- continue
+- narrow
+- pivot
+- stop and synthesize
+
+If the answer shape is already visible, continuing collection without review usually makes the report longer rather than better.
+
+## When to trigger
+
+Run a mid-research review after the first meaningful evidence batch is in hand.
+
+Typical triggers:
+
+- a tentative best answer is visible
+- search results are repeating
+- the scope is still too broad for the real objective
+- a key evidence gap has become clear
+- the current search path is showing declining value
+
+If the task is nearing stop condition quickly, run a compact mid-review anyway instead of skipping directly to synthesis.
+
+## Inputs
+
+Use the current research state, including:
+
+- the real objective
+- the selected route
+- current subquestions
+- strongest evidence so far
+- current tentative answer
+- key unresolved uncertainty
+- branches explored so far
+
+## Required decisions
+
+A real mid-research review should answer:
+
+1. What is the current best answer?
+2. What is the strongest evidence so far?
+3. What missing evidence still matters?
+4. Which branches should be cut, downgraded, or reframed?
+5. Should the research continue, narrow, pivot, or stop?
+
+If these questions are not answered, the review was probably not actually done.
+
+## Visible execution
+
+Mid-research review does not need to appear as a standalone section in the final report.
+
+Its effects should still be visible through signs such as:
+
+- narrower scope
+- reduced repetition
+- clearer prioritization
+- visible branch-cutting
+- stronger distinction between strongest evidence and remaining uncertainty
+- intentional stop logic rather than search exhaustion
+
+## Common failure modes
+
+Common failures include:
+
+- recap without operational consequence
+- continuing broad collection after the answer shape is visible
+- failing to distinguish strongest evidence from accumulated material
+- keeping low-value branches alive without justification
+- treating “more information might exist” as sufficient reason to continue
+
+## Minimal internal shape
+
+A compact internal mid-review may use this shape:
+
+- Current best answer:
+- Strongest evidence so far:
+- Missing decision-relevant evidence:
+- Branches to cut or downgrade:
+- Search decision: continue / narrow / pivot / stop


### PR DESCRIPTION
## Summary

This PR hardens two workflow nodes that already existed in the skill spine but were still too easy to execute weakly:

- mid-research review
- counter-evidence

The goal is not to add more process for its own sake. The goal is to make these steps more operational and more auditable.

## What changed

- added a dedicated `references/mid-research-review.md`
- added `checklists/mid-research-review-audit.md`
- strengthened `references/counter-evidence.md` around load-bearing conclusions
- hardened `checklists/final-audit.md` so weakening logic and review integrity are more visible
- attached the new review discipline back into `SKILL.md`
- recorded the change in `CHANGELOG.md`

## Why this change

The repo already treated mid-research review and counter-evidence as important, but they were still too easy to satisfy nominally:

- mid-review could collapse into recap
- counter-evidence could collapse into a generic risks paragraph
- final audit had limited leverage against outputs that sounded mature but were not really pressure-tested

This PR pushes both nodes from principle-level guidance toward execution-level discipline.

## Intended effect

After this PR:

- mid-research review should more clearly act as a decision point for continuing, narrowing, redirecting, or stopping research
- counter-evidence should more clearly attach to load-bearing conclusions rather than float as end-of-report caution language
- final audit should be better at catching strong-looking reports with weak review discipline

## What this PR does not do

This PR does not:

- introduce a new route
- change repo structure
- add a new execution layer
- make counter-evidence mandatory for every sentence

It only hardens two existing workflow nodes that were already present but under-specified.
