### PR TITLE
refactor: remove MiniMax web search as default provider from SKILL.md and parallel-research.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -126,28 +126,20 @@ Do not keep searching just to make the report longer.
 
 ## Tool strategy
 
-**Default search provider: MiniMax MCP. Do not use the built-in Brave `web_search` as the default discovery path for this skill.**
+**Do not assume a specific default search provider. Before live search, inspect what search / fetch / browser capabilities are available in the current environment: use formal tooling preflight if it exists, otherwise make the selected provider path explicit in the research plan or evidence log.**
 
 When a research task needs live web search:
 
-1. use MiniMax MCP for discovery and comparison-angle finding
+1. select one provider path based on expected query fit and use it for discovery and comparison-angle finding
 2. use `web_fetch` only after a candidate URL is identified
 3. use `browser` only when the page is dynamic or `web_fetch` fails on a confirmed-live URL
 
-Current primary implementation: call the MiniMax web-search script provided by the `minimax-web-search` skill.
+If the selected provider path is unavailable, do not silently fall back to another provider without explicit justification. Only add another provider when degradation, low yield, or query-fit mismatch is explicitly identified.
 
-```bash
-python3 <openclaw-skill-root>/minimax-web-search/scripts/web_search.py "<search query>"
-```
-
-Treat this as the working implementation, not as permission to silently substitute other default search providers.
-
-If MiniMax MCP web search is unavailable, do not silently fall back to Brave API.
-
-Use this degraded fallback policy instead:
+If degraded search is needed, use this fallback policy:
 1. first distinguish temporary rate-limit / quota issues from broader provider unavailability
 2. if live search is still unavailable, declare the search provider degraded in the evidence log
-3. use `agent-reach` Exa search as the first explicit degraded fallback for discovery and comparison-angle finding
+3. if `agent-reach` Exa search is available in the current environment, use it as the first explicit degraded fallback for discovery and comparison-angle finding
 4. current fallback implementation for that path:
 
 ```bash

--- a/references/parallel-research.md
+++ b/references/parallel-research.md
@@ -102,7 +102,7 @@ If you have 3 tracks:
 
 If you have 1 track: run it normally, no parallelism needed.
 
-**Why 2:** Most search APIs (including MiniMax) allow enough concurrent requests for 2 parallel searches before hitting 429. 2 is the safe default. If the API clearly tolerates more in practice, you can adjust up—but default to safe.
+**Why 2:** Running 2 concurrent tracks is a conservative operational default that avoids rate-limit pressure in most environments. If the API clearly tolerates more in practice, you can adjust up—but default to safe.
 
 **Spawning within a batch:** Use `sessions_spawn` for all tracks in the current batch simultaneously. The batch wait is handled by collecting their results before the next spawn call.
 


### PR DESCRIPTION
## Summary

移除 `SKILL.md` 和 `references/parallel-research.md` 中对 MiniMax web search 的默认依赖引用，使工具策略变为 provider-neutral。

### 改了什么

**`SKILL.md`** (Tool strategy 节，第 127-158 行)：
- 删除 `Default search provider: MiniMax MCP`——agent 不再默认尝试已不存在的 provider
- 删除整个 `minimax-web-search` 脚本引用——这是一个已不存在的 skill 的死引用
- 将步骤 1 从 `use MiniMax MCP for discovery` 改为 `select one provider path based on expected query fit`
- 将 `Run tooling preflight...` 改为同时适配有/无正式 preflight 机制的表述
- 将 `primary search provider` 改为 `selected provider path`，避免隐含默认 provider
- 为 Exa fallback 添加 `if available in the current environment` 条件
- **未改动**的后续内容（Exa → Bing → blocked fallback 梯子、Degraded-search execution discipline、Evidence log）保持不变

**`references/parallel-research.md`** (第 105 行)：
- `Most search APIs allow enough concurrent requests...` → `Running 2 concurrent tracks is a conservative operational default...`

### 没改什么（scope 外）

| 文件 | 不改原因 |
|---|---|
| `evals/cases/*`, `evals/comparative-distillation/*` | MiniMax 在其中是**历史评估样本的模型标识**，不是 active provider dependency |
| `evals/meta/degraded-search-execution.md` | 已完全 provider-neutral，无 MiniMax 引用 |
| `examples/research-pack-example.md` | 第 34 行的 MiniMax 是历史 degraded-search log 示例，不是 active dependency |
| `SYSTEM-MAP.md`、`references/failure-taxonomy.md` | MiniMax 引用是文件映射/案例索引，不是 provider 依赖 |

MiniMax 在历史 evals/examples/logs 中的出现均为 historical sample label 而非 active provider requirement。

### 相关

- Addresses #71（移除旧默认 provider 依赖，非彻底关闭——#64 的 preflight 落地后协同完成）
- 与 #64 (tooling preflight) 协同：#71 做减法（移除旧依赖），#64 做加法（新增 preflight 机制）