### PR TITLE
fix: narrow PDF delivery trigger to avoid false positives on generic '报告' terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is intentionally lightweight. Use concise entries that explain:
 ## Unreleased
 
 ### Changed
+- `SKILL.md`: narrowed PDF delivery trigger — removed bare `报告` from keyword list; added explicit delivery-intent phrases ("生成 PDF", "导出 PDF", "PDF 报告", "保存为 PDF", "给我 PDF 文件") and a guardrail against triggering on generic report terminology only. Prevents unnecessary PDF pipeline execution when the user merely says "写一份报告" or similar.
 - `equipment selection / procurement / home-server planning` promoted to first-class route (routing priority #5), with provider-vs-equipment conflict rules and route-conflict examples
 - route lists in `ARCHITECTURE.md`, `SYSTEM-MAP.md`, and `README.md` updated from six to seven mature routes
 - `scripts/markdown_to_html.py`: hardened metadata HTML escaping and security model — `html.escape()` applied to all frontmatter-derived fields; `cover_meta` lines are escaped individually before joining with `<br>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ This file is intentionally lightweight. Use concise entries that explain:
 ## Unreleased
 
 ### Changed
-- `SKILL.md`: narrowed PDF delivery trigger — removed bare `报告` from keyword list; added explicit delivery-intent phrases ("生成 PDF", "导出 PDF", "PDF 报告", "保存为 PDF", "给我 PDF 文件") and a guardrail against triggering on generic report terminology only. Prevents unnecessary PDF pipeline execution when the user merely says "写一份报告" or similar.
+- `SKILL.md`: narrowed PDF delivery trigger — replaced bare keyword matching with an explicit file-delivery intent model: added delivery-phrase list ("生成 PDF", "导出 PDF", "报告文件", "可下载报告", "给报告文件", "附件" etc.) and a negation/discussion guardrail (不要 PDF, no PDF, 解释 PDF 渲染失败, etc.). Bare `报告` no longer triggers PDF pipeline.
+- `evals/cases/pdf-delivery-trigger-regression-case.md`: added acceptance matrix (19 scenarios) to prevent trigger-boundary drift.
 - `equipment selection / procurement / home-server planning` promoted to first-class route (routing priority #5), with provider-vs-equipment conflict rules and route-conflict examples
 - route lists in `ARCHITECTURE.md`, `SYSTEM-MAP.md`, and `README.md` updated from six to seven mature routes
 - `scripts/markdown_to_html.py`: hardened metadata HTML escaping and security model — `html.escape()` applied to all frontmatter-derived fields; `cover_meta` lines are escaped individually before joining with `<br>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This file is intentionally lightweight. Use concise entries that explain:
 ## Unreleased
 
 ### Changed
-- `SKILL.md`: narrowed PDF delivery trigger — replaced bare keyword matching with an explicit file-delivery intent model: added delivery-phrase list ("生成 PDF", "导出 PDF", "报告文件", "可下载报告", "给报告文件", "附件" etc.) and a negation/discussion guardrail (不要 PDF, no PDF, 解释 PDF 渲染失败, etc.). Bare `报告` no longer triggers PDF pipeline.
+- `SKILL.md`: narrowed PDF delivery trigger — replaced bare keyword matching with an explicit file-delivery intent model: added delivery-phrase list ("生成 PDF", "导出 PDF", "报告文件", "可下载报告", "给我报告文件", "作为附件给我" etc.) and a negation/discussion guardrail (不要 PDF, no PDF, 解释 PDF 渲染失败, etc.). Bare `报告` no longer triggers PDF pipeline.
 - `evals/cases/pdf-delivery-trigger-regression-case.md`: added acceptance matrix (19 scenarios) to prevent trigger-boundary drift.
 - `equipment selection / procurement / home-server planning` promoted to first-class route (routing priority #5), with provider-vs-equipment conflict rules and route-conflict examples
 - route lists in `ARCHITECTURE.md`, `SYSTEM-MAP.md`, and `README.md` updated from six to seven mature routes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This file is intentionally lightweight. Use concise entries that explain:
 
 ### Changed
 - `SKILL.md`: narrowed PDF delivery trigger — replaced bare keyword matching with an explicit file-delivery intent model: added delivery-phrase list ("生成 PDF", "导出 PDF", "报告文件", "可下载报告", "给我报告文件", "作为附件给我" etc.) and a negation/discussion guardrail (不要 PDF, no PDF, 解释 PDF 渲染失败, etc.). Bare `报告` no longer triggers PDF pipeline.
-- `evals/cases/pdf-delivery-trigger-regression-case.md`: added acceptance matrix (19 scenarios) to prevent trigger-boundary drift.
+- `evals/cases/pdf-delivery-trigger-regression-case.md`: added acceptance matrix to prevent trigger-boundary drift.
 - `equipment selection / procurement / home-server planning` promoted to first-class route (routing priority #5), with provider-vs-equipment conflict rules and route-conflict examples
 - route lists in `ARCHITECTURE.md`, `SYSTEM-MAP.md`, and `README.md` updated from six to seven mature routes
 - `scripts/markdown_to_html.py`: hardened metadata HTML escaping and security model — `html.escape()` applied to all frontmatter-derived fields; `cover_meta` lines are escaped individually before joining with `<br>`

--- a/SKILL.md
+++ b/SKILL.md
@@ -302,7 +302,9 @@ For most tasks, include:
 
 Default delivery stays as text or markdown.
 
-If the user's request includes `pdf`, `PDF`, or `报告`, also produce a PDF artifact:
+If the user's request includes `pdf` or `PDF`, or uses explicit delivery-intent phrases like "生成 PDF", "导出 PDF", "PDF 报告", "保存为 PDF", "给我 PDF 文件", also produce a PDF artifact:
+
+Do not trigger PDF generation solely because the user said "报告", "研究报告", "分析报告", or similar generic report terminology that only indicates output format (text/markdown) rather than file format.
 
 1. write the final report to a `.md` file first
 2. convert it with `scripts/md_to_pdf.py`

--- a/SKILL.md
+++ b/SKILL.md
@@ -305,7 +305,7 @@ Default delivery stays as text or markdown.
 Produce a PDF artifact when the user's request shows explicit file-delivery intent:
 
 - contains `pdf` or `PDF` in a generative/delivery context (e.g. "生成 PDF", "导出 PDF", "PDF 报告", "保存为 PDF", "给我 PDF 文件", "PDF 版本", "PDF 格式")
-- includes file-oriented phrases like "报告文件", "可下载报告", "正式报告文件", "给我报告文件", "附件", "交付一个文件"
+- includes file-oriented phrases like "报告文件", "可下载报告", "正式报告文件", "给我报告文件", "交付一个文件", "作为附件给我", "以附件形式交付", "输出为附件", "交付成附件"
 - the overall request clearly asks for a deliverable file rather than just report content
 
 Do not trigger PDF generation when:

--- a/SKILL.md
+++ b/SKILL.md
@@ -302,9 +302,16 @@ For most tasks, include:
 
 Default delivery stays as text or markdown.
 
-If the user's request includes `pdf` or `PDF`, or uses explicit delivery-intent phrases like "生成 PDF", "导出 PDF", "PDF 报告", "保存为 PDF", "给我 PDF 文件", also produce a PDF artifact:
+Produce a PDF artifact when the user's request shows explicit file-delivery intent:
 
-Do not trigger PDF generation solely because the user said "报告", "研究报告", "分析报告", or similar generic report terminology that only indicates output format (text/markdown) rather than file format.
+- contains `pdf` or `PDF` in a generative/delivery context (e.g. "生成 PDF", "导出 PDF", "PDF 报告", "保存为 PDF", "给我 PDF 文件", "PDF 版本", "PDF 格式")
+- includes file-oriented phrases like "报告文件", "可下载报告", "正式报告文件", "给我报告文件", "附件", "交付一个文件"
+- the overall request clearly asks for a deliverable file rather than just report content
+
+Do not trigger PDF generation when:
+
+- the user mentions `pdf` / `PDF` only to negate or discuss it: "不要 PDF", "不用 PDF", "无需 PDF", "no PDF", "not PDF", "为什么 PDF 渲染失败", "比较 PDF 和 Markdown", or similar meta-discussion
+- the request only uses generic report terminology ("报告", "研究报告", "分析报告", "写成报告格式") that indicates output shape (text/markdown) rather than file format
 
 1. write the final report to a `.md` file first
 2. convert it with `scripts/md_to_pdf.py`

--- a/evals/cases/pdf-delivery-trigger-regression-case.md
+++ b/evals/cases/pdf-delivery-trigger-regression-case.md
@@ -1,0 +1,48 @@
+# PDF Delivery Trigger Regression Case
+
+## Case identity
+
+- **Task type:** PDF delivery trigger rule boundary test
+- **Artifact:** `SKILL.md` Delivery rule — natural language trigger for PDF pipeline
+- **Date:** 2026-05-11
+- **Why this case matters:** 中文场景中"报告"是高频词，过宽的 PDF 触发规则会导致不必要的 Playwright 渲染，增加失败面和交付延迟。这个 case 把 issue #69 的验收标准沉淀为可复现的回归矩阵，防止后续 prose 修改漂移触发边界。
+
+---
+
+## Acceptance matrix
+
+Each row is a user request fragment. The agent should decide whether to produce a PDF artifact in addition to the default markdown/text.
+
+| Input | Expected PDF | Why |
+|---|---|---|
+| 写一份报告 | No | generic report terminology, no file intent |
+| 写成研究报告格式 | No | format instruction only, not file request |
+| 这个报告帮我改一下 | No | editing request, not delivery request |
+| 给我一份研究报告 | No | report content request, no file format specified |
+| 生成 PDF 报告 | Yes | explicit "生成 PDF" |
+| 导出 PDF | Yes | explicit "导出 PDF" |
+| 保存为 PDF | Yes | explicit "保存为 PDF" |
+| 给我 PDF 文件 | Yes | explicit file + PDF |
+| 给我报告文件 | Yes | explicit file-delivery intent |
+| 可下载报告 | Yes | downloadable file intent |
+| 正式报告文件 | Yes | formal file deliverable |
+| 交付一个文件 | Yes | explicit file deliverable |
+| 附件是报告 | Yes | attachment = file deliverable |
+| 不要生成 PDF，只要 markdown | No | negation of PDF |
+| 解释一下 PDF 渲染为什么失败 | No | meta-discussion, not a request |
+| 比较 PDF 和 Markdown 的优缺点 | No | comparison/discussion, not delivery |
+| 为什么上次 PDF 输出格式乱了 | No | debugging question, not a request |
+| 生成财务报表 PDF | Yes | explicit "生成" + "PDF" |
+| 给我一份可下载的 PDF 版本 | Yes | downloadable file + PDF |
+
+## Regression rules
+
+1. PDF trigger must not fire on generic "报告" without file-delivery intent
+2. PDF trigger must not fire on negated or discussion-context `pdf`/`PDF` mentions
+3. PDF trigger must fire on explicit file-delivery phrases even without the literal string "PDF"
+4. `pdf` / `PDF` substrings alone are sufficient only when the surrounding context is generative or delivery-oriented, not meta-discussion
+
+## Related
+
+- Issue #69
+- `SKILL.md` Delivery rule

--- a/evals/cases/pdf-delivery-trigger-regression-case.md
+++ b/evals/cases/pdf-delivery-trigger-regression-case.md
@@ -27,7 +27,9 @@ Each row is a user request fragment. The agent should decide whether to produce 
 | 可下载报告 | Yes | downloadable file intent |
 | 正式报告文件 | Yes | formal file deliverable |
 | 交付一个文件 | Yes | explicit file deliverable |
-| 附件是报告 | Yes | attachment = file deliverable |
+| 请以附件形式交付报告 | Yes | output-oriented attachment delivery |
+| 附件是报告 | No | describes input attachment, not output request |
+| 附件是报告，帮我总结 | No | input attachment + content request, not file delivery |
 | 不要生成 PDF，只要 markdown | No | negation of PDF |
 | 解释一下 PDF 渲染为什么失败 | No | meta-discussion, not a request |
 | 比较 PDF 和 Markdown 的优缺点 | No | comparison/discussion, not delivery |


### PR DESCRIPTION
## Summary

Narrow the PDF delivery trigger in `SKILL.md` to avoid unnecessary PDF pipeline execution on generic Chinese "报告" terminology, and add regression protection.

## Problem

`SKILL.md` previously triggered PDF generation whenever the user's request contained `pdf`, `PDF`, or `报告`. In Chinese, "报告" is a high-frequency word in phrases like "写一份报告" that only request text/markdown output format, not a PDF file. Additionally, bare `pdf`/`PDF` matching could fire on negation ("不要 PDF") or meta-discussion ("比较 PDF 和 Markdown"), and bare `附件` matched input attachment references.

## Changes

| # | Area | Change |
|---|---|---|
| P1 | `SKILL.md` | Added file-delivery intent phrases ("报告文件", "可下载报告", "正式报告文件", "作为附件给我", "以附件形式交付", etc.). Bare `附件` replaced with output-oriented attachment phrases to avoid matching input attachment references. |
| P2 | `SKILL.md` | Added negation/discussion guardrail — do not trigger on "不要 PDF", "no PDF", "解释 PDF 渲染失败", "比较 PDF 和 Markdown", etc. |
| P3 | `evals/cases/` | Added `pdf-delivery-trigger-regression-case.md` with 20-scenario acceptance matrix covering trigger, no-trigger, negation, discussion, and input-attachment boundary cases. |

Closes #69
