### PR TITLE
docs: harden listed-company judgment memo execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@
 - `ARCHITECTURE.md`：架构说明
 - `SYSTEM-MAP.md`：系统地图
 - `evals/README.md`：评估资产入口
+- `examples/listed-company-judgment-memo-example.md`：通用上市公司 judgment memo 正样本
+- `examples/china-shenhua-reference-grade-rewrite-skeleton.md`：中国神华案例化 reference-grade skeleton
 - `scripts/render_pdf.py` / `scripts/md_to_pdf.py`：交付层脚本
 
 ---

--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -467,10 +467,18 @@ For this route, current-state verification must explicitly lock:
 ### Visible artifact contract
 The final report should visibly show:
 
+- a judgment-first opening rather than a background-first company overview
+- a compact research-anchor block that locks:
+  - latest full-year reported period
+  - latest quarterly / interim reported period
+  - latest current market snapshot date
+  - latest management / leadership state when decision-relevant
 - current business snapshot
 - current financial or market snapshot
 - clearly dated key numbers
 - separation of reported facts vs estimates
+- visible support / weakening evidence / unresolved-variable split for the current thesis
+- claim-level traceability for load-bearing claims in the body, not only a bibliography at the end
 - risks and counter-evidence
 - uncertainty around forward views
 - when moat / monopoly / scarcity is central, a visible distinction among:

--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -495,6 +495,7 @@ Fail if the report:
 
 - mixes reported metrics and forward estimates without clear labels
 - uses undated financial numbers
+- names a stale or mis-timed quarterly / interim period in the research-anchor block and still proceeds as if the memo were current
 - makes market-position claims without scope
 - lets valuation narrative substitute for business evidence
 - treats A-share uniqueness as supply-side monopoly or industry exclusivity

--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -445,6 +445,8 @@ Use when the task is mainly about:
 - `references/market-sizing-and-share-discipline.md` when share/size claims matter
 - `references/source-traceability-and-claim-citation.md`
 - `references/moat-monopoly-screening.md` when the task involves monopoly, irreplaceability, strongest moat, scarce listed assets, or only-listed-proxy judgments
+- `examples/listed-company-judgment-memo-example.md` when the report risks drifting into a company overview instead of a judgment memo
+- `examples/china-shenhua-reference-grade-rewrite-skeleton.md` when a concrete Chinese listed-company reference shape would help keep the memo judgment-first
 
 ### Attach
 - current-state verification

--- a/SKILL.md
+++ b/SKILL.md
@@ -280,6 +280,10 @@ Use `references/decision-report-template.md` when the task needs:
 - comparison
 - action guidance
 
+For listed-company / investment-style work, also use:
+- `examples/listed-company-judgment-memo-example.md` as the default positive memo shape
+- `examples/china-shenhua-reference-grade-rewrite-skeleton.md` when a more concrete Chinese listed-company reference skeleton would help keep the opening judgment-first
+
 The report should not just summarize the topic. It should help the user decide, judge, or verify what matters next.
 
 For most tasks, include:

--- a/SKILL.md
+++ b/SKILL.md
@@ -237,7 +237,14 @@ Before broad company analysis, explicitly confirm:
 
 If the report date is materially later than the supposedly "latest" figures used in the memo, stop and re-check freshness before continuing.
 
+Fail-fast rule for listed-company work:
+- if the research-anchor block contains a quarterly / interim period that is materially inconsistent with the report date or likely filing calendar
+- or if the agent cannot defend why that period is still the newest reasonably available layer
+- do not continue synthesis as if the anchor were acceptable
+- stop, re-check, and either fix the anchor or state explicitly that the latest quarter could not be verified
+
 Do not let an older but well-structured company snapshot become the de facto current baseline just because it is easier to retrieve.
+Do not let a polished research-anchor block create false trust when one of its time layers is stale or mis-timed.
 
 Route-specific current-state requirements are defined in `ROUTING-MATRIX.md`.
 

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -15,6 +15,8 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] no major claim rests on a single weak source
 - [ ] evidence hierarchy is visible: confirmed facts, well-supported inferences, and weak claims are not mixed
 - [ ] key numbers are sourced and dated
+- [ ] load-bearing claims are traceable in the body text, not only recoverable from a source appendix or bibliography
+- [ ] strong-sounding comparative or forecast claims have explicit scope and source role, or were visibly downgraded
 
 ## Counter-evidence
 

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -67,6 +67,7 @@ This is the last gate before the report goes to the user. If any item fails, rev
 
 - [ ] the report reads like a judgment memo rather than only a strong descriptive overview
 - [ ] the main conclusion is visible in the opening section rather than buried after background exposition
+- [ ] the opening makes visible not only the thesis, but also the strongest weakening evidence and the key unresolved variable
 - [ ] if the first 30-40% of background were removed, the core judgment would still remain clear
 - [ ] issuer- or company-sourced claims are not upgraded into confirmed industry facts too easily
 - [ ] `leading` / `unique` / market-share / industry-position / strategic-importance claims are independently supported or visibly downgraded

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -73,6 +73,7 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] the report distinguishes clearly among: company states X / filing states X / third-party evidence supports X / scope remains only partially confirmed
 - [ ] for each load-bearing number, time window, sample boundary, denominator, and comparison basis are explicit when relevant
 - [ ] each important metric is visibly identified as realized performance / management target / third-party estimate / analyst inference / media-reported figure when the distinction matters
+- [ ] for asset injection, financing, restructuring, M&A, or similar corporate actions, the report separates confirmed transaction facts from likely implications and from open uncertainty
 - [ ] open uncertainties do not remain cosmetic; they visibly narrow confidence, timing confidence, ranking strength, scenario weighting, or recommendation strength
 - [ ] if a key technical, commercial, regulatory, or execution milestone is unresolved, the final judgment is correspondingly narrowed
 - [ ] the competition section identifies who actually pressures the thesis, and on what timeline, rather than mostly listing peers and products

--- a/checklists/listed-company-report.md
+++ b/checklists/listed-company-report.md
@@ -47,12 +47,14 @@ Run through every item before delivering the final report.
 ## Judgment-shape micro-audit
 
 - [ ] the opening section states the current thesis before long background exposition begins
+- [ ] the opening page makes the thesis, key risks, and key unknowns easier to see than methodology notes or evidence-label legends
 - [ ] the report identifies the few disclosures or variables that most determine the current view, rather than spreading importance evenly across many company facts
 - [ ] the report distinguishes what currently supports the thesis, what currently weakens it, and what remains unresolved
 - [ ] if one unresolved variable dominates the case, it is named as such rather than diluted inside a general risk list
 - [ ] competition is written as actual thesis pressure or threat-window analysis rather than mostly a peer directory
 - [ ] valuation, growth, market position, and strategic narrative are not blended into one undifferentiated bullish or bearish mood
 - [ ] if the view is positive but not valuation-grade, timing-grade, or precision-grade, the downgrade boundary is explicit
+- [ ] asset injection, restructuring, one-off financing, or major corporate actions are split into: confirmed transaction facts / likely operating impact / open uncertainty about realization
 
 ## Monopoly / moat / scarcity discipline
 

--- a/checklists/listed-company-report.md
+++ b/checklists/listed-company-report.md
@@ -49,6 +49,7 @@ Run through every item before delivering the final report.
 - [ ] the opening section states the current thesis before long background exposition begins
 - [ ] the opening page makes the thesis, key risks, and key unknowns easier to see than methodology notes or evidence-label legends
 - [ ] the report identifies the few disclosures or variables that most determine the current view, rather than spreading importance evenly across many company facts
+- [ ] the 3-5 claims doing the most thesis work are auditable in the body text rather than only indirectly recoverable from a source list
 - [ ] the report distinguishes what currently supports the thesis, what currently weakens it, and what remains unresolved
 - [ ] if one unresolved variable dominates the case, it is named as such rather than diluted inside a general risk list
 - [ ] competition is written as actual thesis pressure or threat-window analysis rather than mostly a peer directory

--- a/checklists/listed-company-report.md
+++ b/checklists/listed-company-report.md
@@ -18,6 +18,7 @@ Run through every item before delivering the final report.
 - [ ] latest full-year financial figures are sourced from annual report, earnings release, or filed disclosure
 - [ ] latest quarterly / interim figures are sourced from the newest reported period reasonably available at the report date
 - [ ] if the memo date is materially later than the supposedly "latest" figures used, freshness was re-checked before synthesis
+- [ ] if the research-anchor block originally contained a stale or mis-timed quarter / interim period, synthesis was stopped and the anchor was corrected or explicitly downgraded before delivery
 - [ ] financial figures are labeled by type: audited annual / interim / earnings release / analyst consensus / inferred
 - [ ] historical reported facts are separated from current market snapshot
 - [ ] forward-looking targets or estimates are clearly labeled as such, not presented as confirmed facts

--- a/checklists/listed-company-report.md
+++ b/checklists/listed-company-report.md
@@ -54,7 +54,7 @@ Run through every item before delivering the final report.
 - [ ] competition is written as actual thesis pressure or threat-window analysis rather than mostly a peer directory
 - [ ] valuation, growth, market position, and strategic narrative are not blended into one undifferentiated bullish or bearish mood
 - [ ] if the view is positive but not valuation-grade, timing-grade, or precision-grade, the downgrade boundary is explicit
-- [ ] asset injection, restructuring, one-off financing, or major corporate actions are split into: confirmed transaction facts / likely operating impact / open uncertainty about realization
+- [ ] asset injection, restructuring, one-off financing, M&A, or other major corporate actions are split into: confirmed transaction facts / likely operating impact / open uncertainty about realization, timing, synergy quality, or dependency on external variables
 
 ## Monopoly / moat / scarcity discipline
 

--- a/checklists/listed-company-report.md
+++ b/checklists/listed-company-report.md
@@ -51,7 +51,9 @@ Run through every item before delivering the final report.
 - [ ] the report identifies the few disclosures or variables that most determine the current view, rather than spreading importance evenly across many company facts
 - [ ] the 3-5 claims doing the most thesis work are auditable in the body text rather than only indirectly recoverable from a source list
 - [ ] the report distinguishes what currently supports the thesis, what currently weakens it, and what remains unresolved
+- [ ] support / weakening / unresolved are visible in the opening 20-30% of the report, not only scattered later across sections
 - [ ] if one unresolved variable dominates the case, it is named as such rather than diluted inside a general risk list
+- [ ] the unresolved variable visibly narrows confidence, timing precision, valuation precision, or recommendation strength rather than remaining a decorative caveat
 - [ ] competition is written as actual thesis pressure or threat-window analysis rather than mostly a peer directory
 - [ ] valuation, growth, market position, and strategic narrative are not blended into one undifferentiated bullish or bearish mood
 - [ ] if the view is positive but not valuation-grade, timing-grade, or precision-grade, the downgrade boundary is explicit

