### PR TITLE
docs: sharpen route-specific micro-audits

### DIFF
--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -127,6 +127,14 @@ Fail if the report:
 
 ## Route: Market Entry / Regional Expansion
 
+### Micro-audit focus
+For this route, be especially strict about:
+
+- explicit go / not now / pilot only / phased-entry language
+- whether hub / beachhead / later expansion roles are separated when relevant
+- whether sequencing depends on named hard gates rather than generic optimism
+- whether the recommendation appears before country-by-country narrative expands
+
 ### Trigger
 Use when the task is mainly about:
 
@@ -288,6 +296,14 @@ Fail if the report:
 
 ## Route: Constrained Choice / Shortlist / Option Selection
 
+### Micro-audit focus
+For this route, be especially strict about:
+
+- whether the winning option beats the runner-up for a few explicit load-bearing reasons rather than diffuse overall narration
+- whether the runner-up remains credible in a named scenario instead of serving as a ceremonial second place
+- whether rejected options are rejected for actual decision reasons rather than lower narrative attention
+- whether hidden operational burdens sit in the ranking logic rather than in cleanup caveats
+
 ### Trigger
 Use when the task is mainly about:
 
@@ -335,6 +351,14 @@ Fail if the report:
 ---
 
 ## Route: Equipment Selection / Procurement / Home-server Planning
+
+### Micro-audit focus
+For this route, be especially strict about:
+
+- whether the recommendation binds hardware route and system choice into one stack decision
+- whether minimum viable vs recommended configuration is separated when it changes the answer materially
+- whether household operating burdens like noise, power, maintenance, backup, and expansion friction are treated as ranking variables rather than side notes
+- whether rejected routes lose for explicit operator constraints rather than broad category descriptions
 
 ### Trigger
 Use when the task is mainly about:
@@ -390,6 +414,15 @@ Fail if the report:
 ---
 
 ## Route: Listed Company / Investment-style Research
+
+### Micro-audit focus
+For this route, be especially strict about:
+
+- whether the opening states the current thesis before long background expansion
+- whether the case is driven by a few current load-bearing variables rather than broad company description
+- whether support, weakening evidence, and unresolved variables are separated clearly
+- whether competition is written as actual thesis pressure rather than peer-directory filler
+- whether valuation, growth, strategic narrative, and market position are kept analytically distinct
 
 ### Trigger
 Use when the task is mainly about:

--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -303,6 +303,7 @@ For this route, be especially strict about:
 - whether the runner-up remains credible in a named scenario instead of serving as a ceremonial second place
 - whether rejected options are rejected for actual decision reasons rather than lower narrative attention
 - whether hidden operational burdens sit in the ranking logic rather than in cleanup caveats
+- whether narrative weight is allocated in proportion to the final decision rather than making all plausible options feel equally alive
 
 ### Trigger
 Use when the task is mainly about:

--- a/checklists/listed-company-report.md
+++ b/checklists/listed-company-report.md
@@ -40,6 +40,16 @@ Run through every item before delivering the final report.
 - [ ] operating cash flow direction noted
 - [ ] segment breakdown if multi-segment business
 
+## Judgment-shape micro-audit
+
+- [ ] the opening section states the current thesis before long background exposition begins
+- [ ] the report identifies the few disclosures or variables that most determine the current view, rather than spreading importance evenly across many company facts
+- [ ] the report distinguishes what currently supports the thesis, what currently weakens it, and what remains unresolved
+- [ ] if one unresolved variable dominates the case, it is named as such rather than diluted inside a general risk list
+- [ ] competition is written as actual thesis pressure or threat-window analysis rather than mostly a peer directory
+- [ ] valuation, growth, market position, and strategic narrative are not blended into one undifferentiated bullish or bearish mood
+- [ ] if the view is positive but not valuation-grade, timing-grade, or precision-grade, the downgrade boundary is explicit
+
 ## Flags
 
 If any item above is unchecked or uncertain, note the limitation explicitly in the report before delivery.

