### PR TITLE
docs: tighten PDF layout discipline

### DIFF
--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -182,6 +182,43 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] punctuation, brackets, dashes, dates, and percentages are stylistically aligned
 - [ ] there are no visible formatting artifacts that reduce final-delivery credibility
 
+## Front-page readability
+
+- [ ] the front page mainly helps the reader grasp the report's judgment rather than the process behind it
+- [ ] the thesis, key risks, and key unknowns can be identified quickly from the opening page
+- [ ] methodology detail has not displaced judgment visibility on the front page
+- [ ] the front page feels like a report opening rather than a process note
+
+## Judgment visibility in layout
+
+- [ ] key judgments are visually visible rather than only embedded in prose
+- [ ] major sections include a visible takeaway, judgment, or summary block when the route carries decision burden
+- [ ] risks, unknowns, and reversal conditions are easy to locate
+- [ ] the layout helps the reader scan the report's decision structure
+
+## Visual hierarchy and scanability
+
+- [ ] major headings and subheadings are clearly distinguished
+- [ ] judgment blocks, risks, evidence notes, and unknowns are visually differentiated from body text
+- [ ] there are no long stretches of dense text that should clearly be broken up
+- [ ] the report can be skimmed without losing the main logic
+
+## Table usefulness
+
+- [ ] each table has a clear title
+- [ ] units and scope are visible when relevant
+- [ ] tables support judgment rather than merely display data
+- [ ] important tables are followed by a short interpretation
+- [ ] the reader can tell why each important table matters
+
+## Mixed-script and target-language cleanliness
+
+- [ ] Chinese text spacing is visually normal
+- [ ] mixed Chinese-English text is readable and stylistically consistent
+- [ ] names, product terms, and other proper nouns are spelled consistently
+- [ ] punctuation, brackets, dashes, dates, and percentages are stylistically aligned
+- [ ] there are no visible formatting artifacts that reduce final-delivery credibility
+
 ## Delivery cleanliness
 
 - [ ] no citation artifacts, retrieval syntax, placeholder entities, or rendering residues leak into the final report body

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -145,6 +145,43 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] if both positive (scale up) and negative (margin down) signals exist in the same period, they are presented together in one sentence or adjacent bullets — not separated in different sections
 - [ ] reader does not have to connect the dots themselves
 
+## Front-page readability
+
+- [ ] the front page mainly helps the reader grasp the report's judgment rather than the process behind it
+- [ ] the thesis, key risks, and key unknowns are easy to identify within 10-15 seconds of scanning
+- [ ] methodology detail does not displace judgment visibility on the front page
+- [ ] the front page feels like a report opening rather than a process note or metadata dump
+
+## Judgment visibility in layout
+
+- [ ] key judgments are visually visible rather than only embedded in prose
+- [ ] major sections include a visible takeaway, judgment, or summary block when the route carries recommendation or decision burden
+- [ ] risks, unknowns, and reversal conditions are easy to locate
+- [ ] the layout helps the reader scan the report's decision structure without reading every paragraph in order
+
+## Visual hierarchy and scanability
+
+- [ ] major headings and subheadings are clearly distinguished
+- [ ] judgment blocks, risks, evidence notes, and unknowns are visually differentiated from body text
+- [ ] long stretches of dense text are broken up when scanability would otherwise suffer
+- [ ] the report can be skimmed without losing the main logic
+
+## Table usefulness
+
+- [ ] each table has a clear title or immediate interpretive context
+- [ ] units, scope, and time basis are visible when relevant
+- [ ] tables support a judgment rather than merely display data
+- [ ] important tables are followed by a short interpretation of what matters most
+- [ ] the reader can tell why a given table matters to the conclusion
+
+## Mixed-script and target-language cleanliness
+
+- [ ] Chinese text spacing is visually normal and not obviously stretched by export
+- [ ] mixed Chinese-English text remains readable and stylistically consistent
+- [ ] names, product terms, and other proper nouns are spelled consistently
+- [ ] punctuation, brackets, dashes, dates, and percentages are stylistically aligned
+- [ ] there are no visible formatting artifacts that reduce final-delivery credibility
+
 ## Delivery cleanliness
 
 - [ ] no citation artifacts, retrieval syntax, placeholder entities, or rendering residues leak into the final report body
@@ -153,6 +190,7 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] the final artifact has been checked specifically for leftover placeholders such as `TBD`, `TODO`, `XXX`, `[[placeholder]]`, `{citation}`, or unresolved bracket markers
 - [ ] source notes, evidence labels, and section labels visible to the user are intentional reader-facing devices rather than leaked process scaffolding
 - [ ] tables, bullets, spacing, and heading hierarchy improve scanability rather than making the report feel like a raw export