--- a/checklists/source-traceability.md
+++ b/checklists/source-traceability.md
@@ -30,6 +30,7 @@ Run through every item before delivering the final report.
 - [ ] no key claim is left without a traceable source
 - [ ] the report reads as auditable — a reader can follow any claim back to a specific source entry
 - [ ] the register does not contain sources that are not actually cited
+- [ ] if a reviewer highlighted the 3-5 sentences doing the most thesis work, each of those sentences would still be defendable without additional hidden notes
 
 ## Flags
 

--- a/evals/cases/china-shenhua-listed-company-judgment-and-traceability-case.md
+++ b/evals/cases/china-shenhua-listed-company-judgment-and-traceability-case.md
@@ -1,0 +1,196 @@
+# Eval: China Shenhua Listed-Company Judgment and Traceability Case
+
+## Goal
+
+Test whether a listed-company deep-research report can avoid looking polished while still failing the real investment-style burden.
+
+This eval is based on a real user-provided report about **China Shenhua (601088 / 01088.HK)** dated **2026-04-16**.
+
+The report looked structured and evidence-aware. It used confidence-style labels such as:
+- confirmed facts
+- inference
+- open uncertainty
+
+But the report still exposed a more specific failure family:
+- the opening behaved more like a company-profile snapshot than a judgment memo
+- several load-bearing claims sounded stronger than their visible sourcing justified
+- key thesis-supporting claims were not auditable at the body-claim level
+- front-page methodology / evidence labeling occupied too much attention relative to the actual thesis, risks, and unknowns
+- corporate-action upside language compressed confirmed transaction facts, likely operating implications, and open uncertainty into one smooth narrative
+
+## Prompt
+
+Use deep-research to produce a Chinese listed-company / investment-style report on China Shenhua.
+
+The report should cover at least:
+- business and products
+- industry position
+- customers and use cases
+- key competitors
+- the last two years of operating and financial signals
+- bullish logic
+- bearish logic
+- main opportunities and risks over the next 1-3 years
+
+Requirements:
+- use multiple sources and cross-check important claims
+- clearly distinguish confirmed facts, likely inference, and open uncertainty
+- if PDF is produced, keep the front page readable and judgment-first
+- make load-bearing claims auditable in the body, not only by listing sources at the end
+- when discussing asset injection, financing, or restructuring, separate:
+  - confirmed transaction facts
+  - likely operating / financial implications
+  - open uncertainty about timing, realization, or synergy quality
+
+## What this eval is testing
+
+### Failure Mode 1: company overview shape substitutes for judgment memo shape
+
+The report may look rich and organized, but the opening still behaves like:
+- a company overview
+- a background summary
+- a cleaned-up profile card
+
+instead of a current judgment memo.
+
+The opening should make visible:
+- the current thesis
+- the strongest confirmed support
+- the key unresolved variable
+- the main risks and unknowns
+- the time anchors supporting the judgment
+
+If the first page can be skimmed without revealing the real current thesis, the route execution is still too weak.
+
+### Failure Mode 2: confidence-label theater without claim-level auditability
+
+The report may use labels such as confirmed / inference / uncertainty, yet still leave important claims unauditable.
+
+Typical examples include strong-sounding claims about:
+- transport-cost advantage
+- volatility sensitivity vs peers
+- asset-injection growth impact
+- dividend superiority
+- future coal-price center or scenario range
+
+These may be directionally plausible, but the report fails if the reader cannot tell:
+- which source supports the exact claim
+- whether the claim is directly stated vs inferred
+- whether the wording strength was downgraded when support was indirect
+
+### Failure Mode 3: front-page process visibility displaces judgment visibility
+
+A report can technically include an evidence legend and still fail the front page.
+
+This eval checks whether:
+- the thesis is easier to spot than the methodology note
+- executive bullets carry judgment rather than metadata
+- key risks and key unknowns are visually easier to find than process framing
+
+The evidence legend should stay compact and should not dominate the reader's first scan.
+
+### Failure Mode 4: corporate-action compression
+
+For China Shenhua-style reports, major corporate actions such as:
+- asset injection
+- financing completion
+- restructuring
+- production-capacity expansion implications
+
+must not be compressed into one smooth bullish line.
+
+The report should separate:
+1. what is confirmed transaction fact
+2. what is likely operating or financial implication
+3. what remains unresolved about realization, timing, or synergy quality
+
+If these are blended together, the report overstates certainty while sounding disciplined.
+
+### Failure Mode 5: support / weakening / unresolved split is not visible
+
+A listed-company report should not only present positive logic plus a generic risk list.
+
+It should visibly separate:
+- what currently supports the thesis
+- what currently weakens it
+- what remains unresolved and therefore limits confidence, timing precision, valuation precision, or recommendation strength
+
+If the report has a bullish mood with decorative caveats, mark this eval as failed.
+
+## Pass criteria
+
+A good answer should:
+
+1. start with a judgment-first opening
+   - thesis first
+   - latest time anchors visible early
+   - risks and unknowns scannable on the front page
+
+2. make load-bearing claims auditable in the body
+   - not only in a bibliography
+   - with visible source role and scope when needed
+
+3. separate evidence weight honestly
+   - confirmed facts vs likely inference vs open uncertainty
+   - direct evidence vs indirect evidence when the claim matters to the bottom line
+
+4. keep strong wording proportional to support
+   - if support is weaker than the wording strength, downgrade the wording visibly
+
+5. split major corporate actions into fact / implication / uncertainty
+   - do not let asset-injection or financing language function as hidden certainty inflation
+
+6. keep the listed-company route visible
+   - the report should read like an investment-style judgment memo, not a polished company brief
+
+## Failure signs
+
+Mark this eval as failed if the answer does any of the following:
+
+- the front page is dominated by methodology, label explanation, or metadata while the thesis remains hard to see
+- the opening reads like a business summary instead of a current judgment memo
+- key bullish claims sound precise or comparative but are not claim-traceable in the body
+- asset injection / financing / restructuring facts are blended directly into growth or valuation upside without an uncertainty split
+- competition appears mainly as a peer directory rather than thesis pressure
+- the report uses confidence labels but still leaves the main bottom line weakly auditable
+- risks exist but do not visibly weaken or narrow the final judgment
+
+## Why this eval matters
+
+This case catches a failure family that can survive even after:
+- freshness hardening
+- source-list additions
+- visible evidence labels
+
+The report can still fail because:
+- route execution is too background-first
+- traceability remains bibliography-level rather than claim-level
+- front-page judgment visibility is too weak
+- positive corporate-action storytelling is not separated from confirmed facts and open uncertainty
+
+If the skill cannot pass this eval, it remains vulnerable to reports that look disciplined but still overstate the reliability of their own conclusion.
+
+## Likely intervention targets
+
+This case should push changes in:
+- `ROUTING-MATRIX.md` listed-company visible artifact contract and hard fails
+- `checklists/listed-company-report.md`
+- `checklists/final-audit.md`
+- `references/report-template.md`
+- `references/decision-report-template.md`
+
+## Reviewer checklist
+
+- Can a reader identify the thesis, key risks, and key unknowns within the first page scan?
+- Does the report visibly lock latest annual / latest quarter / latest market snapshot before broad narrative expansion?
+- Are load-bearing claims auditable in the body rather than only by a source list at the end?
+- Are strong comparative or forecast claims visibly scoped, sourced, or downgraded?
+- Are corporate actions split into confirmed facts / likely implications / open uncertainty?
+- Does the report visibly show what supports the thesis, what weakens it, and what remains unresolved?
+- If the background section were shortened by 30-40%, would the core judgment remain intact?
+
+## Suggested scoring
+
+- Pass: judgment-first, claim-auditable, route-visible, and uncertainty-constraining
+- Partial: structured and sourced, but still too background-first or too bibliography-level in traceability
+- Fail: polished report shape with weak judgment visibility or inflated certainty behind key claims

