### PR TITLE
feat: harden monopoly-style listed-company research discipline

### DIFF
--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -424,6 +424,7 @@ For this route, be especially strict about:
 - whether support, weakening evidence, and unresolved variables are separated clearly
 - whether competition is written as actual thesis pressure rather than peer-directory filler
 - whether valuation, growth, strategic narrative, and market position are kept analytically distinct
+- whether moat / monopoly / listed-proxy scarcity claims are explicitly separated when defensibility is central to the task
 
 ### Trigger
 Use when the task is mainly about:
@@ -443,6 +444,7 @@ Use when the task is mainly about:
 - `references/finance-date-discipline.md`
 - `references/market-sizing-and-share-discipline.md` when share/size claims matter
 - `references/source-traceability-and-claim-citation.md`
+- `references/moat-monopoly-screening.md` when the task involves monopoly, irreplaceability, strongest moat, scarce listed assets, or only-listed-proxy judgments
 
 ### Attach
 - current-state verification
@@ -463,6 +465,12 @@ The final report should visibly show:
 - separation of reported facts vs estimates
 - risks and counter-evidence
 - uncertainty around forward views
+- when moat / monopoly / scarcity is central, a visible distinction among:
+  - legal or regulatory exclusivity
+  - resource or infrastructure control
+  - strong moat but still contestable position
+  - listed-market proxy scarcity only
+- where wording was downgraded because the strongest claim could not be fully verified
 
 ### Hard fail
 Fail if the report:
@@ -471,6 +479,9 @@ Fail if the report:
 - uses undated financial numbers
 - makes market-position claims without scope
 - lets valuation narrative substitute for business evidence
+- treats A-share uniqueness as supply-side monopoly or industry exclusivity
+- uses `唯一` / `only` / `永久` / `permanent` / `不可替代` / `irreplaceable` / `>90%` / `无竞争对手` style wording without evidence strong enough for that exact claim strength
+- mixes monopoly, moat, market leadership, and listed-proxy scarcity into one undifferentiated scale
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -112,6 +112,7 @@ For every important claim, capture:
 Read `references/source-quality.md` when source ranking is ambiguous.
 Read `references/claim-matrix.md` when the task has multiple important conclusions, conflicting evidence, or high stakes.
 Read `references/task-types.md` when the task needs a domain-specific question set.
+Read `references/moat-monopoly-screening.md` when the task screens or ranks listed companies using monopoly, irreplaceability, scarcity, strongest moat, or only-listed-proxy language.
 Read `references/comparative-distillation-method.md` when comparing paired reports to turn stronger-vs-weaker outputs into reusable changes.
 Use `evals/templates/comparative-distillation-template.md` to record paired-report comparisons so extracted patterns land as `NEW_RULE`, `CHECKLIST_HARDENING`, `TEMPLATE_CHANGE`, or `NO_ACTION`.
 

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -78,6 +78,16 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] the final PDF reads as a polished deliverable rather than a text export
 - [ ] hierarchy, spacing, tables, and visual anchors support judgment rather than merely displaying information blocks
 
+## Monopoly / moat / listed-proxy boundary audit
+
+- [ ] monopoly, oligopoly, strong moat, market leadership, and listed-proxy scarcity are clearly separated when defensibility language is load-bearing
+- [ ] any `唯一` / `only` / `sole` / `永久` / `permanent` / `不可替代` / `irreplaceable` / `无竞争对手` / `>90%` claim is supported by evidence strong enough for that exact wording strength
+- [ ] if exact-strength support is missing, the wording is visibly downgraded rather than left in place with cosmetic caveats
+- [ ] A-share uniqueness is not used as shorthand for industry exclusivity or supply-side monopoly
+- [ ] secondary, aggregator, social, or retail-investor sources are not doing load-bearing work for monopoly-style final claims
+- [ ] if the report screens or ranks companies by scarcity / monopoly / irreplaceability, the final ranking shows category boundaries rather than one undifferentiated defensibility scale
+- [ ] a skeptical reader would not be able to point to multiple obvious overclaims in the final text
+
 ## Completeness
 
 - [ ] the report does not leave a strong impression while having weak substance

--- a/checklists/listed-company-report.md
+++ b/checklists/listed-company-report.md
@@ -50,6 +50,16 @@ Run through every item before delivering the final report.
 - [ ] valuation, growth, market position, and strategic narrative are not blended into one undifferentiated bullish or bearish mood
 - [ ] if the view is positive but not valuation-grade, timing-grade, or precision-grade, the downgrade boundary is explicit
 