--- a/checklists/option-selection-final-audit.md
+++ b/checklists/option-selection-final-audit.md
@@ -58,6 +58,9 @@ Run this checklist before delivery.
 - [ ] the runner-up or best alternative is named clearly
 - [ ] eliminated or weak-fit options are identified when useful
 - [ ] the reader can see why one option wins and why the others lose
+- [ ] the winning option is not just described positively; the report identifies the few load-bearing reasons it beats the runner-up under the stated constraints
+- [ ] the runner-up is not just second by narration; the report states what weighting, scenario, or constraint shift would make it first
+- [ ] eliminated options are rejected for specific decision reasons rather than fading out through lower narrative attention
 
 ## Evidence layers
 
@@ -72,6 +75,9 @@ Run this checklist before delivery.
 - [ ] fallback options are given when the leading option is fragile
 - [ ] the report states what would change the ranking or recommendation
 - [ ] uncertainty is tied to the decision, not left as generic caveats
+- [ ] if the recommendation depends on one dominant assumption, that dependency is visible near the recommendation rather than buried later
+- [ ] if the route involves procurement, deployment, or physical movement, the report surfaces hidden friction in the same decision layer as price / performance / convenience rather than treating it as appendix detail
+- [ ] if the route involves multiple stakeholders or geographies, the report shows who is penalized by the winning option and why that penalty is still acceptable or not
 
 ## Decision usefulness
 

--- a/checklists/option-selection-final-audit.md
+++ b/checklists/option-selection-final-audit.md
@@ -85,6 +85,7 @@ Run this checklist before delivery.
 - [ ] the recommendation is sharp enough to act on
 - [ ] the reader can tell who or what is penalized by the recommended choice
 - [ ] the next step is clear
+- [ ] narrative weight is not distributed so evenly that the winning option, runner-up, and rejected options all feel equally plausible by reading time alone
 
 ## Quality bar
 