--- a/evals/cases/cnooc-judgment-shape-improved-but-freshness-still-leaked-case.md
+++ b/evals/cases/cnooc-judgment-shape-improved-but-freshness-still-leaked-case.md
@@ -1,0 +1,336 @@
+# Eval: CNOOC Judgment Shape Improved but Freshness Still Leaked Case
+
+## Goal
+
+Test whether a listed-company / investment-style report can visibly improve its judgment-memo shape and still fail because the freshness hard gate remains unstable.
+
+This eval is based on a real user-provided report about **CNOOC / China National Offshore Oil Corporation (600938.SH / 00883.HK)** dated **2026-04-16**.
+
+The report is valuable because it is **not** a simple repeat of older failure patterns.
+
+Unlike weaker earlier cases, this report already showed meaningful progress:
+- research-anchor block present
+- one-sentence thesis present
+- support / weakening / unresolved structure present
+- key risks and key unknowns visible early
+- output shape much closer to a judgment memo than to a company overview
+
+But despite that progress, the report still leaked on a critical front-end burden:
+- the research-anchor block listed **Q1 2025** as the "latest quarterly period" in a report dated **2026-04-16**
+
+That means the report improved at the judgment-shape layer while still failing at the freshness hard-gate layer.
+
+This makes the case especially useful because it captures a more advanced failure mode:
+
+> **the report is no longer broadly route-wrong, but a stale anchor still breaks memo integrity after route execution has already improved**
+
+---
+
+## Prompt context
+
+The underlying task was to use deep-research in a listed-company / investment-style judgment-memo style and produce a short Chinese memo-shaped report rather than a broad company overview.
+
+The intended validation burden included:
+- research-anchor block
+- one-sentence thesis
+- strongest support
+- strongest weakening evidence
+- key unresolved variable
+- what would change the conclusion
+- body-level auditability for thesis-bearing claims
+- early support / weakening / unresolved visibility
+
+This eval is therefore not testing whether the route was selected at all.
+It is testing whether a partly successful route execution can still be invalidated by stale current-state control.
+
+---
+
+## Real failure pattern
+
+The report did several things better than older listed-company failures:
+- it opened with a judgment-oriented shape
+- it made support / weakening / unresolved visible early
+- it identified a real load-bearing unresolved variable around FCF, capex, payout, and oil-price range
+- it did not collapse entirely into a company profile
+
+But the report still contained a critical time-anchor inconsistency:
+- report date: **2026-04-16**
+- latest full-year period: **FY2025**
+- latest quarterly period stated: **Q1 2025**
+
+That quarterly anchor is very likely stale or mis-timed for the stated report date.
+
+This matters because the problem is not only factual sloppiness. It changes the memo burden itself:
+- a report that looks current and judgment-oriented may still be carrying an outdated quarterly layer
+- the user may trust the memo more precisely because the structure now looks more disciplined
+- stale-anchor errors become more dangerous, not less, once the artifact shape becomes more convincing
+
+---
+
+## What this eval is testing
+
+### Failure Mode 1: route execution improved, freshness gate still unstable
+
+The report visibly carries more of the listed-company judgment burden than earlier weak outputs.
+
+But the current-state gate still leaks at the research-anchor layer.
+
+This should be treated as a distinct failure pattern from:
+- generic company-overview drift
+- total route miss
+- broad source weakness
+
+The route is partly right. The gate still fails.
+
+### Failure Mode 2: stale anchor inside an otherwise improved memo shape
+
+This case is stronger than a generic stale-data case because the stale anchor appears inside a report that already looks much closer to the desired output form.
+
+That means the failure is no longer:
+- `the report never became a judgment memo`
+
+It is now:
+- `the report became more memo-like, but the memo is still not safe to trust because the opening anchor is unstable`
+
+### Failure Mode 3: execution-family upgrade without stability upgrade
+
+This case checks whether repo hardening is improving only the visible artifact shape or also the underlying execution stability.
+
+A report can improve on:
+- opening structure
+- triad visibility
+- thesis compression
+- uncertainty framing
+
+while still failing the harder question:
+- are the latest time layers truly governing the memo?
+
+### Failure Mode 4: stronger shape can hide freshness failure better
+
+When a report is obviously weak, stale anchors are easier to distrust.
+
+When a report looks disciplined, the same stale anchor becomes easier for both the model and the reader to miss.
+
+This means freshness hard-gate failures become higher priority once judgment-memo shape begins to improve.
+
+---
+
+## What the report handled well
+
+The report deserves credit for visible progress in several areas:
+
+### 1. Judgment-first opening improved
+
+The opening contained:
+- research-anchor block
+- one-sentence thesis
+- executive summary
+- key risks
+- key unknowns
+- what matters most now
+
+This is meaningfully better than a business-background-first opening.
+
+### 2. Support / weakening / unresolved structure visibly activated
+
+The report included:
+- main evidence supporting the thesis
+- main evidence weakening the thesis
+- key unresolved variable
+
+This is direct progress on the listed-company judgment-memo burden.
+
+### 3. Unknowns were more load-bearing than in weaker past reports
+
+The unresolved variable focused on whether free cash flow in a moderate oil-price band could simultaneously support:
+- high capex
+- production growth
+- 45% payout ratio
+
+That is a real judgment-limiting unknown, not decorative uncertainty.
+
+### 4. The thesis was more calibrated than a generic positive company summary
+
+The report did not simply frame CNOOC as a clean growth story.
+It attempted to place the company as a:
+- low-cost
+- high-dividend
+- production-growth-assisted defensive asset
+
+with explicit oil-price and cash-flow constraints.
+
+These strengths matter because they prove the route is no longer failing at the most obvious level.
+
+---
+
+## What still failed
+
+### 1. Research-anchor integrity failed at the quarterly layer
+
+The most important visible failure was the quarterly anchor:
+- report date: 2026-04-16
+- latest quarter stated: Q1 2025
+
+For a listed-company memo, this should trigger a hard freshness re-check before synthesis continues.
+
+### 2. Current-state control was present in form, but not stable in execution
+
+The report showed the artifact of current-state discipline:
+- a research-anchor block exists
+
+But the content inside that block was not stable enough.
+
+This means the problem is not only:
+- missing shape
+
+It is:
+- unstable execution of an already-correct shape
+
+### 3. Thesis-bearing claims still remained only partly auditable
+
+Even though the report improved in structure, several high-burden claims still sounded stronger than their body-level auditability fully justified.
+
+Examples include:
+- first-tier global cost competitiveness
+- A-share market pricing having already priced in `defense + repair + energy-security premium`
+- oil-price sensitivity framing
+- FCF stress conclusions under lower oil-price bands
+
+These may be directionally plausible, but the case still shows that a better opening does not automatically solve thesis-bearing claim auditability.
+
+### 4. Conclusion-constraint improved, but not all the way to full stability
+
+The unresolved variable did visibly constrain the memo more than in weaker earlier reports.
+
+But the report still leaned toward:
+- a relatively strong defensive-asset frame
+
+without fully forcing the reader to downgrade:
+- valuation confidence
+- pricing confidence
+- or recommendation strength
+
+as sharply as the unresolved oil-price / FCF / payout interaction arguably required.
+
+---
+
+## Why this eval matters
+
+This case is important because it prevents a common false conclusion:
+
+> `the listed-company problem is now basically solved because the opening shape looks much better`
+
+That is too optimistic.
+
+This case shows a more realistic state of progress:
+- judgment-memo shape has improved
+- early triad structure has improved
+- route visibility has improved
+- but freshness hard-gate stability is still not reliable enough
+
+In other words:
+- the project has likely improved **artifact shape** faster than **execution stability**
+
+That is exactly the kind of distinction a mature eval system should capture.
+
+---
+
+## Pass criteria
+
+A good answer should:
+
+1. preserve the improved judgment-memo opening
+   - research anchors
+   - one-sentence thesis
+   - support / weakening / unresolved early
+
+2. make the freshness gate truly binding
+   - if the report date materially post-dates the allegedly latest quarter, stop and re-check
+   - do not continue with a stale quarter inside the anchor block
+
+3. keep the improved memo shape without letting that shape mask stale current-state control
+
+4. make thesis-bearing claims auditable enough that stronger shape does not create false trust
+
+5. let the key unresolved variable visibly narrow conclusion strength rather than merely sounding prudent
+
+---
+
+## Failure signs
+
+Mark this eval as failed if the answer does several of the following:
+
+- the opening looks materially better than older reports, but the anchor block still contains stale or mis-timed periods
+- the report appears current because it has a research-anchor section, but the time layers are not actually trustworthy
+- the memo shape improves, but the model still writes through a freshness inconsistency instead of stopping
+- better structure makes it easier to miss that the memo is anchored incorrectly
+- thesis-bearing claims remain only partly body-auditable even though the report looks more disciplined overall
+
+---
+
+## Suggested diagnosis
+
+The primary diagnosis for this case is:
+
+- **Anchor-governance failure** inside an otherwise improved listed-company judgment-memo execution
+
+Secondary diagnoses may include:
+- **Thesis-audit failure**
+- **Conclusion-constraint failure**
+
+But the defining lesson is that this is **not mainly a judgment-shape miss**.
+
+That is what makes it a useful second-stage case.
+
+---
+
+## Suggested intervention targets
+
+This case should push attention toward:
+
+- `checklists/listed-company-report.md`
+- `checklists/final-audit.md`
+- `references/finance-date-discipline.md`
+- `SKILL.md` listed-company current-state gate wording
+- route-execution contracts that explicitly state: stale research anchors invalidate the memo even if the structure is otherwise good
+
+This case should **not** be treated as evidence that the route hardening failed entirely.
+Instead, it shows the next bottleneck after route-shape improvement.
+
+---
+
+## Reviewer checklist
+
+- Did the report improve its opening shape relative to older weak company reports?
+- Did the report visibly show support / weakening / unresolved early?
+- Did the research-anchor block contain a stale or mis-timed quarter relative to the report date?
+- If yes, did the memo still continue as if the anchor were acceptable?
+- Did the improved structure make the stale anchor easier to overlook?
+- Are the most thesis-bearing claims fully body-auditable, or only more convincing in tone?
+- Does the unresolved variable actually narrow the conclusion enough?
+
+---
+
+## Suggested scoring
+
+- **Pass:** improved judgment-memo shape with stable current-state anchor control
+- **Partial:** judgment shape improved, but freshness or thesis-audit stability still leaks
+- **Fail:** polished memo-looking artifact still anchored on stale time layers or unstable current-state control
+
+---
+
+## Why this case belongs in the repo
+
+This case captures a project transition point.
+
+Earlier listed-company cases mostly showed:
+- route-family under-execution
+- background-first drift
+- weak judgment compression
+
+This case shows a newer, more mature problem:
+- the report is closer to the right shape
+- the route is more visible
+- but the execution is still not stable enough to trust the memo fully
+
+That is exactly the kind of case a stronger repo should preserve, because it marks where the next real bottleneck now lives.

