### PR TITLE
docs: replace README with Chinese repo-facing overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,65 +1,212 @@
 # deep-research-skill
 
-Decision-oriented deep research skill for OpenClaw-compatible agents.
+面向 **OpenClaw / Codex 类 Agent** 的**决策导向深度研究技能仓库**。
 
-## Goal
+它不是一个“搜一下然后总结”的提示词集合，而是一套把研究任务收紧为**可路由、可审计、可迭代、可交付**流程的方法系统：先识别任务类型，再绑定研究纪律、审计门槛、失败样例和交付管线，最后输出更像 **decision memo** 而不是“信息堆砌型综述”。
 
-Turn “search and summarize” into a stricter research workflow that:
+---
 
-- clarifies the real objective
-- classifies the task type
-- verifies current-state facts for fast-moving topics
-- compares sources by quality and recency
-- actively searches for counter-evidence
-- produces decision-oriented final reports
+## 这个仓库在解决什么问题
 
-## Core files
+很多“deep research”最后会滑向几个常见失败：
 
-Start here:
+- 看起来很完整，其实没有回答真正的决策问题
+- 该查“当前状态”的任务，混入了过时信息
+- 引用很多，但 claim 和 source 之间并不真正可追溯
+- 缺少反证、替代解释、unknown 约束
+- 报告写得像行业综述，不像可执行的判断备忘录
+- 最终 PDF / markdown 交付层仍然有脏痕迹、占位符、结构泄漏
 
-- `SKILL.md` — shared workflow spine and orchestration rules
-- `ROUTING-MATRIX.md` — primary routes, attached disciplines, audits, and visible artifact contracts
-- `ARCHITECTURE.md` — layered system view of the repo
-- `SYSTEM-MAP.md` — family map for references, checklists, evals, and intervention paths
+这个 skill 的目标，就是把这些失败模式显式化，并沉淀成：
 
-## Supporting directories
+- **route（任务路由）**
+- **discipline（研究纪律）**
+- **checklist（交付审计）**
+- **eval（真实坏例子回灌）**
+- **script（交付渲染与验证）**
 
-- `references/` — reusable methods, discipline files, and report templates
-- `checklists/` — delivery-time audit gates
-- `evals/` — organized by subtype for regression, comparative distillation, and meta-discipline tracking
-- `scripts/` — delivery/rendering helpers, especially for markdown → PDF output
-- `examples/` — compact references for expected execution shape across representative memo types
+---
 
-## How the repo fits together
+## 核心能力
 
-The intended flow is:
+### 1. 决策导向，而不是摘要导向
+不是把信息搜齐就结束，而是把任务收紧成：
 
-1. `SKILL.md` defines the workflow spine
-2. `ROUTING-MATRIX.md` selects the active route and attached disciplines
-3. `references/` provides reusable methods and templates
-4. `checklists/` verify that the final artifact is actually ready
-5. `evals/` capture real failures and improvement signals
-6. `scripts/` handle delivery artifacts such as PDF
+- 要判断什么
+- 用什么比较单位判断
+- 哪些事实必须 current-state verified
+- 哪些结论只是 inferred / scenario assumption / illustrative calculation
+- 什么反证会削弱当前结论
+- 什么 unknown 会限制结论强度
 
-If you want the full layered explanation, read `ARCHITECTURE.md`.
-If you want the family/problem-area mapping, read `SYSTEM-MAP.md`.
+### 2. 任务路由明确
+仓库会把不同任务族分开处理，而不是套一个泛用模板。
 
-## How to evolve the repo
+典型覆盖包括：
 
-Use real tasks and real failures.
+- shortlist / option selection
+- market entry / regional expansion
+- market outlook / industry evolution
+- listed-company / moat / monopoly-style judgment
+- uncertainty-sensitive、forward-looking、comparative research
 
-- when a repeated task family needs clearer activation, strengthen `ROUTING-MATRIX.md`
-- when the task shape is right but the method is weak, improve `references/`
-- when the method exists but the final output still leaks failures, harden `checklists/`
-- when the report is analytically fine but final delivery mixes target languages in load-bearing labels, treat that as a delivery-coherence failure rather than a translation nit
-- when the failure is still unclear, add or refine `evals/`
-- when the content is right but the export is broken, fix `scripts/`
+### 3. 研究纪律可复用
+`references/` 中沉淀的是可反复调用的方法，而不是一次性提示词。
 
-Prefer focused changes over grab-bag edits.
+例如：
 
-## Maintenance
+- source quality / source traceability
+- current-state verification
+- counter-evidence
+- quantitative role labeling
+- claim matrix
+- route activation / preflight
+- market sizing / market share discipline
+- ranking and current-claims discipline
 