+## Monopoly / moat / scarcity discipline
+
+- [ ] monopoly, oligopoly, strong moat, market leadership, and listed-market proxy scarcity are clearly separated when defensibility is central to the task
+- [ ] A-share-only listed uniqueness is not used as shorthand for industry exclusivity
+- [ ] `唯一` / `only` / `sole` / `永久` / `permanent` / `不可替代` / `irreplaceable` / `无竞争对手` / `>90%` style wording appears only when the source support matches that exact strength
+- [ ] if source support is weaker than wording strength, the wording is visibly downgraded
+- [ ] load-bearing market-share, ranking, or exclusivity claims include time window, scope, and denominator when relevant
+- [ ] issuer-sourced or media-mediated positioning claims are not upgraded into confirmed industry facts too easily
+- [ ] if the report screens for scarce or monopolistic companies, category boundaries are visible in the final ranking rather than hidden in caveats
+
 ## Flags
 
 If any item above is unchecked or uncertain, note the limitation explicitly in the report before delivery.

--- a/evals/meta/listed-company-monopoly-discipline.md
+++ b/evals/meta/listed-company-monopoly-discipline.md
@@ -1,0 +1,95 @@
+# Eval: Listed-Company Monopoly / Moat Discipline
+
+Use this eval when a listed-company report screens, ranks, or describes companies using monopoly, scarcity, irreplaceability, or strongest-moat language.
+
+## Goal
+
+Catch reports that sound rigorous but still overclaim because concept boundaries and wording-strength control were not executed tightly enough.
+
+This eval exists to distinguish between:
+
+1. a report that identifies real defensibility
+2. a report that quietly inflates defensibility into monopoly-style language
+
+## Typical failure patterns
+
+- strong moat drifts into monopoly wording
+- A-share-only listed exposure drifts into industry uniqueness
+- scarce asset control drifts into full-company exclusivity
+- market leadership drifts into no-competitor language
+- source insufficiency is hidden behind polished prose
+- uncertainty appears in caveats but not in ranking or conclusion language
+
+## What this eval is testing
+
+### Failure Mode 1: Category drift
+The report does not clearly separate:
+- strict monopoly
+- oligopoly or tightly licensed structure
+- resource or infrastructure control
+- strong but contestable moat
+- listed-market proxy scarcity only
+
+### Failure Mode 2: Wording-strength inflation
+The report uses language like:
+- unique / only / sole
+- permanent
+- irreplaceable
+- no real competitor
+- >90% share
+
+without evidence strong enough for that exact wording.
+
+### Failure Mode 3: Source-class inflation
+The report lets secondary, aggregator, media-mediated, or issuer-framed material carry final monopoly-style conclusions that should require stronger support.
+
+### Failure Mode 4: Cosmetic uncertainty
+The report includes caveats, but the final ranking or conclusion still reads as if the load-bearing claims were fully confirmed.
+
+## Pass criteria
+
+A good answer should:
+
+1. separate category types visibly
+2. match wording strength to evidence strength
+3. downgrade wording when exact-strength support is missing
+4. avoid using A-share uniqueness as shorthand for supply-side monopoly
+5. make source-class limitations visible in the final judgment, not only in notes
+
+## Scoring guide
+
+Use a simple 0-2 scale.
+
+### 0 = uncontrolled inflation
+The report repeatedly overstates category strength or uses monopoly-style wording without adequate evidence control.
+
+### 1 = partial control
+Some category separation or wording discipline is visible, but subtle overclaiming still leaks.
+
+### 2 = strong discipline
+Category boundaries are explicit, wording is controlled, and uncertainty visibly narrows final language.
+
+## Review questions
+
+When using this eval, ask:
+
+- Does the report distinguish monopoly from strong moat and listed-proxy scarcity?
+- Which exact sentences use the strongest exclusivity language?
+- Do those sentences have primary or otherwise adequate support for that exact strength?
+- Are issuer or media claims being upgraded too easily?
+- If uncertainty remains, does the final ranking language narrow accordingly?
+
+## Output format for reviewers
+
+When you apply this eval, summarize the result as:
+
+- **Task shape:**
+- **Strongest exclusivity language used:**
+- **What category boundaries were handled well:**
+- **What overclaim or drift still leaked:**
+- **Diagnosis:** category drift / wording-strength inflation / source-class inflation / cosmetic uncertainty
+- **Best next fix:** route hardening / checklist hardening / source-discipline tightening / template change
+
+## Why this eval exists
+
+Listed-company scarcity and monopoly-style tasks often fail in a subtle way: the report can look structured and informed while still stretching `moat` into `monopoly`. This eval turns that subtle failure family into something easier to catch and improve.

