### PR TITLE
feat: add requirements.txt, setup instructions, and CI smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/**'
+      - 'examples/**'
+      - 'requirements.txt'
+      - '.github/workflows/ci.yml'
+
+jobs:
+  quick:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python3 -m py_compile scripts/*.py
+      - run: python3 scripts/validate_research_pack.py examples/research-pack-example.md
+
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -r requirements.txt
+      - run: python -m playwright install chromium --with-deps
+      - run: |
+          input_dir="/tmp/smoke test path"
+          mkdir -p "$input_dir"
+          printf '# Smoke Test\n\nTest paragraph.\n' > "$input_dir/input.md"
+          python3 scripts/md_to_pdf.py "$input_dir/input.md" "$input_dir/output.pdf" \
+            --title "CI Smoke Test"
+      - run: |
+          python3 -c "import sys,pathlib; d=pathlib.Path('/tmp/smoke test path/output.pdf').read_bytes(); assert len(d)>0 and d[:4]==b'%PDF'; print('PDF OK: '+str(len(d))+' bytes')"

--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@
 
 ---
 
+## Setup
+
+```bash
+pip install -r requirements.txt
+python -m playwright install chromium
+```
+
+---
+
 ## 仓库结构
 
 ```text

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+markdown>=3.5
+playwright>=1.40


### PR DESCRIPTION
## Summary

Add Python dependency declaration, setup instructions, and CI smoke test for the PDF pipeline scripts.

### Changes

| File | Content |
|---|---|
| `requirements.txt` (new) | `markdown>=3.5`, `playwright>=1.40` |
| `README.md` | New `## Setup` section with pip install + playwright chromium install |
| `.github/workflows/ci.yml` (new) | Two-job CI: quick (py_compile + validator) + smoke (full PDF pipeline) |

### CI design

- **Quick job**: zero-dependency — all third-party imports are deferred to call time, so `py_compile` and `validate_research_pack.py` work without installing anything
- **Smoke job**: installs deps, runs the full markdown→HTML→PDF pipeline via `md_to_pdf.py`, verifies PDF output exists
- Trigger: only on PRs touching `scripts/`, `requirements.txt`, or the workflow file itself

### Scope

No changes to existing scripts, evals, references, or checklists. Infrastructure only.

Addresses #65