--- a/evals/meta/route-specific-micro-audits.md
+++ b/evals/meta/route-specific-micro-audits.md
@@ -1,0 +1,111 @@
+# Eval: Route-Specific Micro-Audits
+
+Use this eval when a report broadly follows the correct route but still shows repeated route-family weaknesses that should have been caught by a sharper route-specific audit.
+
+## Goal
+
+Distinguish between:
+
+1. correct route selection at a broad level
+2. stable route-family execution at the micro-audit level
+
+A report can pass generic final-audit checks and still miss the subtle route-specific burdens that matter most for repeated high-value task families.
+
+---
+
+## Typical failure patterns
+
+- option-selection report names a winner but does not show the few decisive reasons it beats the runner-up
+- runner-up remains vague and ceremonial instead of scenario-credible
+- market-entry report recommends expansion but leaves hub / beachhead / sequencing roles blurry
+- procurement memo discusses hardware and systems separately instead of as one stack decision
+- listed-company report has good facts but still reads like a company overview with market data attached
+- competition section lists peers rather than identifying who actually pressures the thesis and on what timeline
+
+---
+
+## What this eval is testing
+
+### Failure Mode 1: Broad route pass, micro-route miss
+
+The route is generally correct, but the most route-specific burden is still under-executed.
+
+Examples:
+- selection memo without real winner-vs-runner-up logic
+- company memo without current thesis pressure structure
+- procurement memo without explicit operator-constraint tradeoffs
+
+### Failure Mode 2: Generic audit pass, family-specific leak
+
+The report passes broad quality checks, but a known repeated failure family still slips through.
+
+Examples:
+- hidden friction appears only in caveats instead of ranking logic
+- sequencing logic appears only after country notes expand
+- valuation and strategic narrative are blended into one mood
+
+### Failure Mode 3: Shape looks right, burden still weak
+
+The headers resemble the right route, but the report still avoids the hardest part of that route.
+
+Examples:
+- `Why option A wins` section exists, but mostly repeats description
+- `Risks` section exists, but does not name the single variable most likely to flip the case
+- `Competition` section exists, but does not identify actual execution pressure
+
+---
+
+## Pass criteria
+
+A good answer should:
+
+1. visibly satisfy the route's hardest recurring burden, not just its generic shape
+2. show the route-family distinctions that matter for repeated high-value tasks
+3. make it easy for a reviewer to tell whether the report truly passed the route it claims to follow
+4. reduce repeated manual judgment by turning known failure families into clearer checks
+
+---
+
+## Scoring guide
+
+Use a simple 0-2 scale.
+
+### 0 = broad route only
+- the report chose the right route, but micro-audit failures remain obvious
+
+### 1 = partial micro-audit discipline
+- some route-family burdens are handled well, but subtle repeated weaknesses still leak
+
+### 2 = strong route-family execution
+- the report not only fits the route broadly, but also passes the sharper burdens typical of that route family
+
+---
+
+## Review questions
+
+When using this eval, ask:
+
+- What is the hardest recurring burden for this route family?
+- Did the report visibly carry that burden, or mostly imitate the shape around it?
+- Which repeated failure family should this route-specific audit have caught?
+- Did the report make the winner-vs-runner-up / hub-vs-beachhead / thesis-support-vs-thesis-pressure distinctions explicit enough?
+- Is the right next fix a sharper route-specific checklist item, route-matrix emphasis, or route-family eval example?
+
+---
+
+## Output format for reviewers
+
+When you apply this eval, summarize the result as:
+
+- **Primary route family:**
+- **Hardest recurring burden:**
+- **What the report handled well:**
+- **What subtle route-family weakness still leaked:**
+- **Diagnosis:** broad-route pass / micro-route miss / generic-audit leak / burden-avoidance
+- **Best next fix:** route-matrix emphasis / checklist hardening / route-family template hardening / new example-eval
+
+---
+
+## Why this eval exists
+
+As route definitions improve, more weak reports will stop failing at the big obvious level. They will fail at the repeated subtle level instead. This eval exists to convert known route-family failure patterns into sharper review pressure.

--- a/evals/meta/route-specific-micro-audits.md
+++ b/evals/meta/route-specific-micro-audits.md
@@ -34,6 +34,7 @@ Examples:
 - selection memo without real winner-vs-runner-up logic
 - company memo without current thesis pressure structure
 - procurement memo without explicit operator-constraint tradeoffs
+- shortlist memo that gives near-equal narrative weight to winner, runner-up, and rejected paths
 
 ### Failure Mode 2: Generic audit pass, family-specific leak
 


### PR DESCRIPTION
## Summary
- sharpen route-specific micro-audit pressure for high-value task families instead of relying only on broad final-audit language
- expand option-selection and listed-company checklists with more operational route-family checks
- add route-matrix micro-audit focus blocks for repeated high-value routes
- add a dedicated meta eval for broad-route pass vs micro-route miss

## Why
Issue #47 is about catching the subtle repeated failures that survive even after route selection and broad final-audit logic improve. The right next step is not another layer of generic checklist prose, but sharper route-family checks for the routes that recur most often and matter most.

## What changed
- `checklists/option-selection-final-audit.md`
  - strengthens winner-vs-runner-up logic, elimination logic, hidden friction, and penalty visibility
- `checklists/listed-company-report.md`
  - adds a `Judgment-shape micro-audit` section
- `ROUTING-MATRIX.md`
  - adds route-specific micro-audit focus blocks for market-entry, constrained-choice, equipment/procurement, and listed-company routes
- `evals/meta/route-specific-micro-audits.md`
  - adds a dedicated eval for route-family weaknesses that slip past broad audit gates

## Scope note
This PR intentionally starts with the highest-frequency / highest-value route families rather than trying to harden every route at once.

## Issue
- Closes #47