--- a/evals/comparative-distillation/china-shenhua-minimax-vs-reference-grade-company-memo-distillation.md
+++ b/evals/comparative-distillation/china-shenhua-minimax-vs-reference-grade-company-memo-distillation.md
@@ -1,0 +1,307 @@
+# China Shenhua MiniMax vs Reference-Grade Company Memo Distillation
+
+## Case identity
+
+- **Case name:** China Shenhua listed-company judgment-visibility comparative distillation
+- **Date:** 2026-04-16
+- **Research question:** What reusable repo changes should be extracted from a user-provided MiniMax China Shenhua report when compared against a reference-grade target artifact shaped by the current deep-research rules?
+- **Why this comparison matters:** The MiniMax report is not a bad report. It is strong enough to pass as a polished company brief, which makes it a good stress case for whether the repo can force a true investment-style judgment memo rather than a structured overview.
+- **Report A:** User-provided MiniMax PDF report on China Shenhua dated 2026-04-16
+- **Report B:** Reference-grade rewrite target based on the current listed-company route, existing templates, and the newly hardened judgment-visibility rules
+- **Reference / stronger report (if any):** Report B is not a second model output. It is a rule-conformant target artifact contract that represents what a passing rewrite should look like.
+- **Prompt(s):** Research China Shenhua in the style of deep-research; cover business, industry position, customers, competitors, last-two-year financial signals, bull/bear logic, and 1-3 year opportunities / risks; distinguish confirmed facts, inference, and uncertainty; produce a Chinese structured report and PDF.
+- **Important scope or timing differences:** This is a quasi-paired comparison. Report B is a reference-grade target rather than a separately generated full report. That means the comparison is useful for repo hardening, but not for model-leaderboard style judgments.
+
+---
+
+## Comparison purpose
+
+Use this comparison to identify which structural disciplines the current MiniMax China Shenhua report still misses even after visible evidence labels and a strong report skeleton are present.
+
+The purpose is not to say "MiniMax is worse." The purpose is to determine whether the remaining gap is:
+- a missing rule
+- a missing trigger
+- or execution drift despite existing rules
+
+This comparison is especially useful because the weaker artifact is already polished enough to hide its own remaining weaknesses.
+
+---
+
+## Dimension 1: Current-state discipline
+
+### Report A
+- The report visibly states a coverage range such as `2024 full year + 2025 full year + 2026 Q1 latest data`.
+- It signals awareness that freshness matters.
+- But the report still feels anchored by a broad company snapshot rather than by a clearly locked current thesis tied to the latest reporting layers.
+- The opening does not visibly force the reader to see: latest full-year / latest quarter / latest market snapshot / why those anchors drive the present judgment.
+
+### Report B
+- The opening would explicitly lock the research anchors before broad narrative expansion.
+- The first page would show the current thesis only after making the time layers visible.
+- Older but still useful numbers would be demoted to historical context rather than allowed to carry the opening burden.
+
+### Gap
+- Freshness awareness exists in Report A, but freshness execution is still too weakly operationalized in the opening structure.
+- The failure is less "stale data everywhere" and more "stale-anchor-like report shape still survives despite partial freshness signaling."
+
+### Candidate action
+- Strengthen the listed-company route so the opening must contain a compact research-anchor block and current-thesis block before business-profile expansion.
+
+### Action type
+- `TEMPLATE_CHANGE`
+
+---
+
+## Dimension 2: Numerical and date discipline
+
+### Report A
+- The report includes many concrete numbers and time references.
+- However, several important figures still blur categories such as:
+  - reported historical fact
+  - current market snapshot
+  - projected or scenario-like expectation
+  - derived or comparative claim
+- A/H share, dividend-yield, industry ranking, and price-level statements risk being read as one unified fact layer.
+
+### Report B
+- A passing artifact would make time layering and number-role layering more explicit.
+- Load-bearing numbers would visibly show whether they are:
+  - filing fact
+  - current market snapshot with date
+  - analyst or scenario expectation
+  - inferred comparison
+- Multi-venue numbers such as A-share vs H-share framing would be kept explicitly separated when they affect interpretation.
+
+### Gap
+- Report A has many real numbers, but some of the most important numbers still do too much rhetorical work without enough metric-role clarity.
+
+### Candidate action
+- Add a listed-company audit rule requiring explicit separation when A-share / H-share / current-yield / historical-distribution / scenario-price statements are used in one memo.
+
+### Action type
+- `CHECKLIST_HARDENING`
+
+---
+
+## Dimension 3: Source traceability and evidence weighting
+
+### Report A
+- The report uses visible evidence buckets such as confirmed facts / inference / open uncertainty.
+- But several load-bearing claims still remain bibliography-level rather than claim-level in auditability.
+- Strong-sounding statements about transport-cost advantage, volatility sensitivity, dividend superiority, and growth impact from asset injection do not visibly tell the reader:
+  - what source supports the exact claim
+  - whether the claim is direct or inferred
+  - whether the wording was downgraded when support was indirect
+
+### Report B
+- The stronger reference artifact would make the load-bearing claims auditable in the body.
+- It would not rely on confidence labels alone.
+- At minimum, the body would reveal source role and evidence weight for the specific claims doing the most bottom-line work.
+
+### Gap
+- Report A shows confidence-label discipline, but not yet true claim-audit discipline.
+- The failure is not absence of sources in the broad sense; it is a lack of visible linkage between key conclusion-bearing claims and the exact evidence role behind them.
+
+### Candidate action
+- Promote a stronger claim-traceability rule for listed-company reports: if a claim materially supports the thesis, it must be auditable in the body, not only implied by a source list or section bibliography.
+
+### Action type
+- `CHECKLIST_HARDENING`
+
+---
+
+## Dimension 4: Forward-looking claim discipline
+
+### Report A
+- The report does not collapse into reckless hype.
+- But it still tends to compress these layers too smoothly:
+  - confirmed transaction completion
+  - likely operating implication
+  - medium-term growth implication
+  - scenario-like commodity price support
+- This creates a "polite certainty inflation" problem rather than an obvious hallucination problem.
+
+### Report B
+- A stronger rewrite would force a three-way split whenever corporate action or forward scenario language becomes load-bearing:
+  - confirmed facts
+  - likely implications
+  - unresolved timing / realization / quality uncertainty
+- Forward-looking commodity-price or dividend-defense language would carry more explicit source role and downgrade conditions.
+
+### Gap
+- Report A is disciplined enough to avoid cartoonish overclaiming, but still too smooth in translating real events into thesis support.
+
+### Candidate action
+- Add a reusable corporate-action compression guard covering asset injection, financing completion, restructuring, and similar event-to-thesis jumps.
+
+### Action type
+- `NEW_RULE`
+
+---
+
+## Dimension 5: Structural readability and information density
+
+### Report A
+- The report is organized and readable.
+- It has the look of a serious report.
+- But the front page still behaves more like a mixed report opening than a judgment-first memo opening.
+- Evidence labels and process visibility compete with thesis visibility.
+
+### Report B
+- The stronger target artifact would keep methodology compact and subordinate.
+- The first page would make the reader see, within seconds:
+  - core thesis
+  - key risks
+  - key unknowns
+  - why the current view is not fully precise
+- The layout would feel like a decision memo first, not a report shell with judgment embedded inside it.
+
+### Gap
+- The main problem is not ugly formatting or density overload. It is that report readability still serves explanation better than judgment.
+
+### Candidate action
+- Tighten the report-template front-page rule so evidence legends and process notes cannot dominate the first scan when the route carries investment-style judgment burden.
+
+### Action type
+- `TEMPLATE_CHANGE`
+
+---
+
+## Dimension 6: Decision usefulness
+
+### Report A
+- The report is useful as a structured orientation to China Shenhua.
+- It identifies many true or plausible factors relevant to an investor-style view.
+- But it still underperforms as a current judgment memo because it does not compress clearly enough around:
+  - strongest support
+  - strongest weakening evidence
+  - key unresolved variable
+  - downgrade boundary
+  - what would change the conclusion
+
+### Report B
+- A passing reference artifact would visibly separate:
+  - what supports the thesis now
+  - what weakens it now
+  - what remains unresolved and therefore narrows the conclusion
+- Risks would not sit as ornamental caution. They would visibly constrain confidence, timing precision, or valuation precision.
+
+### Gap
+- Report A is stronger as a company understanding artifact than as a decision-grade company memo.
+- This is now a recurring failure family, not a one-off China Shenhua quirk.
+
+### Candidate action
+- Harden the decision-report template and listed-company checklist around a mandatory support / weakening / unresolved split in the early report structure.
+
+### Action type
+- `TEMPLATE_CHANGE`
+
+---
+
+## Candidate-action summary
+
+| # | Candidate action | Failure family | Action type | Proposed home |
+|---|---|---|---|---|
+| 1 | Require research-anchor block before broad company narrative | current-state / opening-shape discipline | `TEMPLATE_CHANGE` | `references/decision-report-template.md` |
+| 2 | Separate multi-venue and market-snapshot number roles more explicitly | numerical / date discipline | `CHECKLIST_HARDENING` | `checklists/listed-company-report.md` |
+| 3 | Require body-level auditability for thesis-bearing claims | source traceability / evidence weighting | `CHECKLIST_HARDENING` | `checklists/final-audit.md` + `checklists/listed-company-report.md` |
+| 4 | Add corporate-action compression guard | forward-looking / event-to-thesis inflation | `NEW_RULE` | `references/decision-report-template.md` or `references/finance-date-discipline.md` |
+| 5 | Tighten front-page judgment visibility under investment-style route | output structure / information density | `TEMPLATE_CHANGE` | `references/report-template.md` |
+| 6 | Require early support / weakening / unresolved split | decision usefulness / judgment visibility | `TEMPLATE_CHANGE` | `references/decision-report-template.md` + `checklists/listed-company-report.md` |
+
+---
+
+## Triage notes
+
+### Candidate 1
+- **Why it matters:** Listed-company reports can appear current while still being structurally anchored on background rather than on the true latest decision-relevant layers.
+- **Why it is reusable:** This applies to many equity-style memos, especially when the model already has enough data to sound current.
+- **Why this home is best:** The problem is mainly opening-shape execution, so the decision-report template is the right first home.
+- **Promotion status:** `PROMOTE_NOW`
+
+### Candidate 2
+- **Why it matters:** A/H share, yield, market cap, and current-price framing can quietly blur number roles and venue distinctions in China-listed-company work.
+- **Why it is reusable:** This is broader than China Shenhua; it applies to dual-listed and multi-venue company reports generally.
+- **Why this home is best:** This belongs in the route-specific checklist because it is a recurrent audit issue, not just phrasing guidance.
+- **Promotion status:** `PROMOTE_NOW`
+
+### Candidate 3
+- **Why it matters:** A source list is not enough when the bottom-line thesis depends on a handful of strong comparative claims.
+- **Why it is reusable:** This is a recurring failure family across Cambricon, AMD-style company reports, and now China Shenhua.
+- **Why this home is best:** Final audit + listed-company checklist together catch both general and route-specific forms of the failure.
+- **Promotion status:** `PROMOTE_NOW`
+
+### Candidate 4
+- **Why it matters:** Corporate actions are especially prone to over-smooth narrative inflation because the facts are real but the implications are only partly known.
+- **Why it is reusable:** Applies to M&A, asset injection, financing, restructuring, and strategic investment cases across listed-company research.
+- **Why this home is best:** This is fundamentally a reasoning-shape and interpretation rule, so it belongs in the decision template or finance-date discipline rather than only a checklist.
+- **Promotion status:** `PROMOTE_NOW`
+
+### Candidate 5
+- **Why it matters:** If the thesis is hard to see on the first page, the memo will keep reading as a report-shaped overview even when the logic is decent.
+- **Why it is reusable:** Front-page judgment visibility is a cross-case weakness already seen in company and PDF-heavy outputs.
+- **Why this home is best:** Report-template front-page discipline is the natural place to keep this pressure always visible.
+- **Promotion status:** `PROMOTE_NOW`
+
+### Candidate 6
+- **Why it matters:** Decorative caveats do not improve decision usefulness unless they visibly narrow the conclusion.
+- **Why it is reusable:** This repeats the broader unknown-to-conclusion linkage problem, but in a more memo-structural listed-company form.
+- **Why this home is best:** It needs both template pressure and checklist enforcement.
+- **Promotion status:** `PROMOTE_NOW`
+
+---
+
+## Things explicitly rejected
+
+| Observation | Why rejected |
+|---|---|
+| "The report is already good enough, so no repo change is needed." | Too impressionistic; this case is useful precisely because polished overview quality can hide real memo-grade weaknesses |
+| "This should become a separate China coal research route." | Too case-specific; the better abstraction is listed-company judgment visibility, not a sector-specific route |
+| "Evidence labels should be removed because they did not solve the problem." | Wrong lesson; the issue is weak execution and weighting, not that evidence labels themselves are useless |
+| "This proves MiniMax cannot do company reports." | Not auditable and not repo-useful; the right output is discipline hardening, not model tribalism |
+
+---
+
+## Final judgment
+
+### What the stronger report did better
+The reference-grade target does not merely add fresher data or more sources. It changes the artifact shape:
+- thesis first
+- time anchors early
+- support / weakening / unresolved split visible
+- claim-level auditability for load-bearing points
+- corporate-action facts separated from their uncertain implications
+
+### What should change in the repo now
+The repo should harden:
+1. early research-anchor visibility for listed-company work
+2. multi-venue and number-role separation in listed-company audits
+3. body-level auditability for thesis-bearing claims
+4. corporate-action compression guard
+5. front-page judgment visibility
+6. early support / weakening / unresolved split
+
+### What should wait for another confirming case
+- a dedicated new sub-route for corporate-action-heavy company memos
+- any fully separate dual-listed-company route
+- any sector-specific energy / coal research discipline
+
+### Is this mainly a missing rule, missing trigger, or execution problem?
+Mainly an **execution problem**, secondarily a **template / checklist hardness problem**, and only weakly a missing-rule problem.
+
+The core rules already existed in rough form, but this case shows they were not yet strong enough to force the right artifact shape.
+
+---
+
+## Minimal quality bar
+
+Before finalizing this file, check:
+
+- [x] the two reports are comparable enough to justify distillation
+- [x] the comparison used the six fixed dimensions
+- [x] each accepted candidate has an action type
+- [x] each accepted candidate has a proposed repo home
+- [x] at least one rejected observation is documented when relevant
+- [x] the final judgment distinguishes rule gap vs trigger gap vs execution gap
+
+This file is intended as a repo-hardening distillation artifact, not as a benchmark verdict on models.

