### PR TITLE
修复：将 research-pack 示例中的 MiniMax 提供商引用替换为提供商中立术语

### DIFF
--- a/examples/research-pack-example.md
+++ b/examples/research-pack-example.md
@@ -31,9 +31,9 @@ Stop when the top choice, runner-up logic, and ranking-change conditions are sup
 
 ## Degraded-search log
 - Search objective: current transport and logistics sources for candidate meetup cities
-- Primary provider attempted: MiniMax web search
+- Primary provider attempted: <configured live-search provider/tool>
 - Fallback trigger: low-yield results for practical source discovery
-- Fallback provider used: Exa
+- Fallback provider used: <fallback provider/tool, e.g. secondary search provider or browser search>
 - Why this fallback fits better: broader discovery of current web sources for schedules and logistics pages
 - Candidate-source quality: mixed
 - Claims still needing primary-page verification: exact transport timing, current venue constraints


### PR DESCRIPTION
## 概要
- `examples/research-pack-example.md` 的 Degraded-search log 段仍写有 MiniMax 和相关搜索提供商引用，与 #71 已完成的提供商中立策略不一致
- 改为与 `evals/meta/degraded-search-execution.md` 模板一致的提供商中立表述

## 变更内容
| Before | After |
|---|---|
| Primary provider attempted: MiniMax web search | Primary discovery path attempted: configured live-search provider |
| Fallback provider used: Exa | Fallback path used: secondary discovery provider / browser search |

## 关联
- Closes #84
- 延续 #71 移除 MiniMax 默认依赖的清理工作