### PR TITLE
refactor: add Equipment Selection route to Routing priority, sync route docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -81,6 +81,7 @@ The current first-class routes are:
 - market entry / regional expansion
 - market outlook / industry evolution
 - first-tier / competitive positioning
+- equipment selection / procurement / home-server planning
 - constrained choice / shortlist
 - listed-company / investment-style research
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This file is intentionally lightweight. Use concise entries that explain:
 
 ## Unreleased
 
+### Changed
+- `equipment selection / procurement / home-server planning` promoted to first-class route (routing priority #5), with provider-vs-equipment conflict rules and route-conflict examples
+- route lists in `ARCHITECTURE.md`, `SYSTEM-MAP.md`, and `README.md` updated from six to seven mature routes
+
 ### Added
 - `references/mid-research-review.md`
 - `checklists/mid-research-review-audit.md`

--- a/README.md
+++ b/README.md
@@ -44,9 +44,12 @@
 
 典型覆盖包括：
 
-- shortlist / option selection
+- provider / vendor selection
 - market entry / regional expansion
 - market outlook / industry evolution
+- first-tier / competitive positioning
+- equipment selection / procurement / home-server planning
+- constrained choice / shortlist
 - listed-company / moat / monopoly-style judgment
 - uncertainty-sensitive、forward-looking、comparative research
 

--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -86,9 +86,9 @@ Use when the task is mainly about:
 
 **Choose this route when:** the task is to select among providers and justify why one wins under explicit constraints.
 
-**Do not use this route when:** the task is mainly to describe the market or explain industry direction without a real selection burden.
+**Do not use this route when:** the task is mainly to describe the market or explain industry direction without a real selection burden. For physical hardware / device procurement, purchase recommendation, build, or configuration choices (NAS, home server, build-ready stack, office equipment purchasing), use the Equipment Selection / Procurement route instead.
 
-**Often confused with:** market outlook / industry evolution.
+**Often confused with:** market outlook / industry evolution, equipment selection / procurement / home-server planning.
 
 ### Read
 - `references/option-selection-and-shortlist-discipline.md`
@@ -317,7 +317,7 @@ Use when the task is mainly about:
 
 **Do not use this route when:** the real task is market-entry gating, expansion sequencing, or broad market scanning.
 
-**Often confused with:** market entry / regional expansion.
+**Often confused with:** market entry / regional expansion, equipment selection / procurement.
 
 ### Read
 - `references/option-selection-and-shortlist-discipline.md`
@@ -375,6 +375,11 @@ Use when the task is mainly about:
 **Do not use this route when:** the task is mainly to explain hardware categories, compare benchmarks abstractly, or teach general technical concepts without a real procurement burden.
 
 **Often confused with:** constrained choice / shortlist, market outlook / industry evolution.
+
+**Route-conflict examples:**
+- NAS vs mini PC vs self-build vs used workstation — this is an equipment selection task even though multiple "vendors" are involved; do not default to provider / vendor selection
+- hardware vendor shortlist with build-ready stack recommendation — if the output must include budget, configuration, and operating burden, use equipment selection rather than provider selection
+- home-server budget planning — even when framed as a cost comparison, the real decision is a procurement memo, not a market outlook or provider comparison
 
 ### Read
 - `references/decision-report-template.md`
@@ -564,8 +569,9 @@ If multiple primary-looking routes apply, use this order:
 2. market entry / regional expansion
 3. provider / vendor selection
 4. first-tier / competitive positioning
-5. market outlook / industry evolution
-6. constrained choice / shortlist
+5. equipment selection / procurement / home-server planning
+6. market outlook / industry evolution
+7. constrained choice / shortlist
 
 Choose the route that most strongly determines report structure and audit burden.
 

--- a/SYSTEM-MAP.md
+++ b/SYSTEM-MAP.md
@@ -83,6 +83,7 @@ Makes mature task families explicit so the right discipline set and delivery con
 - market entry / regional expansion
 - market outlook / industry evolution
 - first-tier / competitive positioning
+- equipment selection / procurement / home-server planning
 - constrained choice / shortlist
 - listed-company / investment-style research
 


### PR DESCRIPTION
## Summary

将已存在的 Equipment Selection route 纳入 Routing priority，同步更新所有 route 列表文档，并添加 provider-vs-equipment 冲突规则。

### 改动

| 文件 | 改动 |
|---|---|
| `ROUTING-MATRIX.md` | Routing priority 插入 equipment selection 为 #5；Provider route 增加硬件采购排除引用；Equipment route 增加 3 个 route-conflict 示例 |
| `ARCHITECTURE.md` | route 列表从 6 项扩为 7 项，增加 equipment selection |
| `SYSTEM-MAP.md` | 同上 |
| `README.md` | 典型覆盖列表同步 |

### 路由冲突处理

- **Provider vs Equipment**: Provider route 的 Do not use 明确写了 "physical hardware/device procurement → use Equipment Selection instead"
- **Constrained choice vs Equipment**: Equipment 优先级 #5 > constrained choice #7
- **Route-conflict 示例**: NAS vs mini PC vs self-build、hardware vendor shortlist、home-server budget planning

### Scope

- checklist/final-audit.md 已有 Equipment Selection 专用 check，未动
- 未改动其他 route 的 trigger/artifact contract

Closes #67