+- [ ] presentation credibility leaks such as spelling mistakes, inconsistent naming, awkward table rhythm, orphaned headings, or obvious spacing artifacts are treated as delivery failures rather than cosmetic nits
 - [ ] if PDF is delivered, the PDF was reviewed as a deliverable in its own right rather than assumed correct because markdown looked clean
 - [ ] if markdown looked acceptable but PDF degraded structure, spacing, or readability, that is treated as a delivery failure rather than a minor rendering quirk
 

--- a/references/decision-report-template.md
+++ b/references/decision-report-template.md
@@ -39,6 +39,69 @@ A minimal working contract can be written in seven short lines:
 
 If this step is skipped, the report will often sound informed while still defaulting to a generic overview shape.
 
+## Judgment-first front page
+
+For decision-oriented or investment-style reports, the front page should act as a judgment entry point rather than a methodology-heavy opening.
+
+The front page should usually contain:
+- report title
+- date / coverage period
+- one-sentence judgment or thesis
+- 3-5 executive bullets
+- key risks
+- key unknowns
+- optional: what to watch next
+
+Do not let label explanations, route metadata, or process notes dominate the front page if they reduce judgment visibility.
+
+## Section takeaway block
+
+Each major section should make its decision value visually visible, not only verbally present.
+
+For major business, market, or option-analysis sections, include a compact takeaway block such as:
+- Section judgment
+- Main driver
+- Main risk
+- Key unknown
+- optional: What would change this view
+
+This block helps the final PDF remain scannable and prevents judgment from disappearing into background prose.
+
+## Judgment before background
+
+For decision-oriented sections, do not spend multiple paragraphs on background before making the section's main judgment visible.
+
+Prefer this order:
+1. section judgment
+2. why it matters
+3. supporting evidence
+4. limits, risks, or unknowns
+
+If the section opens with background, the judgment should still become visible early rather than appearing only at the end.
+
+## Decision-table discipline
+
+In decision reports, tables should support the reader's judgment, not merely display information.
+
+For comparison tables, segment tables, driver tables, or risk tables:
+- make the title interpretive, not generic
+- keep units and time scope explicit
+- keep number formatting consistent
+- follow the table with 1-2 sentences explaining what matters most in the table
+
+Do not end an important subsection with an un-interpreted table.
+
+## Methods note placement
+
+Evidence labels, confidence notes, and numeric-role explanations remain useful, but they should not automatically dominate the front page.
+
+Keep them visible, but default to:
+- a compact methods note
+- a page-2 opening block
+- or an appendix-style explanation
+
+Use the front page primarily for judgment clarity and orientation.
+
 ## Recommended structure
 
 ### Load-bearing numbers and their role

--- a/references/decision-report-template.md
+++ b/references/decision-report-template.md
@@ -201,6 +201,74 @@ In these multidimensional-positioning cases:
 - do not let roadmap products, self-tests, valuation signals, or regional leadership silently substitute for current global product/commercial leadership
 - if an overall label is still used, show the rule that permits collapsing multiple dimensions into one classification
 
+## Judgment-first front page
+
+For decision-oriented or investment-style reports, the front page should act as a judgment entry point rather than a methodology-heavy opening.
+
+The front page should usually contain:
+
+- report title
+- date / coverage period
+- one-sentence judgment or thesis
+- 3-5 executive bullets
+- key risks
+- key unknowns
+- optional: what to watch next
+
+Do not let label explanations, route metadata, or process notes dominate the front page if they reduce judgment visibility.
+
+## Section takeaway block
+
+Each major section should make its decision value visually visible, not only verbally present.
+
+For major business, market, or option-analysis sections, include a compact takeaway block such as:
+
+- Section judgment
+- Main driver
+- Main risk
+- Key unknown
+- optional: What would change this view
+
+This block helps the final PDF remain scannable and prevents judgment from disappearing into background prose.
+
+## Judgment before background
+
+For decision-oriented sections, do not spend multiple paragraphs on background before making the section's main judgment visible.
+
+Prefer this order:
+
+1. section judgment
+2. why it matters
+3. supporting evidence
+4. limits, risks, or unknowns
+
+If the section opens with background, the judgment should still become visible early rather than appearing only at the end.
+
+## Decision-table discipline
+
+In decision reports, tables should support the reader's judgment, not merely display information.
+
+For comparison tables, segment tables, driver tables, or risk tables:
+
+- make the title interpretive, not generic
+- keep units and time scope explicit
+- keep number formatting consistent
+- follow the table with 1-2 sentences explaining what matters most in the table
+
+Do not end an important subsection with an un-interpreted table.
+
+## Methods note placement
+
+Evidence labels, confidence notes, and numeric-role explanations remain useful, but they should not automatically dominate the front page.
+
+Keep them visible, but default to:
+
+- a compact methods note
+- a page-2 opening block
+- or an appendix-style explanation
+
+Use the front page primarily for judgment clarity and orientation.
+
 ## Company / equity-style decision reports
 
 When the task is primarily about evaluating a company, competitive position, or investment-style thesis, do not default to a background-first company overview. Start with a judgment summary rather than a company-history or product-catalog opening.