--- a/evals/meta/listed-company-judgment-memo-execution-family.md
+++ b/evals/meta/listed-company-judgment-memo-execution-family.md
@@ -1,0 +1,339 @@
+# Eval: Listed-Company Judgment-Memo Execution Family
+
+Use this meta-eval when a listed-company / investment-style report looks researched, structured, and even evidence-aware, but still falls short of a true judgment memo.
+
+This file exists to capture a recurring execution family seen across multiple real cases, including:
+- Intel freshness hard-gate failure
+- AMD MiniMax equity-style distillation
+- China Shenhua judgment-visibility and traceability failure
+
+The point is not that these reports were all bad in the same way. The point is that they repeatedly failed at the same deeper burden:
+
+> **turning a company-research artifact into a real current judgment memo rather than a polished overview with evidence features attached**
+
+---
+
+## Goal
+
+Distinguish between:
+
+1. a company report that is broadly informed and structured
+2. a company report that actually carries the judgment burden of the listed-company route
+
+This meta-eval helps prevent the project from misdiagnosing these cases as:
+- mere freshness misses
+- mere citation misses
+- mere output-format issues
+- or a need for a fully separate equity route
+
+In many cases, the deeper issue is that the route is broadly right, but its highest-value execution burden is still not being carried consistently.
+
+---
+
+## Core diagnosis
+
+This execution family typically appears when the report shows several signs of improvement at once:
+- current-state awareness
+- visible evidence buckets
+- source lists or structured sourcing
+- readable formatting
+- plausible financial and company detail
+
+But still fails on one or more of these higher-order burdens:
+- the opening behaves like a company profile rather than a judgment memo
+- freshness is acknowledged, but the opening thesis is not truly anchored on the newest reporting layers
+- load-bearing claims are sourced in spirit, but not auditable at the exact body-claim level
+- uncertainty is disclosed, but does not visibly narrow conclusion strength or precision
+- corporate actions are real, but their implications are narrated too smoothly
+- support / weakening / unresolved are not visible early enough to shape the reader's interpretation
+
+That is why these cases can look "much better than before" while still not yet being decision-grade.
+
+---
+
+## Stable failure family
+
+### Failure Mode 1: overview-shape persistence
+
+The report still behaves like:
+- a company overview
+- a strategic profile
+- a structured briefing
+- a business-summary artifact
+
+rather than a judgment memo.
+
+Typical signs:
+- business background arrives before the current thesis is truly visible
+- the opening could fit many route types, not just listed-company judgment work
+- the reader learns a lot about the company before learning the report's actual current judgment
+
+### Failure Mode 2: anchor-shape failure rather than total freshness failure
+
+The report may mention current periods, but the artifact shape is still not controlled by the latest time layers.
+
+Typical signs:
+- the report date is later than the allegedly latest figures used
+- market snapshot is present somewhere, but not structurally early enough to anchor the memo
+- older but polished snapshots quietly control the opening narrative
+
+This is not always a pure data miss. Sometimes it is a **shape miss**:
+- freshness knowledge exists
+- but freshness does not govern the opening burden
+
+### Failure Mode 3: bibliography-level traceability instead of thesis-bearing auditability
+
+The report may include:
+- a source list
+- source buckets
+- evidence labels
+- some inline support
+
+But the key 3-5 sentences doing the most thesis work are still not clearly defendable in the body.
+
+Typical signs:
+- strong comparative claims exist, but only generic section bibliography is visible
+- reader cannot tell whether a crucial claim is direct evidence or inference
+- the report sounds sourced, but the bottom line remains hard to audit sentence-by-sentence
+
+### Failure Mode 4: cosmetic uncertainty or insufficient downgrade
+
+The report names unknowns, but the bottom line still sounds too strong.
+
+Typical signs:
+- uncertainty is present in a dedicated section but does not narrow recommendation strength
+- the report is directionally careful, but still too precise on timing, valuation, or upside framing
+- the key unresolved variable is not promoted into the opening structure
+
+### Failure Mode 5: corporate-action thesis inflation
+
+A real corporate action silently upgrades a still-conditional thesis.
+
+Typical signs:
+- asset injection becomes growth certainty
+- financing completion becomes rerating logic
+- restructuring becomes margin certainty
+- approvals or registrations become realized capacity impact
+
+The transaction fact is real, but the economic meaning remains partly conditional.
+
+### Failure Mode 6: support / weakening / unresolved split appears too late or too softly
+
+The report may contain all three in some form, but not in a way that visibly governs the memo.
+
+Typical signs:
+- support dominates the opening
+- weakening evidence appears later as balance commentary
+- unresolved variables remain in risks or caveats instead of narrowing the early judgment
+
+This produces a report that feels fair-minded, but still reads bullish-by-default or overview-first.
+
+---
+
+## What this meta-eval is testing
+
+### 1. Route-family burden
+
+The hardest recurring burden in listed-company judgment memos is not merely:
+- having numbers
+- having sources
+- having risks
+- having a market snapshot
+
+It is:
+- **compressing the report around a current thesis**
+- **making the thesis auditable where it matters most**
+- **making weakening evidence and unresolved variables visible early enough to constrain interpretation**
+
+### 2. Execution-family stability
+
+This meta-eval asks whether the repo has reached stable execution for listed-company judgment work, not just case-by-case patches.
+
+A report can pass broad quality checks and still fail if it repeatedly leaks at the same high-value pressure points.
+
+### 3. Rule-activation realism
+
+This meta-eval also checks whether:
+- the right route was selected
+- the right checklist/reference families likely fired
+- their effects became visible in the final artifact
+
+It is therefore closely related to:
+- `route-specific-micro-audits.md`
+- `unknown-to-conclusion-linkage.md`
+- `rule-activation-and-execution-discipline.md`
+
+But it is more specific to **listed-company / equity-style judgment memo execution**.
+
+---
+
+## Pass criteria
+
+A good report should:
+
+1. **open as a judgment memo, not a profile**
+   - thesis visible early
+   - latest research anchors visible early
+   - strongest weakening evidence visible early
+   - key unresolved variable visible early
+
+2. **make thesis-bearing claims auditable in the body**
+   - not just through a bibliography
+   - not just through evidence labels
+   - not just through a well-sourced appendix
+
+3. **let current-state anchors control the memo shape**
+   - latest full-year, latest quarter/interim, latest market snapshot
+   - older numbers clearly demoted when needed
+
+4. **separate fact from implication from uncertainty in corporate-action cases**
+   - especially for financing, M&A, restructuring, asset injection, major approvals
+
+5. **make uncertainty change the conclusion**
+   - if unresolved variable is load-bearing, it narrows confidence / timing / valuation / recommendation strength
+
+6. **keep support / weakening / unresolved visible in the opening burden**
+   - not only later in separate sections
+
+---
+
+## Failure signs
+
+Mark this meta-eval as failed if a listed-company report does several of the following at once:
+
+- the opening still reads like a company summary with judgment added later
+- current-state anchors exist but do not visibly govern the report's first 20-30%
+- the report has source discipline in broad form, but the most thesis-bearing sentences remain hard to audit
+- unknowns exist, but do not downgrade the actual conclusion enough
+- risks are visible, but weakening evidence is not structurally early
+- corporate actions are described in a way that overstates implication certainty
+- a skeptical reviewer could still say: `this is a strong overview, but not yet a decision-grade listed-company memo`
+
+---
+
+## Case linkage
+
+### Intel case contribution
+
+The Intel case shows that a listed-company report can fail before any deeper memo-quality issue is even assessed, because stale or mis-timed anchors distort the whole memo.
+
+What it contributed to this family:
+- freshness is a front-end judgment problem, not just a data problem
+- opening-anchor control matters
+- older but plausible snapshots can silently become the whole memo's current baseline
+
+### AMD case contribution
+
+The AMD case shows that once the report becomes evidence-aware, the next failure layer is not missing structure but insufficient judgment compression.
+
+What it contributed to this family:
+- evidence labels can activate without solving memo-grade usefulness
+- unknowns need to constrain conclusion scope
+- company reports can remain explanation-centered even when sourced and organized
+
+### China Shenhua case contribution
+
+The China Shenhua case shows the more mature version of the family:
+- front page looks serious
+- confidence labels exist
+- report looks polished
+- but claim auditability, front-page judgment visibility, corporate-action separation, and early triad execution still leak
+
+What it contributed to this family:
+- bibliography-level traceability is not enough
+- corporate-action compression is a distinct listed-company failure mode
+- support / weakening / unresolved must be made early and visible, not merely present
+
+---
+
+## Diagnosis guide
+
+When using this meta-eval, classify the failure primarily as one of:
+
+### A. Anchor-governance failure
+The report did not let current reporting layers govern the memo shape.
+
+### B. Judgment-shape failure
+The report still reads like a profile or overview rather than a memo.
+
+### C. Thesis-audit failure
+The key thesis-bearing claims are not body-auditable enough.
+
+### D. Conclusion-constraint failure
+Unknowns or weakening evidence do not constrain the final judgment enough.
+
+### E. Mixed execution-family failure
+Several of the above happen together.
+
+Most real cases in this family will be **D or E**, with some A/B/C mix.
+
+---
+
+## Best next fixes
+
+Use this meta-eval to decide what kind of repo change is most justified.
+
+### Use `reference` changes when:
+- the model needs a stronger artifact concept
+- the report shape drifts even when some rules are known
+- the opening burden is under-specified
+
+### Use `checklist` hardening when:
+- the failure is already known and should now be a pre-delivery gate
+- the issue is repeated often enough to justify explicit fail conditions
+
+### Use `route-matrix` or route-specific changes when:
+- the route-family burden itself is under-specified
+- the visible artifact contract is still too generic
+
+### Use `meta eval` only when:
+- the same execution family keeps reappearing across multiple concrete cases
+- the project needs a named diagnosis layer above the individual case files
+
+---
+
+## Reviewer questions
+
+When applying this meta-eval, ask:
+
+- Does the opening behave like a current judgment memo or a polished company profile?
+- Could the first page still survive if a skeptical reader asked: `what is the thesis, what weakens it most, and what remains unresolved?`
+- Are the 3-5 most thesis-bearing sentences defendable in the body without hidden notes?
+- Did current-state anchors govern the memo, or merely appear somewhere in it?
+- Do unknowns visibly reduce what the report is willing to conclude?
+- Are corporate actions narrated as facts, or as facts plus conditional implications?
+- If the background were shortened by 30-40%, would the report become clearer rather than weaker?
+
+---
+
+## Output format for reviewers
+
+When you apply this meta-eval, summarize the result as:
+
+- **Primary listed-company burden:**
+- **What the report handled well:**
+- **Where the family failure still leaked:**
+- **Most thesis-bearing weak point:**
+- **Diagnosis:** anchor-governance failure / judgment-shape failure / thesis-audit failure / conclusion-constraint failure / mixed execution-family failure
+- **Best next fix:** template hardening / checklist hardening / route-matrix hardening / new case-eval / no repo change
+
+---
+
+## Why this meta-eval exists
+
+This project is now past the stage where every weak listed-company report fails for the same obvious reason.
+
+The more common modern failure is subtler:
+- the report looks much more disciplined than older outputs
+- many important rules are partially activated
+- but the final artifact still does not reliably behave like a decision-grade company memo
+
+This meta-eval exists so that those cases are not dismissed as:
+- `basically fine`
+- `just needs a few more citations`
+- `just a freshness issue`
+- `just a formatting preference`
+
+Instead, they can be recognized for what they are:
+
+> a stable execution-family problem in listed-company judgment-memo delivery