--- a/evals/meta/route-specific-micro-audits.md
+++ b/evals/meta/route-specific-micro-audits.md
@@ -20,6 +20,7 @@ A report can pass generic final-audit checks and still miss the subtle route-spe
 - market-entry report recommends expansion but leaves hub / beachhead / sequencing roles blurry
 - procurement memo discusses hardware and systems separately instead of as one stack decision
 - listed-company report has good facts but still reads like a company overview with market data attached
+- listed-company scarcity or monopoly report mixes moat, monopoly, and A-share-only proxy uniqueness into one scale
 - competition section lists peers rather than identifying who actually pressures the thesis and on what timeline
 
 ---

--- a/references/claim-matrix.md
+++ b/references/claim-matrix.md
@@ -68,6 +68,16 @@ A good claim should be:
 - scoped
 - evidence-linked
 
+For listed-company monopoly / moat / scarcity screening tasks, also capture:
+
+- exact claim wording
+- source class
+- year / scope / market definition
+- whether wording downgrade is needed
+- the strongest wording allowed in final delivery
+
+Do not let ranking backbone claims depend on vague market-share figures, undefined time windows, or secondary-only `unique` / `absolute` / `irreplaceable` language.
+
 ## Contradiction handling
 
 When support and counter-evidence conflict, compare:

--- a/references/moat-monopoly-screening.md
+++ b/references/moat-monopoly-screening.md
@@ -1,0 +1,105 @@
+# Moat / Monopoly Screening Discipline
+
+Use this reference when a research task asks for monopoly companies, irreplaceable listed companies, strongest moats, scarce listed assets, only-listed proxies, or similar public-market exclusivity judgments.
+
+This task family is not a generic company-profile route.
+
+It carries a distinct burden:
+- concept-boundary control
+- wording-strength control
+- source-sufficiency control
+- category-aware screening or ranking
+
+## Core rule
+
+Do not collapse all defensibility language into one bucket.
+
+Separate clearly among:
+- strict monopoly
+- oligopoly or tightly licensed structure
+- resource or infrastructure control
+- strong moat but still contestable
+- listed-market proxy scarcity only
+
+A report that sounds sharp but mixes these categories is not ready.
+
+## Required distinctions
+
+For each shortlisted company, make clear which of these is actually being claimed:
+
+1. legal or regulatory exclusivity
+2. policy-limited licensing or national-franchise scarcity
+3. resource lock-in or infrastructure control
+4. process, craft, geography, or brand moat
+5. listed-market scarcity only
+
+If more than one applies, name the combination rather than compressing it into `垄断` / `monopoly` automatically.
+
+## Strong-claim wording discipline
+
+Treat these as red-flag claims that require stronger backing than ordinary descriptive language:
+
+- unique / only / sole / exclusive
+- permanent
+- irreplaceable
+- no real competitor
+- impossible to replicate
+- only X licenses
+- only national license
+- over 90% share
+- absolute dominance
+- prohibited imitation
+
+If the exact strength of the wording is not supported by sufficiently direct evidence, downgrade the wording.
+
+## Mandatory downgrade rules
+
+- If the support is only secondary commentary, treat the claim as inference only.
+- If market definition, year, geography, or denominator is unclear, do not use the claim as a ranking backbone.
+- If only A-share uniqueness is confirmed, do not imply supply-side monopoly.
+- If policy or licensing structure is real but current exclusivity is not fully verified, downgrade to high-entry-barrier / tightly regulated structure rather than monopoly.
+- If market-share leadership is supported but exclusivity is not, downgrade from monopoly wording to leader / dominant player / strong moat.
+- If resource importance is clear but economic exclusivity is not, separate asset scarcity from full-company exclusivity.
+
+## Source sufficiency for load-bearing claims
+
+For claims about monopoly status, licensing exclusivity, permanent protection, sole-provider status, or extreme market-share dominance:
+
+- prefer primary evidence first
+- treat reposts, social discussion, retail-investor commentary, and news aggregation as discovery only
+- do not label such claims as confirmed fact unless supported by company filings, regulator documents, or other primary institutional material
+- broker research may support interpretation, but should not alone carry `sole` / `only` / `permanent` / `>90%` wording
+
+If source strength does not justify wording strength, downgrade the wording.
+
+## Concept-boundary traps
+
+Watch for these common drifts:
+
+- strong brand moat -> monopoly
+- listed-only exposure -> industry uniqueness
+- scarce asset -> exclusive economics
+- market leadership -> no meaningful competition
+- regulatory scarcity -> sole national franchise
+- management-stated ranking -> confirmed industry fact
+
+Do not let polished prose hide category drift.
+
+## Required artifact shape
+
+The final report should visibly show:
+- what kind of exclusivity is being claimed
+- what is confirmed fact vs inference vs unresolved
+- where wording was downgraded because evidence is incomplete
+- where a company is scarce as an A-share proxy but not a supply-side monopoly
+- what counter-evidence or scope limitations weaken the strongest claim
+
+## Hard fail
+
+Fail the artifact if it:
+- treats A-share uniqueness as industry exclusivity
+- uses monopoly wording without concept separation
+- lets ranking language exceed evidence strength
+- uses undefined market-share numbers as load-bearing proof
+- lets caveats stay cosmetic while final language remains absolute
+- allows weak source classes to carry high-confidence monopoly claims