-- record meaningful behavior changes in `CHANGELOG.md`
-- track likely next work in `ROADMAP.md`
-- when fixing a real failure mode, add or update an eval whenever possible
-- keep rendering/pipeline fixes separate from research-discipline changes when they address different failure families
+### 4. 最终交付有审计门槛
+`checklists/` 不是装饰。它们的作用是防止“研究过程还行，但最后交付还是脏”。
+
+会重点拦截：
+
+- 强断言无足够 source support
+- freshness / date discipline 不够
+- claim 不可追溯
+- 反证和不确定性没有进入最终判断
+- placeholder residue / citation artifact / delivery cleanliness 问题
+
+### 5. 用真实坏例子驱动迭代
+`evals/` 不是演示材料，而是把真实失败案例转成规则、模板、检查项和回归资产。
+
+这意味着这个仓库的演进逻辑不是“继续堆规则”，而是：
+
+- 发现真实 bad case
+- 先判断是 policy gap 还是 execution drift
+- 再决定改 route、reference、checklist、eval 还是 script
+
+---
+
+## 仓库结构
+
+```text
+.
+├── SKILL.md                # 主工作流脊柱：给 Agent 的入口说明
+├── ROUTING-MATRIX.md       # 任务路由、附加 discipline、审计绑定
+├── ARCHITECTURE.md         # 分层架构视图
+├── SYSTEM-MAP.md           # 全仓库结构地图 / 问题域地图
+├── references/             # 可复用研究方法、模板、纪律说明
+├── checklists/             # 交付前审计门槛
+├── evals/                  # 坏例子、回归资产、对比蒸馏沉淀
+├── examples/               # 代表性任务形状示例
+├── scripts/                # markdown / PDF 渲染与验证工具
+├── CHANGELOG.md            # 重要行为变化记录
+└── ROADMAP.md              # 后续改进方向
+```
+
+---
+
+## 推荐阅读顺序
+
+如果你是第一次看这个仓库，建议按这个顺序：
+
+1. **`README.md`**：看清仓库目标与结构
+2. **`SKILL.md`**：看 Agent 实际执行时的工作流脊柱
+3. **`ROUTING-MATRIX.md`**：看任务如何分流，以及每类任务挂什么 discipline / audit
+4. **`ARCHITECTURE.md`**：看仓库分层与职责边界
+5. **`SYSTEM-MAP.md`**：看问题域、失败族和干预路径
+6. 按任务需要再进入 `references/`、`checklists/`、`evals/`、`scripts/`
+
+---
+
+## 这个仓库怎么协同工作
+
+它的大致执行顺序是：
+
+1. **`SKILL.md`** 定义通用工作流脊柱
+2. **`ROUTING-MATRIX.md`** 识别当前任务族，并挂上对应 discipline / audit
+3. **`references/`** 提供方法、模板、claim discipline 与研究约束
+4. **`checklists/`** 检查最终产物是否真的达到交付标准
+5. **`evals/`** 把真实失败沉淀成可复盘、可回归的资产
+6. **`scripts/`** 负责 markdown → PDF 等交付层问题
+
+一句话概括：
+**route 决定你该怎么研究，checklist 决定你能不能交付，eval 决定你会不会重复犯错。**
+
+---
+
+## 适合什么任务
+
+这个 skill 更适合下面这类任务：
+
+- 不是只要信息，而是要**判断 / 选择 / 优先级 / 建议**
+- 问题对**当前状态**敏感，旧资料会误导结论
+- 需要比较多个选项，而不是单点介绍
+- 需要把**反证、未知项、证据强弱**放进最终结论
+- 最终产物要像 **memo / recommendation / decision support**，而不是普通综述
+
+例如：
+
+- “哪个国家最适合先进入，为什么不是另外两个？”
+- “未来 12 个月这个市场更可能怎么演化？关键变量是什么？”
+- “这家公司是否真的具备稀缺 / 垄断 / 不可替代特征？”
+- “几个候选方案里，默认首选是谁，什么变化会让排名翻转？”
+
+---
+
+## 不想把它做成什么
+
+这个仓库**不追求**：
+
+- 把所有研究问题都硬塞进同一个模板
+- 用更多提示词长度代替方法清晰度
+- 用“看起来像研究”的长文掩盖 decision drift
+- 用 provider 切换代替 search objective / query shape 的思考
+- 把 final-delivery cleanliness 当成小问题
+
+---
+
+## 如何演进这个仓库
+
+推荐按“问题最靠近哪里，就改哪里”的方式迭代：
+
+- **任务激活不准** → 改 `ROUTING-MATRIX.md`
+- **方法不够强** → 改 `references/`
+- **最后成稿仍然脏** → 改 `checklists/`
+- **失败模式仍模糊** → 加 `evals/`
+- **内容没问题但 PDF / HTML 渲染坏掉** → 改 `scripts/`
+
+尽量避免“大杂烩式 PR”。
+
+更稳的方式通常是：
+
+- route / policy 一条 PR
+- checklist / audit 一条 PR
+- rendering / PDF pipeline 一条 PR
+
+---
+
+## 维护原则
+
+- 重要行为变化写入 `CHANGELOG.md`
+- 明确下一步改进放进 `ROADMAP.md`
+- 真实坏例子尽量配套新增或更新 `evals/`
+- 渲染层问题与研究纪律问题分开提交，避免 scope 混杂
+- 对“未知项”要让它真正约束结论，而不是只在文中象征性提一句
+- 把 final delivery cleanliness 当作硬门槛，而不是排版小瑕疵
+
+---
+
+## 相关文件入口
+
+- `SKILL.md`：Agent 执行入口
+- `ROUTING-MATRIX.md`：任务路由总表
+- `ARCHITECTURE.md`：架构说明
+- `SYSTEM-MAP.md`：系统地图
+- `evals/README.md`：评估资产入口
+- `scripts/render_pdf.py` / `scripts/md_to_pdf.py`：交付层脚本
+
+---
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- replace the repo README with a Chinese repo-facing overview
- reposition the README as a public-facing GitHub landing page instead of a minimal internal note
- clarify what the skill solves, its core capabilities, repo structure, reading order, and maintenance philosophy

## GitHub facade updates
- update the repo description (About)
- add repository topics for discoverability

## Scope
Docs / repo facade only. No skill-execution logic changed.