### PR TITLE
docs: harden degraded-search execution and logging

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -164,6 +164,42 @@ mcporter call 'exa.web_search_exa(query: "<search query>", numResults: 5)'
 13. if Bing is also blocked or unusable, declare the live-search step blocked and note which freshness checks or claims could not be verified live
 14. continue with offline materials only if the remaining uncertainty is made explicit
 
+## Degraded-search execution discipline
+
+When fallback search is needed, do not switch providers mechanically.
+
+Before changing provider path, make an explicit judgment about the cause:
+
+- provider failure or temporary outage
+- quota / rate-limit pressure
+- query-fit mismatch
+- low-yield results despite provider availability
+- browser-side localization need
+
+Prefer this execution logic:
+
+- use Exa first when the task is discovery-heavy and likely benefits from English-language web coverage, technical docs, company pages, or broad web recall
+- do not force Exa first when the task is dominated by Chinese-language news flow, localized search intent, or browser-local ranking behavior
+- move to Bing only when Exa is unavailable, clearly low-yield for the query class, or mismatched to the search intent
+- stop degraded-search escalation when the next provider is unlikely to add decision-relevant value rather than escalating just because another provider exists
+
+If fallback search keeps returning noisy or repetitive candidate sources, say so and tighten the live-search objective instead of continuing provider churn.
+
+## Degraded-search evidence log
+
+When degraded fallback is used, keep a compact internal log in this shape:
+
+- search objective:
+- primary provider attempted:
+- fallback trigger: provider failure / quota / query-fit / low-yield / localization need
+- fallback provider used:
+- why this fallback fits better:
+- candidate-source quality: strong / mixed / weak
+- claims still needing primary-page verification:
+- live-search status: recovered / partially recovered / blocked
+
+This log does not need to appear verbatim in the final memo, but its effects should be recoverable in the Research Pack, uncertainty register, or source notes.
+
 Other tools:
 - `web_fetch`: extract readable page content after search identifies a candidate source
 - `browser`: handle dynamic pages or failed fetches for confirmed-live URLs

--- a/SKILL.md
+++ b/SKILL.md
@@ -180,6 +180,7 @@ Prefer this execution logic:
 
 - use Exa first when the task is discovery-heavy and likely benefits from English-language web coverage, technical docs, company pages, or broad web recall
 - do not force Exa first when the task is dominated by Chinese-language news flow, localized search intent, or browser-local ranking behavior
+- before escalating again, tighten the search objective or query shape if the current path is returning noisy but not obviously irrelevant material
 - move to Bing only when Exa is unavailable, clearly low-yield for the query class, or mismatched to the search intent
 - stop degraded-search escalation when the next provider is unlikely to add decision-relevant value rather than escalating just because another provider exists
 

--- a/evals/meta/degraded-search-execution.md
+++ b/evals/meta/degraded-search-execution.md
@@ -33,6 +33,7 @@ The workflow changes provider because a ladder exists, not because the switch wa
 Examples:
 - Exa -> Bing -> more Bing-like browsing without explaining why the search intent changed
 - switching provider after weak results without identifying whether the problem was query-fit, low-yield, or provider failure
+- escalating providers when the better next move would have been to tighten the objective or query shape first
 
 ### Failure Mode 2: Query-fit misfire
 

--- a/evals/meta/degraded-search-execution.md
+++ b/evals/meta/degraded-search-execution.md
@@ -1,0 +1,113 @@
+# Eval: Degraded Search Execution
+
+Use this eval when live-search fallback was needed and you need to judge whether degraded discovery was handled explicitly and intelligently rather than mechanically.
+
+## Goal
+
+Distinguish between:
+
+1. fallback policy exists on paper
+2. fallback execution actually improved the research path
+
+A skill can have a reasonable fallback ladder and still execute it poorly through provider churn, weak query-fit judgment, or poor logging.
+
+---
+
+## Typical failure patterns
+
+- provider fallback happens, but the trigger is not recorded clearly
+- Exa is used even when the query obviously needs localized browser-side discovery
+- Bing is used only because it is next in sequence, not because it is a better fit
+- fallback search returns noisy candidates, but the search objective is not tightened
+- degraded-search path is used, but the evidence log does not preserve what was tried and what remained unverified
+- result pages are implicitly treated as evidence instead of discovery-only candidate lists
+
+---
+
+## What this eval is testing
+
+### Failure Mode 1: Mechanical fallback
+
+The workflow changes provider because a ladder exists, not because the switch was justified.
+
+Examples:
+- Exa -> Bing -> more Bing-like browsing without explaining why the search intent changed
+- switching provider after weak results without identifying whether the problem was query-fit, low-yield, or provider failure
+
+### Failure Mode 2: Query-fit misfire
+
+The chosen fallback does not match the search objective.
+
+Examples:
+- technical-doc query forced into browser-localized search first
+- localized Chinese news-flow task forced through Exa as if it were the default best path
+- dynamic page need misdiagnosed as search-provider weakness
+
+### Failure Mode 3: Weak degraded-search logging
+
+Fallback may have been reasonable, but the research state no longer preserves what happened.
+
+Examples:
+- no record of which provider path was attempted
+- no distinction between provider failure, rate-limit pressure, and low-yield results
+- no note of what still required primary-page verification
+
+---
+
+## Pass criteria
+
+A good degraded-search workflow should:
+
+1. record why fallback was triggered
+2. choose fallback path based on query-fit, not only sequence order
+3. keep result pages in the discovery layer rather than treating them as memo evidence
+4. stop escalation when additional provider churn is unlikely to add decision-relevant value
+5. preserve degraded-search state in a compact log or recoverable process artifact
+
+---
+
+## Scoring guide
+
+Use a simple 0-2 scale.
+
+### 0 = poor degraded-search execution
+- fallback path was mechanical, noisy, or poorly logged
+
+### 1 = partially disciplined fallback
+- fallback choice was somewhat justified, but query-fit or logging discipline remains weak
+
+### 2 = strong degraded-search execution
+- fallback was explicitly triggered, fit-matched, efficiently bounded, and recoverably logged
+
+---
+
+## Review questions
+
+When using this eval, ask:
+
+- Why was the primary provider insufficient: failure, quota, query-fit, or low-yield?
+- Did the chosen fallback actually match the search objective better?
+- Were result pages kept as discovery-only rather than treated as evidence?
+- Should the workflow have stopped, tightened the query, or switched tools instead of escalating providers?
+- Is the degraded-search state recoverable from notes, logs, or the Research Pack?
+
+---
+
+## Output format for reviewers
+
+When you apply this eval, summarize the result as:
+
+- **Search objective:**
+- **Primary provider outcome:**
+- **Fallback trigger:**
+- **Fallback path used:**
+- **Why that path was or was not a good fit:**
+- **What remained unverified after fallback:**
+- **Diagnosis:** mechanical fallback / query-fit misfire / weak degraded-search logging / strong degraded-search execution
+- **Best next fix:** SKILL fallback hardening / log-shape hardening / query-fit guidance / stop-condition hardening
+
+---
+
+## Why this eval exists
+
+As fallback policy becomes clearer, the next failure mode is no longer missing policy but weak execution. This eval exists to pressure-test whether degraded search actually improves the research path or just makes the process look more sophisticated.