--- a/references/source-quality.md
+++ b/references/source-quality.md
@@ -127,6 +127,25 @@ If a claim stays unresolved in a load-bearing way, do not stop at relabeling the
 - stability of the ranking
 - timing confidence behind the action
 
+## Load-bearing claims in listed-company monopoly / moat research
+
+For claims about monopoly status, licensing exclusivity, permanent protection, sole-provider status, or extreme market-share dominance:
+
+- prefer primary evidence first
+- treat reposts, social discussion, retail-investor commentary, and news aggregation as discovery only
+- do not label such claims as confirmed fact unless supported by company filings, regulator documents, or other primary institutional material
+- broker research may support interpretation, but should not alone carry `sole` / `only` / `permanent` / `>90%` wording
+
+If source strength does not justify wording strength, downgrade the wording.
+
+When the wording contains `唯一` / `only` / `sole` / `exclusive` / `永久` / `permanent` / `不可替代` / `irreplaceable` / `无竞争对手` / `>90%`, check explicitly:
+- exact claim wording
+- source class
+- year and market scope
+- whether the source supports the exact strength or only a weaker adjacent claim
+
+If that check fails, downgrade the conclusion rather than merely softening the source note.
+
 ## Issuer-sourced competitive and positioning claims
 
 Treat issuer-sourced claims with extra caution, especially when they involve:


### PR DESCRIPTION
## Summary
- add a dedicated moat / monopoly screening reference for listed-company research
- harden listed-company routing, checklist, and final-audit rules around overclaiming
- tighten source-quality and claim-matrix discipline for monopoly-style wording
- add a dedicated eval meta file for listed-company monopoly / moat drift

## Why
A recent bad case showed that the skill already had broad source-quality and uncertainty discipline, but did not activate reliably enough for listed-company scarcity / monopoly-style tasks. The main failure pattern was not just factual error; it was route-specific drift:
- moat / monopoly / listed-proxy scarcity collapsed into one scale
- strong wording outpaced source strength
- caveats appeared, but conclusion language stayed too absolute

This PR turns that failure family into explicit route, source, checklist, and eval pressure.

## Files changed
- `ROUTING-MATRIX.md`
- `SKILL.md`
- `checklists/final-audit.md`
- `checklists/listed-company-report.md`
- `references/source-quality.md`
- `references/claim-matrix.md`
- `references/moat-monopoly-screening.md` (new)
- `evals/meta/listed-company-monopoly-discipline.md` (new)
- `evals/meta/route-specific-micro-audits.md`

## Outcome
Future reports of this type should be forced to:
- separate monopoly vs strong moat vs listed-proxy scarcity
- downgrade `only / sole / permanent / irreplaceable / >90%` wording unless exact-strength support exists
- stop letting secondary or aggregator sources carry load-bearing monopoly claims
- surface category boundaries in the final ranking instead of hiding them in caveats
