### PR TITLE
feat: harden listed-company freshness gates

### DIFF
--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -451,6 +451,14 @@ Use when the task is mainly about:
 - forward-looking claims discipline when forecasts appear
 - source traceability
 
+For this route, current-state verification must explicitly lock:
+
+- latest full-year reported period
+- latest quarterly / interim reported period
+- latest current market snapshot date
+- latest management / leadership state when decision-relevant
+- whether the opening thesis is anchored on those latest periods rather than on stale-but-plausible background material
+
 ### Audit
 - `checklists/listed-company-report.md`
 - `checklists/source-traceability.md`

--- a/SKILL.md
+++ b/SKILL.md
@@ -225,6 +225,20 @@ Typical triggers include:
 
 If current state cannot be verified, say so clearly instead of filling gaps with likely-but-stale knowledge.
 
+For listed-company or investment-style research, treat current-state verification as a hard gate rather than a general reminder.
+
+Before broad company analysis, explicitly confirm:
+
+- latest full-year reported period
+- latest quarterly / interim reported period
+- latest current market snapshot date
+- latest management / leadership state when decision-relevant
+- whether the opening section is anchored on those latest periods rather than on an older but easier-to-find snapshot
+
+If the report date is materially later than the supposedly "latest" figures used in the memo, stop and re-check freshness before continuing.
+
+Do not let an older but well-structured company snapshot become the de facto current baseline just because it is easier to retrieve.
+
 Route-specific current-state requirements are defined in `ROUTING-MATRIX.md`.
 
 ## Mid-research review

--- a/checklists/listed-company-report.md
+++ b/checklists/listed-company-report.md
@@ -16,9 +16,12 @@ Run through every item before delivering the final report.
 ## Reporting discipline
 
 - [ ] latest full-year financial figures are sourced from annual report, earnings release, or filed disclosure
+- [ ] latest quarterly / interim figures are sourced from the newest reported period reasonably available at the report date
+- [ ] if the memo date is materially later than the supposedly "latest" figures used, freshness was re-checked before synthesis
 - [ ] financial figures are labeled by type: audited annual / interim / earnings release / analyst consensus / inferred
 - [ ] historical reported facts are separated from current market snapshot
 - [ ] forward-looking targets or estimates are clearly labeled as such, not presented as confirmed facts
+- [ ] older but still useful numbers are visibly labeled as historical background / older snapshot rather than treated as current-state anchors
 
 ## Current product lineup
 
@@ -39,6 +42,7 @@ Run through every item before delivering the final report.
 - [ ] gross margin or net margin where relevant
 - [ ] operating cash flow direction noted
 - [ ] segment breakdown if multi-segment business
+- [ ] the report makes visible which numbers belong to the latest reported annual period, which belong to the latest reported quarter/interim period, and which belong only to older historical context
 
 ## Judgment-shape micro-audit
 