--- a/references/report-template.md
+++ b/references/report-template.md
@@ -6,6 +6,50 @@ Do not force every section if the task does not need it, but keep the report dec
 
 ## Default structure
 
+## Front-page discipline
+
+The front page should help the reader grasp the report's main judgment quickly.
+
+For user-facing reports, the front page should usually prioritize:
+- title
+- report date / coverage period
+- one-sentence bottom line or thesis
+- 3-5 executive bullets
+- key risks
+- key unknowns
+
+Do not default to using the front page as the main location for:
+- full evidence-label explanations
+- full numeric-role explanations
+- long methodology notes
+
+Method transparency should remain visible, but detailed label explanations and process notes should usually move to a later methods note, page-2 opening block, or appendix.
+
+## Scanability and paragraph discipline
+
+Final reports should support scan reading, not only sequential reading.
+
+Prefer:
+- shorter paragraphs
+- one main judgment per paragraph
+- bullets for risks, unknowns, limits, and counter-evidence
+- visible subheadings or callouts for key takeaways
+
+Avoid long stretches of dense prose when a list, takeaway block, or short sub-section would improve readability.
+
+## Table discipline
+
+Use tables when they help the reader compare, prioritize, or interpret evidence.
+Tables should not appear as unsupported data dumps.
+
+By default, a useful table should include:
+- a clear title
+- visible units and time scope
+- consistent number formatting
+- a short interpretation below the table explaining what the table shows and why it matters
+
+## Default structure
+
 ### 1. Executive summary
 
 **Format: use bullet points, not paragraphs.** Each bullet should contain one distinct idea. Do NOT write the executive summary as a wall of running text.

--- a/references/report-template.md
+++ b/references/report-template.md
@@ -110,6 +110,51 @@ Organize by task type. Examples:
 - list the most important sources
 - when applicable, use a structured source register rather than a loose bibliography
 
+## Front-page discipline
+
+The front page should help the reader grasp the report's main judgment quickly.
+
+For user-facing reports, the front page should usually prioritize:
+
+- title
+- report date / coverage period
+- one-sentence bottom line or thesis
+- 3-5 executive bullets
+- key risks
+- key unknowns
+
+Do not default to using the front page as the main location for:
+
+- full evidence-label explanations
+- full numeric-role explanations
+- long methodology notes
+
+Method transparency should remain visible, but detailed label explanations and process notes should usually move to a later methods note, page-2 opening block, or appendix.
+
+## Scanability and paragraph discipline
+
+Final reports should support scan reading, not only sequential reading.
+
+Prefer:
+
+- shorter paragraphs
+- one main judgment per paragraph
+- bullets for risks, unknowns, limits, and counter-evidence
+- visible subheadings or callouts for key takeaways
+
+Avoid long stretches of dense prose when a list, takeaway block, or short sub-section would improve readability.
+
+## Table discipline
+
+Use tables when they help the reader compare, prioritize, or interpret evidence. Tables should not appear as unsupported data dumps.
+
+By default, a useful table should include:
+
+- a clear title
+- visible units and time scope
+- consistent number formatting
+- a short interpretation below the table explaining what the table shows and why it matters
+
 ## Final-delivery rule
 
 Treat the final artifact as its own subsystem, not as a passive export of good reasoning.

--- a/scripts/markdown_to_html.py
+++ b/scripts/markdown_to_html.py
@@ -486,6 +486,79 @@ blockquote {
   background: #f8fbff;
   page-break-inside: avoid;
 }