--- a/examples/china-shenhua-reference-grade-rewrite-skeleton.md
+++ b/examples/china-shenhua-reference-grade-rewrite-skeleton.md
@@ -1,0 +1,410 @@
+# China Shenhua Reference-Grade Rewrite Skeleton
+
+Use this example when you need a **reference-grade listed-company / investment-style memo shape** rather than a polished company overview.
+
+This is not a full report. It is a skeleton that shows what a passing rewrite should look like for a case like **China Shenhua (601088 / 01088.HK)**.
+
+It is especially useful after the following failure families have already been observed:
+- stale or weakly-governing freshness anchors
+- bibliography-level rather than thesis-bearing traceability
+- corporate-action thesis inflation
+- support / weakening / unresolved split appearing too late
+- front-page judgment visibility losing to methodology or background
+
+---
+
+## Example task
+
+Research China Shenhua in Chinese as a listed-company / investment-style memo.
+
+Cover at least:
+- business and products
+- industry position
+- customers and use cases
+- key competitors
+- last two years of operating and financial signals
+- bull logic
+- bear logic
+- opportunities and risks over the next 1-3 years
+
+The report should use multiple sources, distinguish confirmed facts / inference / open uncertainty, and be suitable for PDF delivery.
+
+---
+
+## Expected route
+
+Primary route:
+- listed-company / investment-style judgment memo
+
+Expected secondary disciplines:
+- current-state verification
+- finance date discipline
+- source traceability and claim citation
+- corporate-action compression guard
+- unknown-to-conclusion linkage
+- front-page judgment visibility
+
+---
+
+## Expected visible artifact contract
+
+A passing report for this case should make the following visible early:
+
+- current thesis
+- latest research anchors
+- strongest confirmed support
+- strongest current weakening evidence
+- key unresolved variable
+- what would change the conclusion
+- support / weakening / unresolved split
+- body-level auditability for thesis-bearing claims
+- separation of transaction fact vs implication vs uncertainty when corporate action matters
+
+If the artifact still reads first as a company profile, the route has not been executed strongly enough.
+
+---
+
+## Front-page shape
+
+A strong first page for this case should usually look like:
+
+1. title
+2. report date
+3. coverage and research-anchor block
+4. one-sentence thesis
+5. 4-6 executive bullets
+6. key risks
+7. key unknowns
+8. compact evidence legend
+
+Do **not** let the first page be dominated by:
+- long evidence methodology notes
+- background company description
+- segment or business tables before the thesis is clear
+- a decorative executive summary that is mostly factual backdrop
+
+---
+
+## Minimal output shape
+
+### 1. Title and report identity
+
+Example:
+- `中国神华（601088.SH / 01088.HK）投资风格研究备忘录`
+- `报告日期：YYYY-MM-DD`
+- `研究类型：Listed Company / Investment-Style Memo`
+
+### 2. Research-anchor block
+
+This block should appear before broad analysis.
+
+Example pattern:
+
+- `最新完整年报期：2025FY（来源：年报 / 业绩公告）`
+- `最新季度期：2026Q1（来源：一季报 / 季度经营数据）`
+- `最新市场快照：YYYY-MM-DD 收盘价 / 市值 / PE / PB / 股息率口径`
+- `最新重要公司动作：资产注入 / 配套融资 / 批复状态（如与 thesis 相关）`
+
+This block exists to make current-state control visible.
+
+### 3. One-sentence thesis
+
+The thesis should be directional but calibrated.
+
+Example pattern:
+
+> `当前更接近“高现金流 + 高股息 + 一体化壁垒支撑的防御型煤炭龙头”，而不是一个可无条件外推的中期成长股；若煤价中枢、资产注入协同和资本开支约束未同步改善，估值与成长叙事都应保持克制。`
+
+Good thesis behavior:
+- contains a real judgment
+- names the rough type of opportunity
+- already contains a limiting condition
+
+Bad thesis behavior:
+- pure praise
+- business summary with no view
+- over-precise target-like wording without support
+
+### 4. Executive summary bullets
+
+Use 4-6 short bullets. One idea per bullet.
+
+Suggested pattern:
+- `[已确认事实]` strongest current support
+- `[已确认事实]` another load-bearing support
+- `[推断]` current weakening evidence or pressure
+- `[未知事项]` key unresolved variable
+- `[推断]` what would change the conclusion
+
+For this case, a good executive summary should already show:
+- why the company still looks defensible
+- why the memo is not simply bullish
+- which variable could most change the view
+
+### 5. Key risks and key unknowns block
+
+Do not bury this later.
+
+Suggested compact blocks:
+
+#### 关键风险
+- 煤价中枢继续弱于预期
+- 电价 / 利用小时继续承压
+- 资产注入后协同兑现慢于预期
+- 高分红与资本开支需求之间出现张力
+
+#### 关键未知
+- 注入资产对盈利质量的真实增厚幅度
+- 2026-2027 产能释放与整合节奏
+- 当前市场已计入多少股息防御与周期修复预期
+
+---
+
+## Core memo shape
+
+### 6. What matters most now
+
+This section should identify the few variables that actually determine the case.
+
+For China Shenhua-style work, useful candidates include:
+- 煤价中枢与长协结构的共同作用
+- 一体化成本与运输壁垒是否仍构成超额防御
+- 电力板块对煤价波动的对冲质量
+- 资产注入带来的真实经营增量 vs 叙事增量
+- 高股息能否维持且不以牺牲长期资本质量为代价
+
+This section should not become a mini company overview.
+
+### 7. Main evidence supporting the thesis
+
+Use a short, visibly thesis-linked structure.
+
+Suggested sub-pattern:
+
+#### 7.1 一体化壁垒仍是当前最强支撑
+- what is directly confirmed
+- which metrics support it
+- why it matters now
+- inline source ids for thesis-bearing claims
+
+#### 7.2 长协与现金流结构提高了防御性
+- direct evidence
+- source role
+- limitation if any
+
+#### 7.3 高股息 / 高现金回报仍对估值形成底部支撑
+- distinguish:
+  - reported payout facts
+  - current market yield snapshot
+  - inference about investor support
+
+Do not compress `high dividend` directly into `valuation is safe`.
+
+### 8. Main evidence weakening the thesis
+
+This section should feel real, not ceremonial.
+
+Suggested sub-pattern:
+
+#### 8.1 煤价与电价双重压力下，盈利弹性可能弱于表面防御性
+- direct reported weakness
+- what part is inference
+- what conclusion this weakens
+
+#### 8.2 公司仍高度依赖煤炭主业，成长叙事的质量不应被高股息掩盖
+- separate cyclic cash generation from durable growth quality
+
+#### 8.3 若市场已充分定价“防御 + 修复”，上行空间未必与叙事强度匹配
+- this may be partly inference; mark accordingly
+
+A good weakening section should visibly reduce conclusion strength.
+
+### 9. Key unresolved variable
+
+Promote one variable as the dominant unresolved issue.
+
+Example pattern:
+
+> `当前最关键未知，不是公司是否具备一体化壁垒，而是资产注入与后续资本配置能否把“规模扩张”转化为“高质量增厚”，而非只提供阶段性叙事弹性。`
+
+Then explain:
+- why this variable matters more than other risks
+- what it limits: timing? valuation precision? medium-term growth confidence?
+- what evidence would reduce the uncertainty
+
+### 10. What would change the conclusion
+
+This section is required.
+
+Example structure:
+
+#### 会让判断更积极的条件
+- stronger-than-expected price / cost / cash-flow resilience
+- clearer synergy realization from corporate actions
+- valuation remains undemanding even after defense narrative repricing
+
+#### 会让判断转弱的条件
+- coal-price weakness persists while market still prices repair
+- dividend support weakens under capex or integration pressure
+- power segment does not stabilize earnings as expected
+
+---
+
+## Detailed analysis sections
+
+Only after the judgment structure is visible should the report expand.
+
+### 11. Business and segment structure
+
+Keep concise. Focus only on the parts that sharpen the current thesis.
+
+Suggested scope:
+- coal
+- power
+- transport / port / shipping
+- coal chemical
+- other financial or ancillary businesses only if decision-relevant
+
+For each segment, avoid full encyclopedia style.
+Use:
+- current role in the thesis
+- what is confirmed
+- what remains secondary
+
+### 12. Industry position and competitive pressure
+
+Do not write this as a peer directory.
+
+Better shape:
+- what kind of position China Shenhua really has
+- who pressures the thesis now
+- which competitors matter for:
+  - cost comparison
+  - resource base comparison
+  - transport dependence
+  - earnings volatility comparison
+
+Make visible the difference between:
+- market leadership
+- moat
+- listed-market scarcity
+- regulatory or infrastructure control
+
+### 13. Customers and use cases
+
+Keep this short unless customer mix is load-bearing.
+
+The point is not to catalog customers. The point is to show:
+- what demand base is structurally sticky
+- what part is vulnerable to macro or policy shifts
+
+### 14. Last-two-years operating and financial signals
+
+This section should not be a dump of all numbers.
+
+Use a table if helpful, but always interpret it.
+
+Suggested grouping:
+- revenue / profit
+- cash flow
+- payout
+- coal volume / price
+- power volume / tariff / utilization
+- transport or logistics indicators if thesis-bearing
+
+Important: pair scale and profitability signals together when they diverge.
+
+### 15. Corporate-action analysis (required if asset injection / financing / restructuring matters)
+
+This section should explicitly use the three-way split:
+
+#### 15.1 已确认事实
+- what was approved / completed / financed / injected
+
+#### 15.2 可能影响
+- likely operating implications
+- likely balance-sheet or capital-allocation implications
+
+#### 15.3 仍然未知
+- timing
+- synergy quality
+- earnings quality
+- integration friction
+- dependence on external variables such as coal price or demand cycle
+
+This section exists to prevent transaction fact from becoming thesis inflation.
+
+---
+
+## Conclusion sections
+
+### 16. Bull / base / bear framing
+
+Use this only if it improves judgment clarity.
+
+If included, do not treat it as storytelling.
+Each case should state:
+- what is confirmed
+- what is inferred
+- what unknown dominates
+
+### 17. Bottom line
+
+The bottom line should answer:
+- what the stock or company most resembles now
+- what kind of investor or decision frame that suits
+- what should not be over-claimed
+
+Example pattern:
+
+> `当前更适合将中国神华视为“高分红、防御属性较强、但成长质量仍需验证”的资源型核心资产，而不是简单按资产注入叙事外推的中期高成长标的。若后续披露证明协同兑现、资本配置和盈利质量同步改善，判断可上修；在此之前，更稳妥的是维持方向性偏正面、但在估值与成长强度上保持克制。`
+
+### 18. What to monitor next
+
+This section should be concrete.
+
+Suggested items:
+- next quarterly coal-price and volume mix disclosure
+- power segment utilization and tariff trend
+- post-injection integration signals
+- payout policy vs capex balance
+- market re-rating already reflected or not
+
+### 19. Source register
+
+Use structured source traceability.
+
+At minimum include:
+- annual report / quarterly filing
+- exchange or regulatory disclosures
+- company announcements
+- current market snapshot source
+- secondary research used for peer comparison
+- inference register or uncertainty register if needed
+
+---
+
+## Typical failure signs for this case
+
+Mark the rewrite as still weak if it does any of the following:
+- opens with business overview before the thesis is clear
+- puts evidence legend ahead of judgment visibility
+- lists many numbers but does not show which ones actually drive the conclusion
+- writes high-dividend / low-cost / industry-leading / transport advantage claims without making the body claims auditable
+- treats asset injection as near-automatic growth confirmation
+- includes risks, but not a real weakening-evidence section
+- includes uncertainty, but the bottom line is not visibly narrowed by it
+
+---
+
+## Minimal pass test
+
+Before calling the rewrite acceptable, ask:
+
+- Can the first page alone tell me the thesis, the strongest support, the strongest weakening evidence, and the key unresolved variable?
+- Are the 3-5 most thesis-bearing sentences defendable in the body?
+- Does the report read like a memo I could use to judge the stock now, rather than a strong company profile?
+- If I cut 30-40% of the background, does the memo become sharper rather than weaker?
+- Are corporate actions separated into fact / implication / uncertainty?
+
+If not, the rewrite is still not reference-grade.

