### PR TITLE
feat: add runtime dependency preflight to PDF pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       - run: python3 -m py_compile scripts/*.py
       - run: python3 scripts/validate_research_pack.py examples/research-pack-example.md
       - run: python3 scripts/test_validator_regression.py
+      - run: python3 scripts/test_md_to_pdf_preflight.py
 
   smoke:
     runs-on: ubuntu-latest
@@ -96,6 +97,20 @@ jobs:
           echo 'Img stripping check OK'
           rm -rf "$temp"
       - run: python3 scripts/test_remote_block.py
+      - run: |
+          temp=$(mktemp -d)
+          printf '# Test\n\nHello.\n' > "$temp/in.md"
+          set +e
+          PLAYWRIGHT_BROWSERS_PATH="$temp/no-browsers" \
+            python3 scripts/md_to_pdf.py "$temp/in.md" "$temp/out.pdf" \
+            --title "Preflight" > "$temp/out" 2> "$temp/err"
+          rc=$?
+          set -e
+          cat "$temp/err"
+          if [ $rc -ne 1 ]; then echo "FAIL: expected exit 1, got $rc"; exit 1; fi
+          grep -qi 'chromium' "$temp/err" || { echo 'FAIL: chromium not in stderr'; exit 1; }
+          echo 'Chromium preflight check OK'
+          rm -rf "$temp"
       - run: |
           input_dir="/tmp/smoke test path"
           mkdir -p "$input_dir"

--- a/scripts/md_to_pdf.py
+++ b/scripts/md_to_pdf.py
@@ -7,8 +7,23 @@ Usage:
 import argparse
 import subprocess
 import sys
-import os
 from pathlib import Path
+
+_REQUIREMENTS_FILE = str(Path(__file__).resolve().parent.parent / 'requirements.txt')
+
+
+def _check_playwright_chromium():
+    try:
+        from playwright.sync_api import sync_playwright
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            browser.close()
+        return True
+    except Exception as e:
+        if 'Executable doesn\'t exist' in str(e):
+            return False
+        print(f"Error: Playwright Chromium found but failed to launch: {e}", file=sys.stderr)
+        sys.exit(1)
 
 
 def run(args_list, description):
@@ -18,6 +33,25 @@ def run(args_list, description):
         print(f"❌ Failed: {description}")
         sys.exit(result.returncode)
     print(f"✅ {description}")
+
+
+def _check_runtime_deps():
+    missing = []
+    for mod in ('markdown', 'nh3', 'playwright'):
+        try:
+            __import__(mod)
+        except ImportError:
+            missing.append(mod)
+
+    if missing:
+        print("Error: missing required Python packages: " + ", ".join(missing), file=sys.stderr)
+        print(f"Run: {sys.executable} -m pip install -r {_REQUIREMENTS_FILE}", file=sys.stderr)
+        sys.exit(1)
+
+    if not _check_playwright_chromium():
+        print("Error: Playwright Chromium browser is not installed", file=sys.stderr)
+        print(f"Run: {sys.executable} -m playwright install chromium", file=sys.stderr)
+        sys.exit(1)
 
 
 def main():
@@ -38,6 +72,8 @@ def main():
     if not md_path.exists():
         print(f"File not found: {md_path}")
         sys.exit(1)
+
+    _check_runtime_deps()
 
     # Determine output PDF path
     if args.output:

--- a/scripts/test_md_to_pdf_preflight.py
+++ b/scripts/test_md_to_pdf_preflight.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Verify that md_to_pdf.py preflight catches missing dependencies with a clear error."""
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPT = str(Path(__file__).resolve().parent / 'md_to_pdf.py')
+
+
+def test_file_not_found_before_preflight() -> None:
+    """File-not-found error should be reported even when deps are missing."""
+    result = subprocess.run(
+        [sys.executable, SCRIPT, '/nonexistent/input.md'],
+        capture_output=True, text=True
+    )
+    assert result.returncode == 1, f"expected exit 1, got {result.returncode}"
+    assert 'File not found' in result.stdout, (
+        f"expected 'File not found' in stdout, got: {result.stdout}"
+    )
+
+
+def test_preflight_catches_missing_nh3() -> None:
+    """Simulate missing nh3 via PYTHONPATH shim and verify clear error message."""
+    with tempfile.TemporaryDirectory() as d:
+        md_file = Path(d) / 'input.md'
+        md_file.write_text('# Test\n\nHello.\n')
+
+        shim_dir = Path(d) / '_shims'
+        shim_dir.mkdir()
+        (shim_dir / 'nh3.py').write_text('raise ImportError("simulated missing nh3")')
+
+        env = os.environ.copy()
+        pythonpath = str(shim_dir)
+        if env.get('PYTHONPATH'):
+            pythonpath += os.pathsep + env['PYTHONPATH']
+        env['PYTHONPATH'] = pythonpath
+
+        result = subprocess.run(
+            [sys.executable, SCRIPT, str(md_file)],
+            capture_output=True, text=True, env=env
+        )
+        assert result.returncode == 1, f"expected exit 1, got {result.returncode}"
+        assert 'nh3' in result.stderr, f"'nh3' not in stderr: {result.stderr}"
+        assert 'requirements.txt' in result.stderr, (
+            f"'requirements.txt' not in stderr: {result.stderr}"
+        )
+
+
+def main() -> int:
+    tests = [
+        ('file-not-found before preflight', test_file_not_found_before_preflight),
+        ('preflight catches missing nh3', test_preflight_catches_missing_nh3),
+    ]
+    failures = []
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"  PASS  {name}")
+        except AssertionError as e:
+            print(f"  FAIL  {name}: {e}")
+            failures.append(name)
+    if failures:
+        print(f"\n{len(failures)} test(s) failed: {', '.join(failures)}")
+        return 1
+    print(f"\nAll {len(tests)} tests passed.")
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## 问题

Closes #80 — 当前 `md_to_pdf.py` 在下游子进程（`markdown_to_html.py` / `render_pdf.py`）依赖缺失时，只抛 `ModuleNotFoundError`，错误信息不友好。

## 修改

### `scripts/md_to_pdf.py`

1. **Python 包预检** — 在 `main()` 入口检查 `markdown`、`nh3`、`playwright` 是否可 import，缺失时输出带绝对路径的 `pip install` 命令。
2. **Playwright Chromium 预检** — 使用 Playwright 自己的 `sync_playwright()` + `p.chromium.launch()` 做真正的浏览器可用性检查，捕获 "Executable doesn't exist" 异常时输出 `playwright install chromium`。不再手写缓存路径判断（消除 stale 目录 / 版本不匹配 / headless_shell 差异 / XDG_CACHE_HOME / LOCALAPPDATA / PLAYWRIGHT_BROWSERS_PATH=0 等问题）。
3. **执行顺序** — preflight 在文件存在性检查之后，避免遮蔽 "File not found"。
4. **修复命令使用当前解释器** — 所有提示都用 `{sys.executable} -m pip` / `{sys.executable} -m playwright`，避免多 Python 环境装歪。

### `scripts/test_md_to_pdf_preflight.py`（新增）

验证：
- 输入文件不存在时，先报 "File not found"
- 用 PYTHONPATH shim 模拟 `nh3` 缺失时，exit=1，stderr 包含 `nh3` 和 `requirements.txt`

### `.github/workflows/ci.yml`

- `quick` job 增加 `test_md_to_pdf_preflight.py`
- `smoke` job 增加 Chromium 预检测试（`PLAYWRIGHT_BROWSERS_PATH` 指向空目录，验证 preflight 捕获并输出 `chromium`）

## 不改的

- 不修改 `markdown_to_html.py` / `render_pdf.py`
- 不改 `README.md` / `SKILL.md`