### PR TITLE
feat: harden markdown_to_html.py metadata HTML escaping and security model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,23 @@ jobs:
       - run: pip install -r requirements.txt
       - run: python -m playwright install chromium --with-deps
       - run: |
+          temp=$(mktemp -d)
+          cat > "$temp/in.md" << 'INEOF'
+          ---
+          title: <script>x</script>
+          date: 2024-01-01
+          type: test
+          ---
+
+          # Body
+          INEOF
+          python3 scripts/markdown_to_html.py "$temp/in.md" "$temp/out.html"
+          grep -q '&lt;script&gt;' "$temp/out.html" || { echo 'FAIL: metadata not escaped'; exit 1; }
+          grep -q '<br>' "$temp/out.html" || { echo 'FAIL: <br> missing from multiline meta'; exit 1; }
+          ! grep -q '&lt;br&gt;' "$temp/out.html" || { echo 'FAIL: <br> was escaped instead of literal'; exit 1; }
+          echo 'HTML escaping regression check OK'
+          rm -rf "$temp"
+      - run: |
           input_dir="/tmp/smoke test path"
           mkdir -p "$input_dir"
           printf '# Smoke Test\n\nTest paragraph.\n' > "$input_dir/input.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This file is intentionally lightweight. Use concise entries that explain:
 ### Changed
 - `equipment selection / procurement / home-server planning` promoted to first-class route (routing priority #5), with provider-vs-equipment conflict rules and route-conflict examples
 - route lists in `ARCHITECTURE.md`, `SYSTEM-MAP.md`, and `README.md` updated from six to seven mature routes
+- `scripts/markdown_to_html.py`: hardened metadata HTML escaping and security model — `html.escape()` applied to all frontmatter-derived fields; `cover_meta` lines are escaped individually before joining with `<br>`
 
 ### Added
 - `references/mid-research-review.md`

--- a/scripts/markdown_to_html.py
+++ b/scripts/markdown_to_html.py
@@ -1,9 +1,18 @@
 #!/usr/bin/env python3
 """
 Universal Markdown → Styled HTML converter for Deep Research reports.
+
+Security model: this script is designed for processing agent-authored
+Deep Research reports. It escapes frontmatter-derived metadata fields
+(title, cover_title, cover_subtitle, cover_meta) to prevent HTML injection.
+Body HTML is produced by Python-Markdown with the 'extra' extension,
+which preserves raw HTML in the markdown source. Do not pass untrusted
+content to this script without sanitizing first.
+
 Usage:
     python3 markdown_to_html.py <input.md> [output.html] [--title "Report Title"]
 """
+import html
 import sys
 import re
 import os
@@ -765,8 +774,16 @@ def normalize_text_for_pdf(text):
     return text
 
 
-def build_html(title, body_html, cover_title="", cover_subtitle="", cover_meta=""):
+def build_html(title, body_html, cover_title="", cover_subtitle="", cover_meta="", meta_lines=None):
     """Wrap processed body HTML in the full HTML document."""
+    title = html.escape(title)
+    cover_title = html.escape(cover_title)
+    cover_subtitle = html.escape(cover_subtitle)
+    if meta_lines is not None:
+        cover_meta = '<br>'.join(html.escape(line) for line in meta_lines)
+    elif cover_meta:
+        parts = re.split(r'<br\s*/?>', cover_meta, flags=re.I)
+        cover_meta = '<br>'.join(html.escape(part) for part in parts)
     cover_block = ""
     body_class = "has-cover" if cover_title else ""
     if cover_title:
@@ -1219,7 +1236,8 @@ def process_markdown(md_text):
 def extract_cover_meta(md_text):
     """
     Try to extract cover fields from markdown frontmatter or first few lines.
-    Returns (cover_title, cover_subtitle, cover_meta, cleaned_body)
+    Returns (cover_title, cover_subtitle, meta_lines, cleaned_body)
+    where meta_lines is a list of raw metadata strings (unjoined, unescaped).
     """
     lines = md_text.split('\n')
 
@@ -1239,8 +1257,6 @@ def extract_cover_meta(md_text):
         elif line.startswith('type:') or lower.startswith('research type:'):
             meta_lines.append(f"研究类型：{line.split(':', 1)[1].strip()}")
 
-    cover_meta = '<br>'.join(meta_lines) if meta_lines else ''
-
     # Strip frontmatter (--- ... ---)
     body_lines = lines
     if lines and lines[0].strip() == '---':
@@ -1252,7 +1268,7 @@ def extract_cover_meta(md_text):
         if end is not None:
             body_lines = lines[end+1:]
 
-    return title, subtitle, cover_meta, '\n'.join(body_lines)
+    return title, subtitle, meta_lines, '\n'.join(body_lines)
 
 
 # ─── Main ─────────────────────────────────────────────────────────────────────
@@ -1266,7 +1282,7 @@ def convert(input_path, output_path=None, title=None):
     md_text = normalize_text_for_pdf(md_text)
 
     # Extract cover info
-    cover_title, cover_subtitle, cover_meta, body_text = extract_cover_meta(md_text)
+    cover_title, cover_subtitle, meta_lines, body_text = extract_cover_meta(md_text)
 
     # Use provided title or fall back
     report_title = title or cover_title or md_path.stem
@@ -1280,7 +1296,7 @@ def convert(input_path, output_path=None, title=None):
         body_html=body_html,
         cover_title=cover_title,
         cover_subtitle=cover_subtitle,
-        cover_meta=cover_meta,
+        meta_lines=meta_lines,
     )
 
     # Output


### PR DESCRIPTION
## Summary

为 `scripts/markdown_to_html.py` 添加 HTML escaping 和明确的安全模型。只处理 metadata 字段，body HTML sanitization 不在本 PR 范围。

### 改动

| 文件 | 改动 |
|---|---|
| `scripts/markdown_to_html.py` | `build_html()` 中对 `title`、`cover_title`、`cover_subtitle` 做 `html.escape()`；`cover_meta` 改为逐行 escape 后用真实 `<br>` 拼接；旧 API `cover_meta='a<br>b'` 向后兼容；脚本 docstring 增加安全模型说明 |
| `.github/workflows/ci.yml` | smoke job 新增 metadata escaping 回归测试（元数据 escape + 多行 `<br>` 保留 + 无 `&lt;br&gt;`） |
| `CHANGELOG.md` | Unreleased 添加本次变更记录 |

### Scope 说明

- **Metadata escaping** ✅ 已处理
- **Body HTML sanitization** ❌ 未处理——Python-Markdown 的 `extra` extension 允许 raw HTML 穿透。加 sanitizer 需引入第三方库且与现有 HTML 后处理有冲突风险。脚本安全模型已明确为 trusted-input only
- **PDF 远程资源** ❌ 未处理——如需防守不可信输入可在 `render_pdf.py` 加请求拦截，不在本 PR

### 验证

```bash
# 恶意元数据被 escape
→ <title>&lt;script&gt;alert(1)&lt;/script&gt;</title>
# 多行 meta 保留真实 <br>
→ <div class="cover-meta">研究日期：2024-01-01<br>研究类型：test</div>
```

Addresses #68 (metadata escaping；body sanitization 不在本 PR 范围)