--- a/examples/listed-company-judgment-memo-example.md
+++ b/examples/listed-company-judgment-memo-example.md
@@ -1,0 +1,368 @@
+# Listed-Company Judgment Memo Example
+
+Use this example when the task is to evaluate a **publicly listed company** as a current judgment memo rather than as a company overview.
+
+This is a general-purpose example for the listed-company / investment-style route. It is intentionally more abstract than a company-specific skeleton such as China Shenhua.
+
+It is meant to show the **artifact shape of a passing report**.
+
+---
+
+## Example task
+
+Research a publicly listed company and produce a structured memo that helps a reader judge the company **now**.
+
+Typical user asks may include:
+- whether the company looks attractive, defensive, overhyped, or avoid-for-now
+- what the main bull and bear logic are
+- what changed over the last 1-2 years
+- what matters over the next 1-3 years
+- whether current market pricing seems supported by business reality
+
+The report may cover:
+- business and products
+- industry position
+- customers and use cases
+- competition
+- operating and financial signals
+- valuation or market context
+- bull / bear logic
+- opportunities, risks, and what would change the conclusion
+
+---
+
+## Expected route
+
+Primary route:
+- listed-company / investment-style judgment memo
+
+Expected secondary disciplines:
+- current-state verification
+- finance date discipline
+- source traceability and claim citation
+- unknown-to-conclusion linkage
+- front-page judgment visibility
+- counter-evidence handling
+- corporate-action compression guard when relevant
+
+---
+
+## Expected visible artifact contract
+
+A strong listed-company judgment memo should make the following visible:
+
+- a real current thesis, not just a company description
+- explicit research anchors
+- strongest confirmed support
+- strongest current weakening evidence
+- key unresolved variable
+- what would change the conclusion
+- support / weakening / unresolved split
+- body-level auditability for thesis-bearing claims
+- separation of reported facts / market snapshot / estimates / inference
+- conditional framing where the evidence does not justify flat certainty
+
+If the report still reads mainly as a company profile with some financial context attached, the route is under-executed.
+
+---
+
+## Typical failure signs
+
+Common failures include:
+
+- turning into a company overview before the thesis is visible
+- using current numbers, but not letting them govern the opening burden
+- listing sources at the end while leaving thesis-bearing claims weakly auditable in the body
+- disclosing uncertainty without narrowing the conclusion
+- describing competition as a peer directory rather than thesis pressure
+- treating corporate actions as near-automatic value creation
+- presenting risks only as ceremonial balance rather than as real weakening evidence
+
+---
+
+## Minimal output shape
+
+### 1. Title and report identity
+
+Example pattern:
+- `某公司（TICKER）投资风格研究备忘录`
+- `报告日期：YYYY-MM-DD`
+- `研究类型：Listed Company / Investment-Style Memo`
+
+### 2. Research-anchor block
+
+This block should appear before broad narrative expansion.
+
+At minimum, show:
+- latest full-year reported period
+- latest quarter / interim reported period
+- latest market snapshot date
+- latest management or major company-action state when decision-relevant
+
+Example pattern:
+- `最新完整报告期：FY2025`
+- `最新季度期：2026Q1`
+- `最新市场快照：YYYY-MM-DD 收盘价 / 市值 / PE / PB / PS / 股息率口径`
+- `最新重要动作：融资 / 收购 / 重组 / 指引更新（如相关）`
+
+### 3. One-sentence thesis
+
+The thesis should be directional, useful, and bounded.
+
+Good thesis behavior:
+- states what kind of case this is now
+- includes at least one limiting condition or dependency
+- avoids fake precision
+
+Good pattern:
+> `当前更接近“X 类型机会”，而不是“Y 类型机会”；若 A / B / C 未改善，当前判断应保持克制。`
+
+Bad pattern:
+- pure praise
+- generic company summary
+- over-precise valuation or timing judgment without evidence support
+
+### 4. Executive summary bullets
+
+Use short bullets, not a wall of prose.
+
+A good executive summary should already reveal:
+- the core thesis
+- at least one strongest support
+- at least one strongest weakening factor
+- the key unresolved variable
+- what would change the conclusion
+
+Suggested bullet roles:
+- `[已确认事实]` strongest support
+- `[已确认事实]` another load-bearing support
+- `[推断]` strongest weakening evidence
+- `[未知事项]` key unresolved variable
+- `[推断]` what would change the conclusion
+
+### 5. Key risks and key unknowns block
+
+Keep these early and scannable.
+
+Do not bury them after long business background.
+
+Suggested split:
+
+#### 关键风险
+- the main things currently weakening the case
+
+#### 关键未知
+- the unresolved variable(s) that limit confidence, timing precision, valuation precision, or recommendation strength
+
+---
+
+## Core memo shape
+
+### 6. What matters most now
+
+This section should identify the 2-5 variables that actually determine the current view.
+
+Good behavior:
+- prioritizes rather than catalogs
+- explains why these variables matter more than the rest
+- makes later sections feel subordinate to these variables
+
+Bad behavior:
+- mini company overview
+- equal weight for every fact
+- laundry list without burden ranking
+
+### 7. Main evidence supporting the thesis
+
+This section should be explicitly thesis-linked.
+
+For each support point, make visible:
+- what is directly confirmed
+- why it matters to the thesis
+- whether any part is inference-heavy
+- where the body claim is sourced
+
+Typical support categories may include:
+- cost or margin resilience
+- market position or switching-cost advantage
+- cash-flow quality
+- capital-return support
+- product or segment strength
+- regulatory / infrastructure / channel advantage
+
+### 8. Main evidence weakening the thesis
+
+This section should feel substantial, not ceremonial.
+
+Good behavior:
+- identifies the strongest current pressure on the thesis
+- explains what part of the conclusion it weakens
+- prevents the report from reading as bullish-by-default
+
+Typical weakening categories may include:
+- cyclic pressure
+- margin pressure
+- overdependence on one segment or product
+- valuation already pricing much of the good story
+- competitive catch-up risk
+- execution quality concerns
+
+### 9. Key unresolved variable
+
+Promote one dominant unknown when possible.
+
+A good unresolved-variable section should answer:
+- what is still not known
+- why it matters more than other caveats
+- what layer it constrains:
+  - directional judgment
+  - timing confidence
+  - valuation precision
+  - recommendation strength
+- what evidence would reduce the uncertainty
+
+### 10. What would change the conclusion
+
+This section is required.
+
+Suggested split:
+
+#### 会让判断转强的条件
+- what would justify a stronger view
+
+#### 会让判断转弱的条件
+- what would materially weaken or reverse the view
+
+If the report contains uncertainty but no change-the-conclusion logic, it is usually not yet decision-grade.
+
+---
+
+## Detailed analysis sections
+
+Only after the judgment structure is visible should the report expand.
+
+### 11. Business and segment structure
+
+Keep it thesis-relevant.
+
+Do not default to a full corporate profile.
+
+For each segment, prefer:
+- current role in the thesis
+- which metrics matter most
+- what is primary vs secondary
+
+### 12. Industry position and competitive pressure
+
+Do not write this mainly as a peer directory.
+
+A good competition section should show:
+- who actually pressures the thesis now
+- on what timeline
+- in which dimension
+- whether the pressure is narrative, commercial, technological, cost-based, or regulatory
+
+If the task touches defensibility, keep separate:
+- market leadership
+- moat
+- monopoly / oligopoly
+- listed-market scarcity
+- infrastructure or regulatory control
+
+### 13. Customers and use cases
+
+Keep this short unless customer concentration, customer quality, or demand stickiness is load-bearing.
+
+The goal is not to catalog customers; it is to explain demand quality.
+
+### 14. Operating and financial signals
+
+This section should not be a number dump.
+
+At minimum, distinguish:
+- reported historical facts
+- current market snapshot
+- forward-looking estimates or guidance
+- inferred or derived calculations
+
+When growth and weakness coexist, pair them visibly.
+
+Good pattern:
+- `规模仍在扩张，但盈利和现金流承压。`
+
+### 15. Corporate-action analysis (when relevant)
+
+If financing, M&A, restructuring, asset injection, major approvals, or strategic transactions matter, explicitly split:
+
+#### 15.1 已确认事实
+#### 15.2 可能影响
+#### 15.3 仍然未知
+
+This section exists to stop transaction fact from becoming thesis inflation.
+
+---
+
+## Conclusion sections
+
+### 16. Bull / base / bear framing (optional)
+
+Use only if it clarifies judgment.
+
+If used, each case should separate:
+- confirmed support
+- inference-heavy logic
+- open uncertainty
+
+### 17. Bottom line
+
+A strong bottom line should answer:
+- what the company or stock most resembles now
+- what should not be over-claimed
+- what kind of judgment is justified:
+  - directional
+  - valuation-grade
+  - timing-grade
+  - recommendation-grade
+
+Good behavior:
+- clear, calibrated, decision-useful
+- not too soft
+- not too certain
+
+### 18. What to monitor next
+
+This section should be concrete.
+
+Typical monitoring items:
+- next quarterly disclosure
+- segment-level improvement or deterioration
+- capital allocation change
+- competitive milestone
+- valuation rerating already reflected or not
+- guidance revision or reversal condition
+
+### 19. Source register
+
+Use structured traceability.
+
+At minimum include:
+- filings
+- company disclosures
+- market snapshot source
+- secondary sources used for comparison
+- inference or uncertainty register when needed
+
+---
+
+## Minimal pass test
+
+Before calling a listed-company memo acceptable, ask:
+
+- Can the first page tell me the thesis, strongest support, strongest weakening evidence, and key unresolved variable?
+- Are the 3-5 most thesis-bearing sentences defendable in the body?
+- Do the current reporting layers visibly govern the memo?
+- Does uncertainty visibly narrow the conclusion?
+- If corporate actions matter, are they split into fact / implication / uncertainty?
+- If I cut 30-40% of the background, would the report become sharper rather than weaker?
+
+If not, the report is probably still a strong overview rather than a true judgment memo.