--- a/examples/research-pack-example.md
+++ b/examples/research-pack-example.md
@@ -29,6 +29,16 @@ Constrained choice / shortlist
 ## Stop condition
 Stop when the top choice, runner-up logic, and ranking-change conditions are supported well enough for a practical recommendation.
 
+## Degraded-search log
+- Search objective: current transport and logistics sources for candidate meetup cities
+- Primary provider attempted: MiniMax web search
+- Fallback trigger: low-yield results for practical source discovery
+- Fallback provider used: Exa
+- Why this fallback fits better: broader discovery of current web sources for schedules and logistics pages
+- Candidate-source quality: mixed
+- Claims still needing primary-page verification: exact transport timing, current venue constraints
+- Live-search status: partially recovered
+
 ## Source register
 - Source: transport schedule / route information
   - Supports: travel feasibility and burden comparison

--- a/references/current-state-verification.md
+++ b/references/current-state-verification.md
@@ -87,6 +87,14 @@ If the current state cannot be verified clearly:
 - avoid filling the gap with likely-but-stale knowledge
 - separate historical context from verified current state
 
+If live search degraded during current-state verification, distinguish clearly between:
+
+- current state likely exists but search-provider access degraded
+- current state is still ambiguous even after fallback discovery
+- current state may require primary-page/browser verification rather than more search-result pages
+
+Do not treat search-provider weakness and underlying fact ambiguity as the same problem.
+
 ## Output expectation
 
 For fast-moving topics, make the current-state check visible in the final answer when useful.

--- a/references/research-pack-contract.md
+++ b/references/research-pack-contract.md
@@ -40,6 +40,7 @@ A minimal Research Pack should include:
 Use the following when relevant:
 
 - current-state snapshot
+- degraded-search log
 - counter-evidence log
 
 ## Field intent
@@ -73,6 +74,9 @@ What remains unresolved and why it matters.
 
 ### Current-state snapshot
 What must be verified as current when the task is time-sensitive.
+
+### Degraded-search log
+If fallback discovery was needed, record which provider path was attempted, why fallback was triggered, what fallback path was used, and what remained unverified.
 
 ### Counter-evidence log
 What could weaken, delay, qualify, or overturn the answer.
@@ -122,6 +126,7 @@ A compact Research Pack may use this shape:
 - Core subquestions
 - Stop condition
 - Current-state snapshot
+- Degraded-search log
 - Source register
 - Claim register
 - Uncertainty register

--- a/references/research-pack-contract.md
+++ b/references/research-pack-contract.md
@@ -76,7 +76,7 @@ What remains unresolved and why it matters.
 What must be verified as current when the task is time-sensitive.
 
 ### Degraded-search log
-If fallback discovery was needed, record which provider path was attempted, why fallback was triggered, what fallback path was used, and what remained unverified.
+If fallback discovery was needed, record which provider path was attempted, why fallback was triggered, whether the search objective or query shape was tightened before escalating, what fallback path was used, and what remained unverified.
 
 ### Counter-evidence log
 What could weaken, delay, qualify, or overturn the answer.


### PR DESCRIPTION
## Summary
- harden degraded-search behavior from a provider-order policy into a more explicit execution discipline
- standardize a compact degraded-search log for fallback reasoning and unverified claims
- clarify current-state verification behavior when search-provider weakness and fact ambiguity diverge
- add a dedicated meta eval for degraded-search execution quality

## Why
Issue #46 is no longer mainly about which provider comes next. The bigger risk now is mechanical fallback, weak query-fit judgment, and poor recovery logging that makes degraded search look more disciplined than it really was.

## What changed
- `SKILL.md`
  - adds `Degraded-search execution discipline`
  - adds `Degraded-search evidence log`
- `references/research-pack-contract.md`
  - adds `Degraded-search log` as a recoverable internal artifact when relevant
- `examples/research-pack-example.md`
  - shows the compact degraded-search log shape in use
- `references/current-state-verification.md`
  - separates provider degradation from genuine fact ambiguity
- `evals/meta/degraded-search-execution.md`
  - adds a dedicated eval for mechanical fallback, query-fit misfire, and weak logging

## Issue
- Closes #46
