### PR TITLE
fix: harden md_to_pdf.py path safety with shell=False argv lists

### DIFF
--- a/scripts/md_to_pdf.py
+++ b/scripts/md_to_pdf.py
@@ -11,9 +11,9 @@ import os
 from pathlib import Path
 
 
-def run(cmd, description):
+def run(args_list, description):
     print(f"\n▶ {description}")
-    result = subprocess.run(cmd, shell=True, capture_output=False)
+    result = subprocess.run(args_list, shell=False, capture_output=False)
     if result.returncode != 0:
         print(f"❌ Failed: {description}")
         sys.exit(result.returncode)
@@ -45,32 +45,28 @@ def main():
         pdf_path = md_path.with_suffix('.pdf')
 
     html_path = md_path.with_suffix('.html')
+    scripts_dir = Path(__file__).parent.resolve()
 
     # Step 1: Markdown → HTML
-    title_flag = f'--title "{args.title}"' if args.title else ''
-    run(
-        f'python3 {Path(__file__).parent}/markdown_to_html.py "{md_path}" "{html_path}" {title_flag}',
-        f"Markdown → HTML: {html_path.name}"
-    )
+    cmd = [sys.executable, str(scripts_dir / 'markdown_to_html.py'), str(md_path), str(html_path)]
+    if args.title:
+        cmd += ['--title', args.title]
+    run(cmd, f"Markdown → HTML: {html_path.name}")
 
     # Step 2: HTML → PDF
-    render_flags = []
+    cmd = [sys.executable, str(scripts_dir / 'render_pdf.py'), str(html_path), str(pdf_path)]
     if args.title:
-        render_flags.append(f'--title "{args.title}"')
+        cmd += ['--title', args.title]
     if args.landscape:
-        render_flags.append('--landscape')
-    render_flags.extend([
-        f'--media {args.media}',
-        f'--margin-top {args.margin_top}',
-        f'--margin-right {args.margin_right}',
-        f'--margin-bottom {args.margin_bottom}',
-        f'--margin-left {args.margin_left}',
-    ])
-    render_flag_str = ' '.join(render_flags)
-    run(
-        f'python3 {Path(__file__).parent}/render_pdf.py "{html_path}" "{pdf_path}" {render_flag_str}',
-        f"HTML → PDF: {pdf_path.name}"
-    )
+        cmd.append('--landscape')
+    cmd += [
+        '--media', args.media,
+        '--margin-top', args.margin_top,
+        '--margin-right', args.margin_right,
+        '--margin-bottom', args.margin_bottom,
+        '--margin-left', args.margin_left,
+    ]
+    run(cmd, f"HTML → PDF: {pdf_path.name}")
 
     print(f"\n✅ Complete: {pdf_path}")
 


### PR DESCRIPTION
## Summary

修复 `scripts/md_to_pdf.py` 在仓库路径或输入文件路径包含空格时崩溃的问题。

- 将 `subprocess.run(cmd, shell=True)` 改为 `subprocess.run(args_list, shell=False)`
- 内部 pipeline 调用（markdown_to_html.py / render_pdf.py）全部改用显式 argv list，不再做 f-string 路径拼接
- 脚本路径、输入/输出路径、`--title`、margin 等 flag 全部作为独立 list element 传入

## 根因

第 52 行 `{Path(__file__).parent}/markdown_to_html.py` 未加引号，shell 在空格处拆分路径，导致 `can't open file '/path/deep'` 错误。输入/输出路径虽已用 `"..."` 包裹，但脚本路径漏了。`shell=True` 使整个命令被 shell 二次解析，所有未引号的空格都变成参数分隔符。

## 验证

已在含空格路径 `/tmp/test space path/` 下成功运行 smoke test：
- HTML 生成 ✅
- PDF 生成 ✅（25KB，内容正确）

## Scope

只改了一个文件 `scripts/md_to_pdf.py`，未动其他模块。