+
+.front-page-summary {
+  display: block;
+  margin: 8pt 0 16pt;
+  padding: 14pt 16pt;
+  border-radius: 10pt;
+  background: linear-gradient(180deg, #f8fbff 0%, #eef4ff 100%);
+  border: 1px solid #d9e6fb;
+  page-break-inside: avoid;
+}
+
+.front-page-thesis {
+  display: block;
+  margin: 0 0 10pt;
+  padding-left: 10pt;
+  border-left: 4pt solid #2563eb;
+  color: #0f172a;
+  font-weight: 700;
+  font-size: 10.4pt;
+  line-height: 1.7;
+}
+
+.takeaway-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8pt 10pt;
+  margin: 10pt 0 16pt;
+  page-break-inside: avoid;
+}
+
+.takeaway-card {
+  border: 1px solid #dbe4f0;
+  border-radius: 8pt;
+  background: #f8fbff;
+  padding: 9pt 10pt;
+  min-height: 100%;
+}
+
+.takeaway-card-label {
+  display: block;
+  margin: 0 0 4pt;
+  font-size: 7.6pt;
+  line-height: 1.3;
+  text-transform: uppercase;
+  letter-spacing: 0.35pt;
+  color: #475569;
+  font-weight: 800;
+}
+
+.takeaway-card-value {
+  display: block;
+  font-size: 9.2pt;
+  line-height: 1.58;
+  color: #0f172a;
+}
+
+.methods-note {
+  margin: 8pt 0 14pt;
+  padding: 8pt 10pt;
+  border-radius: 8pt;
+  background: #f8fafc;
+  border: 1px dashed #cbd5e1;
+  color: #475569;
+  font-size: 8.4pt;
+  line-height: 1.6;
+  page-break-inside: avoid;
+}
+
+@media print {
+  .takeaway-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
 """
 
 REPORT_THEME_CSS = """
@@ -875,6 +948,98 @@ def maybe_wrap_wide_tables_in_html(html):
     return re.sub(r'<table[\s\S]*?</table>', repl, html, flags=re.I)
 
 
+def _convert_front_page_summary(html):
+    thesis_labels = r'(?:Core thesis|Thesis|Bottom line|Bottom-line judgment|Judgment|Recommendation|结论|核心判断|核心结论|建议)'
+    html = re.sub(
+        rf'<p><strong>({thesis_labels})[:：]</strong>\s*(.*?)</p>',
+        r'<div class="front-page-summary"><div class="front-page-thesis"><strong>\1:</strong> \2</div></div>',
+        html,
+        flags=re.I | re.S,
+    )
+
+    html = re.sub(
+        r'<div class="front-page-summary">\s*(<div class="front-page-thesis">.*?</div>)\s*</div>\s*(<ul>.*?</ul>)',
+        r'<div class="front-page-summary">\1\2</div>',
+        html,
+        flags=re.S,
+    )
+    return html
+
+
+TAKEAWAY_LABEL_PATTERNS = {
+    'section judgment': r'(?:Section judgment|Judgment|本节判断|核心判断|结论判断)',
+    'main driver': r'(?:Main driver|Core driver|核心驱动|主要驱动)',
+    'main risk': r'(?:Main risk|Core risk|核心风险|主要风险)',
+    'key unknown': r'(?:Key unknown|Main unknown|关键未知项|主要未知项|未知项)',
+    'what would change this view': r'(?:What would change this view|What would change the conclusion|改变判断的条件|什么会改变这一判断|什么会改变结论)',
+}
+
+
+def _convert_takeaway_cards(html):
+    paragraph_pattern = re.compile(r'<p><strong>([^<]{1,80})[:：]</strong>\s*(.*?)</p>', flags=re.I | re.S)
+    matches = list(paragraph_pattern.finditer(html))
+    if not matches:
+        return html
+
+    def normalize_label(label):
+        raw = re.sub(r'<[^>]+>', '', label).strip()
+        for canon, pattern in TAKEAWAY_LABEL_PATTERNS.items():
+            if re.fullmatch(pattern, raw, flags=re.I):
+                return canon, raw
+        return None, raw
+
+    rebuilt = []
+    last = 0
+    i = 0
+    while i < len(matches):
+        m = matches[i]
+        canon, raw = normalize_label(m.group(1))
+        if not canon:
+            i += 1
+            continue
+        group = []
+        j = i
+        while j < len(matches):
+            mj = matches[j]
+            cj, rawj = normalize_label(mj.group(1))
+            if not cj:
+                break
+            if j > i and mj.start() != matches[j-1].end():
+                between = html[matches[j-1].end():mj.start()]
+                if re.sub(r'\s+', '', between):
+                    break
+            group.append((mj, cj, rawj, mj.group(2).strip()))
+            j += 1
+            if len(group) >= 5:
+                break
+
+        if len(group) >= 2:
+            rebuilt.append(html[last:group[0][0].start()])
+            cards = []
+            for _, _, rawj, value in group:
+                cards.append(
+                    f'<div class="takeaway-card"><span class="takeaway-card-label">{rawj}</span>'
+                    f'<span class="takeaway-card-value">{value}</span></div>'
+                )
+            rebuilt.append('<div class="takeaway-grid">' + ''.join(cards) + '</div>')
+            last = group[-1][0].end()
+            i = j
+        else:
+            i += 1
+
+    rebuilt.append(html[last:])
+    return ''.join(rebuilt)
+
+
+def _mark_methods_notes(html):
+    return re.sub(
+        r'<p><strong>((?:Methods note|Method note|方法说明|研究方式|证据分级|数字角色))[:：]</strong>\s*(.*?)</p>',
+        r'<div class="methods-note"><strong>\1:</strong> \2</div>',
+        html,
+        flags=re.I | re.S,
+    )
+
+
 def style_generated_html(html):
     """Apply lightweight post-processing to markdown-generated HTML."""
     # Strip internal render hints; these should never leak into final delivery output.
@@ -909,6 +1074,9 @@ def style_generated_html(html):
         return f'<blockquote>{inner}</blockquote>'
 
     html = re.sub(r'<blockquote>\s*(.*?)\s*</blockquote>', quote_repl, html, flags=re.S|re.I)
+    html = _convert_front_page_summary(html)
+    html = _convert_takeaway_cards(html)
+    html = _mark_methods_notes(html)
     return html
 
 

--- a/scripts/markdown_to_html.py
+++ b/scripts/markdown_to_html.py
@@ -487,6 +487,41 @@ blockquote {
   page-break-inside: avoid;
 }
 
+.front-page-note {
+  margin: 8pt 0 14pt;
+  padding: 9pt 11pt;
+  border-left: 3pt solid #93c5fd;
+  background: #f8fbff;
+  color: var(--color-subtitle);
+  border-radius: 0 6pt 6pt 0;
+  font-size: 8.8pt;
+  line-height: 1.6;
+}
+
+.takeaway-block {
+  margin: 10pt 0 14pt;
+  padding: 10pt 12pt;
+  border-radius: 8pt;
+  border: 1px solid #cfe0ff;
+  border-left: 4pt solid var(--color-primary);
+  background: linear-gradient(180deg, #f8fbff 0%, #f1f7ff 100%);
+  page-break-inside: avoid;
+}
+
+.takeaway-block strong {
+  color: #1e3a8a;
+}
+
+.interpretation-note {
+  margin: -6pt 0 14pt;
+  padding: 7pt 10pt;
+  border-radius: 6pt;
+  background: #f8fafc;
+  color: var(--color-subtitle);
+  font-size: 8.6pt;
+  line-height: 1.58;
+}
+
 .front-page-summary {
   display: block;
   margin: 8pt 0 16pt;


### PR DESCRIPTION
## Summary
This PR hardens the final PDF delivery discipline for `deep-research` reports, especially for decision-oriented and investment-style outputs.

Closes #54.

The main goal is to improve:
- front-page readability
- judgment visibility in layout
- scanability under PDF export
- table usefulness as decision support
- mixed-script / Chinese final-delivery cleanliness

## What changed

### `references/report-template.md`
Added:
- `Front-page discipline`
- `Scanability and paragraph discipline`
- `Table discipline`

### `references/decision-report-template.md`
Added:
- `Judgment-first front page`
- `Section takeaway block`
- `Judgment before background`
- `Decision-table discipline`
- `Methods note placement`

### `checklists/final-audit.md`
Added:
- `Front-page readability`
- `Judgment visibility in layout`
- `Visual hierarchy and scanability`
- `Table usefulness`
- `Mixed-script and target-language cleanliness`

Also extended delivery cleanliness to cover presentation credibility leaks such as spacing artifacts, naming inconsistency, broken table rhythm, and obvious small spelling mistakes.

### `scripts/markdown_to_html.py`
Added rendering support for:
- front-page summary blocks
- takeaway blocks
- interpretation notes
- compact methods notes

## Why
Recent reports already have stronger evidence labeling, structure, and route discipline, but PDF quality still showed stable layout weaknesses:
- methodology-heavy front pages
- judgment buried in prose
- dense reading flow
- tables that display without interpreting
- mixed-script rendering that weakens final polish

This PR addresses those layout-level execution issues directly.

## Scope boundary
This PR is **not** about decorative styling or turning reports into slide decks.
It keeps a restrained research aesthetic while improving judgment visibility, scanability, layout discipline, and final-delivery cleanliness.