--- a/evals/cases/intel-current-state-freshness-case.md
+++ b/evals/cases/intel-current-state-freshness-case.md
@@ -1,0 +1,114 @@
+# Eval: Intel Listed-Company Freshness Hard Gate Case
+
+## Goal
+
+Test whether a listed-company deep-research report dated in 2026 can still silently anchor itself on 2024 and 2025 Q1 material as if those were the current baseline.
+
+This eval targets a recurring failure mode:
+
+- the report looks structured and evidence-aware
+- many numbers are real
+- but the opening thesis is anchored on stale reporting periods and stale market snapshots rather than the newest reasonably available reported periods at the report date
+
+## Real failure pattern
+
+A user-provided Intel report dated **2026-04-13** still described **2025 Q1** as the "latest financial" period and relied heavily on older 2024 / early-2025 snapshots for:
+
+- financial performance anchors
+- market-share context
+- target-price / consensus framing
+- foundry scale framing
+- product / roadmap state
+
+The problem was not total fabrication. The problem was that older but plausible data became the memo's de facto current-state anchor.
+
+## What this eval is testing
+
+### Failure Mode 1: stale reporting-period anchor
+
+The report date is materially later than the supposedly latest figures used.
+
+For example:
+- report dated 2026-04
+- memo still treats 2025 Q1 as "latest financial"
+
+This should trigger a hard freshness re-check before synthesis.
+
+### Failure Mode 2: older market snapshots presented as current state
+
+Older figures such as:
+- old market share snapshots
+- old analyst target-price snapshots
+- old valuation or ownership snapshots
+- old product or roadmap milestone wording
+
+may still be useful as background, but they must not silently function as the current-state baseline.
+
+### Failure Mode 3: broad company analysis starts before current-state lock
+
+The model begins writing business, competition, and thesis sections before explicitly locking:
+- latest full-year reported period
+- latest quarterly / interim reported period
+- latest current market snapshot date
+- latest leadership / management state when decision-relevant
+
+## Pass criteria
+
+A good answer should:
+
+1. lock the current time layers before broad synthesis
+   - latest full-year reported period
+   - latest quarterly / interim reported period
+   - latest current market snapshot date
+
+2. treat stale-but-plausible anchors as a hard failure condition
+   - if the memo date is materially later than the allegedly latest period, re-check first
+   - do not continue as if the old anchor were acceptable
+
+3. downgrade older but useful data visibly
+   - historical background
+   - prior-cycle comparison
+   - older market snapshot
+
+4. make the opening section reflect the newest verified reporting layer rather than an easier older snapshot
+
+## Failure signs
+
+Mark this eval as failed if the answer does any of the following:
+
+- calls an older quarter or fiscal year the "latest" when newer reported periods should already exist
+- uses older market-share, target-price, or analyst-snapshot data as if it were the current baseline
+- lets a stale opening snapshot determine the whole memo's framing
+- includes many real numbers but still mis-times the company state overall
+
+## Why this eval matters
+
+This is a listed-company execution problem, not just a generic freshness problem.
+
+In investment-style research, a stale anchor distorts:
+- the opening thesis
+- the weight assigned to risks vs catalysts
+- whether management guidance is still current
+- how valuation context is interpreted
+- what counts as unresolved vs already updated
+
+A report can therefore look numerically rich while still failing the real current-state contract.
+
+## Suggested intervention target
+
+This case should push changes at multiple layers:
+
+- `SKILL.md` current-state verification for listed-company work
+- `ROUTING-MATRIX.md` listed-company hard-fail rules
+- `references/finance-date-discipline.md`
+- `checklists/listed-company-report.md`
+
+## Reviewer checklist
+
+- Did the report lock the latest annual period before broad analysis?
+- Did the report lock the latest quarterly / interim period before broad analysis?
+- Did the report include a clearly dated current market snapshot?
+- Were older market snapshots visibly downgraded to historical context?
+- Could the opening section still be true if a newer reported period already existed?
+
+If yes, the freshness hard gate failed.

--- a/references/finance-date-discipline.md
+++ b/references/finance-date-discipline.md
@@ -77,6 +77,30 @@ If this data cannot be obtained cleanly, note the limitation explicitly rather t
 
 Do not write a listed-company investment memo without current market context. Historical financials alone are insufficient for investment analysis.
 
+### Freshness hard gate for listed-company work
+
+Before broad analysis, explicitly lock three time layers:
+
+1. latest full-year reported period
+2. latest quarterly / interim reported period
+3. latest current market snapshot date
+
+If the report date is materially later than the period being presented as "latest," stop and re-check whether a newer filing, earnings release, or market snapshot should already exist.
+
+Common failure pattern:
+- the report is dated well after a newer quarter should already be available
+- an older annual or quarterly snapshot is easier to retrieve
+- that older snapshot quietly becomes the opening anchor for the whole memo
+
+Treat that as a freshness failure, not as a minor lag.
+
+When older numbers remain useful, label them as one of:
+- historical background
+- prior-cycle comparison
+- older market snapshot
+
+Do not let them stand in for current-state anchors.
+
 ## 3. Forward-looking targets or estimates
 
 Examples:


### PR DESCRIPTION
## Summary
- treat current-state verification as a hard gate for listed-company / investment-style research
- require explicit locking of latest annual period, latest quarterly/interim period, and latest current market snapshot date before broad company synthesis
- harden the listed-company route and checklist against stale-but-plausible anchors
- add an Intel eval case to preserve the real failure pattern

## Why
A recent Intel report dated 2026-04 still treated 2025 Q1 as the latest financial snapshot and let older market/context snapshots function as the memo's current baseline. The problem was not fake data; it was stale anchor selection.

## Files
- `SKILL.md`
- `ROUTING-MATRIX.md`
- `references/finance-date-discipline.md`
- `checklists/listed-company-report.md`
- `evals/cases/intel-current-state-freshness-case.md`

## Scope
Policy / execution hardening only. No renderer or repo-facade changes.