### PR TITLE
docs: track listed-company stale-anchor failure family

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,7 @@ This file tracks likely next improvements and helps keep repo evolution intentio
 - Add more evals for freshness, counter-evidence, and decision-quality regressions.
 - Test the skill against more real fast-moving company/product cases.
 - Tighten current-state verification if stale facts still leak into reports.
+- Treat **listed-company stale-anchor selection** as a distinct failure family rather than only a generic freshness issue: test whether older-but-plausible annual / quarterly / market snapshots are still silently becoming the memo baseline, and decide whether this needs a dedicated meta-eval or failure-taxonomy entry.
 - Add meta-evals and trigger-routing improvements for failure families identified in `references/failure-taxonomy.md`, especially rule activation, scope completeness, decision utility, and market-outlook routing.
 - Decide whether to formalize eval subtypes (`case`, `rubric`, `distillation`, `meta-eval`) in naming or folder structure.
 - Run at least 2-3 more real comparative-distillation cases and promote only the recurring candidate rules.


### PR DESCRIPTION
## Summary
- add a focused roadmap note to track **listed-company stale-anchor selection** as its own failure family
- make the next-step question explicit: should this remain a freshness subcase, or graduate into a dedicated meta-eval / taxonomy entry?

## Why
Recent real listed-company cases showed that the failure is narrower than generic stale facts: older-but-plausible annual / quarterly / market snapshots can silently become the memo baseline even when the report contains many real numbers.

## Related
- Issue #60
- PR #59
- `evals/cases/intel-current-state-freshness-case.md`

## Scope
Roadmap note only.