--- a/references/decision-report-template.md
+++ b/references/decision-report-template.md
@@ -208,15 +208,23 @@ When the task is primarily about evaluating a company, competitive position, or 
 Prefer this front structure:
 
 1. Core thesis
-2. Strongest confirmed support
-3. Key unresolved variable
-4. What would change the conclusion
-5. What matters most now
-6. Main evidence supporting the thesis
-7. Main evidence weakening the thesis
-8. Key unknowns and why they matter
-9. What to watch next
-10. Only then: business background, segment detail, products, roadmap, customers, and competitors
+2. Research anchors (latest full-year / latest quarter-interim / latest market snapshot / latest management state when relevant)
+3. Strongest confirmed support
+4. Key unresolved variable
+5. What would change the conclusion
+6. What matters most now
+7. Main evidence supporting the thesis
+8. Main evidence weakening the thesis
+9. Key unknowns and why they matter
+10. What to watch next
+11. Only then: business background, segment detail, products, roadmap, customers, and competitors
+
+For asset injection, restructuring, major financing, or M&A-heavy cases, force a three-way split:
+- confirmed transaction facts
+- likely operating or financial implications
+- open uncertainty about timing, realization, or synergy quality
+
+Do not compress these into one bullish or bearish sentence.
 
 Background, segment description, roadmap detail, and customer examples should appear only insofar as they sharpen the current thesis, not as default report ballast. Reduce background to the minimum necessary context required to interpret the judgment.
 

--- a/references/decision-report-template.md
+++ b/references/decision-report-template.md
@@ -222,9 +222,15 @@ Prefer this front structure:
 For asset injection, restructuring, major financing, or M&A-heavy cases, force a three-way split:
 - confirmed transaction facts
 - likely operating or financial implications
-- open uncertainty about timing, realization, or synergy quality
+- open uncertainty about timing, realization, synergy quality, or dependency on external variables such as commodity prices, approvals, customer uptake, or integration pace
 
 Do not compress these into one bullish or bearish sentence.
+Do not let a real transaction fact silently upgrade a still-conditional thesis into a high-confidence conclusion.
+
+A useful mini-pattern is:
+- `已发生什么`
+- `这可能意味着什么`
+- `仍然不知道什么`
 
 Background, segment description, roadmap detail, and customer examples should appear only insofar as they sharpen the current thesis, not as default report ballast. Reduce background to the minimum necessary context required to interpret the judgment.
 

--- a/references/decision-report-template.md
+++ b/references/decision-report-template.md
@@ -243,6 +243,14 @@ Under "What matters most now", prefer to surface:
 - which business line or driver most shapes the current view
 - which 2-4 disclosures or metrics matter most next
 - which facts would most strengthen or weaken the thesis
+- which unresolved variable most limits precision, timing confidence, or valuation confidence
+
+For listed-company and other judgment-heavy memos, treat this as a structural triad, not a stylistic preference:
+- what currently supports the thesis
+- what currently weakens the thesis
+- what remains unresolved and therefore narrows the conclusion
+
+If one of these three is missing, the report usually drifts back into polished-overview mode.
 
 Write competition as threat-window analysis rather than a peer directory. Prefer to show:
 - short-term threat

--- a/references/finance-date-discipline.md
+++ b/references/finance-date-discipline.md
@@ -94,6 +94,27 @@ Common failure pattern:
 
 Treat that as a freshness failure, not as a minor lag.
 
+### Fail-fast rule: stale anchor invalidates the memo
+
+For listed-company / investment-style work, a stale or mis-timed research anchor is not a cosmetic flaw.
+It invalidates the memo until corrected.
+
+If any of the following occurs:
+- the report date is materially later than the allegedly latest quarter or interim period
+- the research-anchor block names a period that does not plausibly match the filing calendar
+- the agent cannot explain why no newer reported layer should reasonably exist
+
+then do not continue writing through the inconsistency.
+
+Required action:
+1. stop synthesis
+2. re-check the latest quarter / interim layer
+3. either fix the anchor or explicitly state that the latest period could not be verified
+4. if the latest period cannot be verified, downgrade the memo visibly rather than pretending the anchor is stable
+
+A polished memo shape does not rescue a stale anchor.
+In fact, the better the memo looks, the more dangerous a stale anchor becomes because readers are more likely to trust it.
+
 When older numbers remain useful, label them as one of:
 - historical background
 - prior-cycle comparison

--- a/references/finance-date-discipline.md
+++ b/references/finance-date-discipline.md
@@ -168,6 +168,40 @@ Avoid these mistakes:
 - using live valuation ratios without snapshot date
 - quoting market-share or shipment numbers without period definition
 - blending company disclosures and third-party estimates into one table without labels
+- compressing a confirmed corporate action directly into an operating or valuation conclusion without separating what is fact vs implication vs open uncertainty
+
+## Corporate-action compression guard
+
+For listed-company work, treat these as a separate reasoning layer rather than ordinary company facts:
+
+- asset injection
+- M&A
+- financing completion
+- restructuring
+- capacity expansion approval or registration
+- major strategic partnership with claimed earnings impact
+
+When these events matter to the thesis, split them explicitly into three layers:
+
+1. confirmed transaction or event facts
+2. likely operating / financial implications
+3. open uncertainty about timing, realization, integration quality, or scenario dependence
+
+Do not compress these three layers into one smooth sentence such as:
+- `配套融资完成，打开中期成长空间`
+- `资产注入落地，将显著增厚利润`
+- `重组完成后成长确定性提升`
+
+Better pattern:
+- `已确认事实：公司已完成某项融资 / 注入 / 重组。`
+- `可能影响：若按当前披露口径顺利并表或协同兑现，可能带来产能、储量、收入结构或成本结构变化。`
+- `未知事项：兑现节奏、协同质量、盈利质量、资本开支压力、整合摩擦仍待后续披露验证。`
+
+This guard matters because corporate actions often create a false sense of precision:
+- the transaction fact is real
+- but the economic consequence remains only partially known
+
+If the consequence is still conditional, write it as conditional. Do not let transaction finality masquerade as thesis finality.
 
 ## Precision discipline (from GPT vs Minimax distillation)
 

--- a/references/report-template.md
+++ b/references/report-template.md
@@ -152,9 +152,14 @@ A good report should let the reader quickly answer:
 
 ## Required evidence-tier legend
 
-At the top of every report, include a brief legend defining evidence confidence levels.
+Include a brief legend defining evidence confidence levels near the top of every report.
 
 If the final report is written in Chinese, keep the legend in Chinese too. Do not mix a Chinese body with accidental English evidence buckets unless bilingual output was explicitly requested.
+
+Placement rule:
+- keep the legend compact
+- do not let it displace the one-sentence thesis, executive bullets, key risks, or key unknowns from the reader's first screen / first page scan
+- if space is tight, place the legend immediately after the executive summary block or at the start of the next page rather than above the thesis
 
 Preferred Chinese format:
 

--- a/references/source-traceability-and-claim-citation.md
+++ b/references/source-traceability-and-claim-citation.md
@@ -165,6 +165,41 @@ For each load-bearing claim, try to make visible:
 
 If the report uses confidence labels but hides the source type and inference role for the key judgment, it is still not adequately auditable.
 
+### Thesis-bearing claim guard
+
+Treat a claim as thesis-bearing when weakening or removing it would materially change:
+- the bottom line
+- the main ranking or recommendation
+- the confidence level
+- the valuation / timing / upside-downside framing
+- the reader's view of the core thesis
+
+Typical thesis-bearing claims in listed-company work include:
+- cost advantage vs peers
+- current market-position or ranking claims
+- dividend superiority or valuation-support claims
+- event-to-thesis claims such as asset injection -> growth, financing -> rerating, restructuring -> margin improvement
+- commodity-price or market-cycle assumptions that materially support the thesis
+- claims that a certain business segment is the key driver of the current view
+
+For these claims, bibliography-level traceability is not enough.
+
+The body text should make visible, at minimum:
+- what the claim is
+- which source or evidence bucket supports it
+- whether it is directly stated or inferred
+- what key limitation or dependency still applies if the evidence is indirect
+
+Bad pattern:
+- a polished sentence makes a strong comparative or forward-looking claim
+- the reader sees confidence labels or a source list
+- but cannot tell which exact source does the real work for that sentence
+
+Good pattern:
+- `长协占比较高这一事实可由年报经营披露支持 [S03]；但“煤价敏感度仅为行业平均三分之一”仍属于基于同业比较和经营结构的推断 [I02]。`
+
+If a thesis-bearing claim cannot be made auditable in the body without awkwardness, that is usually a sign the claim should be narrowed, split, or downgraded.
+
 ## Common failure patterns
 
 ### Pattern 1: Bibliography theater
@@ -243,6 +278,8 @@ Slow down and add more traceability when:
 - a source is listed but never actually cited in the body
 - the report has a long sources list but no inline citations
 - a current-state claim is sourced to an old filing with no indication of supersession
+- the report's most thesis-bearing sentence would become hard to defend if a reviewer asked `which exact source supports this line?`
+- a strong comparative claim is visible in the body, but only a generic section bibliography exists beneath it
 
 ## Final discipline
 


### PR DESCRIPTION
## Summary
- harden listed-company judgment visibility and support/weakening/unresolved execution
- add thesis-bearing claim traceability and corporate-action compression guards
- add China Shenhua and CNOOC eval assets, a listed-company meta eval, and positive memo skeleton/examples
- add stale-anchor fail-fast rules for listed-company research anchors

## Why
This batch turns recent listed-company deep-research failures into reusable routing, checklist, eval, and example improvements, with special focus on:
- judgment-first memo shape
- body-level auditability for thesis-bearing claims
- fact / implication / uncertainty separation for corporate actions
- fail-fast handling when research-anchor periods are stale or mis-timed
