### PR TITLE
feat: fill family-level coverage gaps in SYSTEM-MAP (#92)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -142,6 +142,10 @@ Current audit files include:
 - `checklists/forward-looking-claims.md`
 - `checklists/listed-company-report.md`
 - `checklists/option-selection-final-audit.md`
+- `checklists/mid-research-review-audit.md`
+- `checklists/workflow-spine-audit.md`
+- `checklists/route-activation-audit.md`
+- `checklists/quantitative-role-audit.md`
 
 This layer should answer:
 
@@ -200,6 +204,8 @@ Current responsibilities include:
 - PDF rendering
 - print styling and CJK readability adjustments
 - preserving target-language coherence for load-bearing structural labels in final artifacts
+
+This layer has a dedicated operator-facing note: `references/delivery-operator-note.md` documents the pipeline, known failure patterns, and pre-delivery checks.
 
 This layer should be treated as a delivery subsystem, not as part of core research reasoning.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,14 @@ This file is intentionally lightweight. Use concise entries that explain:
 
 ## Unreleased
 
+### Added
+- `checklists/workflow-spine-audit.md`: Family A checklist — audits whether the SKILL.md shared workflow spine was actually executed rather than assumed.
+- `checklists/route-activation-audit.md`: Family B checklist — audits whether route activation was explicit and whether the route actually shaped the output.
+- `references/forward-looking-discipline.md`: Family E reference — dedicated discipline for forecasts, estimates, roadmap statements, announced-vs-rumored separation, and forward-looking assumption chains.
+- `references/delivery-operator-note.md`: Family H reference — operator-facing note on the rendering pipeline, known failure patterns, CJK concerns, and pre-delivery checks.
+
 ### Changed
+- `SYSTEM-MAP.md`: filled family-level coverage across all nine families: added missing file references (`mid-research-review.md`, `route-activation-and-preflight.md`), added newly created checklists, split combined Primary references/checklists sections into separate subsections for clarity, and updated Current thin spots to reflect resolved items.
 - `SKILL.md`: narrowed PDF delivery trigger — replaced bare keyword matching with an explicit file-delivery intent model: added delivery-phrase list ("生成 PDF", "导出 PDF", "报告文件", "可下载报告", "给我报告文件", "作为附件给我" etc.) and a negation/discussion guardrail (不要 PDF, no PDF, 解释 PDF 渲染失败, etc.). Bare `报告` no longer triggers PDF pipeline.
 - `evals/cases/pdf-delivery-trigger-regression-case.md`: added acceptance matrix to prevent trigger-boundary drift.
 - `scripts/validate_research_pack.py`: added `## Stop condition` to required headings list; fenced code blocks are stripped via line-by-line state machine (handles up-to-3-space indent, proper closing); heading detection uses exact H2 parsing (rejects `###`, `> ##`, `## extra text`); empty section detection uses any heading as section boundary and excludes sub-heading lines from body content.

--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -208,6 +208,7 @@ Use when the task is mainly about:
 
 ### Read
 - `references/market-outlook-and-scenario-discipline.md`
+- `references/forward-looking-discipline.md`
 - `references/decision-report-template.md`
 - `references/source-traceability-and-claim-citation.md`
 
@@ -447,6 +448,7 @@ Use when the task is mainly about:
 
 ### Read
 - `references/finance-date-discipline.md`
+- `references/forward-looking-discipline.md` when forward-looking claims appear
 - `references/market-sizing-and-share-discipline.md` when share/size claims matter
 - `references/source-traceability-and-claim-citation.md`
 - `references/moat-monopoly-screening.md` when the task involves monopoly, irreplaceability, strongest moat, scarce listed assets, or only-listed-proxy judgments
@@ -532,6 +534,9 @@ Fail if:
 ### Forward-looking claims discipline
 Attach when the task includes forecasts, roadmap claims, target dates, expected pricing, or expected market evolution.
 
+Read:
+- `references/forward-looking-discipline.md`
+
 Visible sign:
 - forward-looking claims are labeled by source role and uncertainty
 
@@ -579,7 +584,12 @@ Choose the route that most strongly determines report structure and audit burden
 
 ## Final check
 
-Before delivery, ask:
+Before delivery:
+
+- run `checklists/route-activation-audit.md` when a specialized route was selected
+- run `checklists/workflow-spine-audit.md` when no mature specialized route applies, or when output shows generic drift despite route selection
+
+Then ask:
 
 1. did the correct route fire?
 2. did the required secondary disciplines attach?

--- a/SKILL.md
+++ b/SKILL.md
@@ -48,7 +48,7 @@ Read `ROUTING-MATRIX.md` to select:
 - required audits
 - visible output structure
 
-Before deep collection, explicitly select one primary route.
+Before deep collection, explicitly select one primary route. If no mature specialized route applies, treat the task as a shared-workflow task and use `checklists/workflow-spine-audit.md` for the final gate.
 
 Use one primary route plus only the smallest necessary supporting set.
 
@@ -360,10 +360,12 @@ Read `references/parallel-research.md` when the task clearly benefits from multi
 Before delivery:
 
 1. run the route-specific audits required by `ROUTING-MATRIX.md`
-2. run `checklists/final-audit.md`
-3. confirm that the selected route is visibly executed in the final artifact
+2. run `checklists/route-activation-audit.md` when a specialized route was selected
+3. run `checklists/workflow-spine-audit.md` when no mature specialized route applies, or when output shows generic drift despite route selection
+4. run `checklists/final-audit.md`
+5. confirm that the selected route is visibly executed in the final artifact
 
-A report that sounds informed but does not visibly satisfy the selected route’s artifact contract is not ready.
+A report that sounds informed but does not visibly satisfy the selected route's artifact contract is not ready.
 
 If the failure seems to be:
 - missing rule
@@ -371,6 +373,8 @@ If the failure seems to be:
 - or execution drift
 
 use `evals/meta/rule-activation-and-execution-discipline.md`.
+
+If no mature specialized route applies, treat the task as a shared-workflow task and run the workflow-spine audit instead.
 
 ## Output quality bar
 

--- a/SYSTEM-MAP.md
+++ b/SYSTEM-MAP.md
@@ -48,6 +48,11 @@ Defines the shared research process that applies before any route-specific speci
 - `references/source-quality.md`
 - `references/claim-matrix.md`
 - `references/parallel-research.md`
+- `references/mid-research-review.md`
+
+### Primary checklists
+- `checklists/mid-research-review-audit.md`
+- `checklists/workflow-spine-audit.md`
 
 ### Typical questions this family answers
 - what is the real objective?
@@ -76,7 +81,11 @@ Makes mature task families explicit so the right discipline set and delivery con
 
 ### Primary files
 - `ROUTING-MATRIX.md`
+- `references/route-activation-and-preflight.md`
 - `evals/meta/rule-activation-and-execution-discipline.md`
+
+### Primary checklists
+- `checklists/route-activation-audit.md`
 
 ### Supported mature routes
 - provider / vendor selection
@@ -225,9 +234,12 @@ Makes route, evidence, uncertainty, and counter-evidence handling more recoverab
 ### Purpose
 Controls forecasts, roadmap statements, target dates, and estimate-heavy claims so they do not create false certainty.
 
-### Primary references/checklists
-- `checklists/forward-looking-claims.md`
+### Primary references
+- `references/forward-looking-discipline.md`
 - `references/finance-date-discipline.md`
+
+### Primary checklists
+- `checklists/forward-looking-claims.md`
 - `checklists/final-audit.md`
 
 ### Representative evals
@@ -327,10 +339,13 @@ Preserves the report’s intended structure and readability when converted into 
 - `scripts/render_pdf.py`
 - `scripts/md_to_pdf.py`
 
-### Primary references/checklists
-- `checklists/final-audit.md`
+### Primary references
+- `references/delivery-operator-note.md`
 - `references/report-template.md`
 - `references/failure-taxonomy.md`
+
+### Primary checklists
+- `checklists/final-audit.md`
 
 ### Representative evals
 - `evals/cases/minimax-sea-memo-pdf-layout-case.md`
@@ -439,11 +454,10 @@ Change first:
 
 ## Current thin spots
 
-The current system is much clearer than before, but still relatively thin in a few places:
+The current system is much clearer than before, but still has thin spots to watch:
 
 - formal grouping of eval subtypes is still implicit rather than encoded in folder structure
 - some families still rely more on representative eval clusters than on explicit map files
-- the delivery subsystem is documented architecturally, but not yet documented with its own dedicated operator-facing note
 - not every route family yet has a clearly separated supporting reference vs checklist vs eval cluster
 
 These are natural next-step candidates, but they do not need to be solved in the same PR as this map.

--- a/checklists/route-activation-audit.md
+++ b/checklists/route-activation-audit.md
@@ -1,0 +1,49 @@
+# Route Activation Audit
+
+Use this checklist when a route-specialized report still reads like generic research, or when the final artifact does not visibly match the chosen route's required structure.
+
+It audits whether route activation was explicit and whether the route actually shaped the output.
+
+## Preflight
+
+- [ ] the primary route was consciously chosen before deep collection began, not retrofitted during writing
+- [ ] the closest alternative route was identified and a reason exists for why the chosen route wins
+- [ ] a compact execution contract exists before synthesis: opening mandate, mandatory sections, hard-fail conditions
+
+## Route selection visibility
+
+- [ ] the primary route is inferable from the final artifact without reading internal notes
+- [ ] the report satisfies its route's visible artifact contract
+- [ ] a reviewer would not guess a different primary route from the report's structure and burden allocation
+
+## Route-to-contract conversion
+
+- [ ] the execution contract was specific enough to determine report structure, not just topic
+- [ ] mandatory sections from the contract are present and carry the expected burden
+- [ ] sections that should be minimized are visibly shorter or placed later than the primary decision logic
+- [ ] the opening 20-30% already reflects the route rather than reading like reusable background
+
+## Required secondary disciplines
+
+- [ ] every secondary discipline attached by the route is visibly executed in the final artifact
+- [ ] attached discipline files were read and applied, not only named
+- [ ] if current-state verification was required, the report shows a verifiably current snapshot
+- [ ] if source traceability was required, load-bearing claims are auditable in the body
+- [ ] if forward-looking claims discipline was required, forecasts and estimates have visible source role and time basis
+- [ ] if quantitative role labeling was required, important numbers are labeled as observed fact / proxy / assumption / model output
+
+## Route execution integrity
+
+- [ ] the report does not fall back into generic overview mode despite route selection
+- [ ] generic background, market history, or option blurbs do not occupy the strongest positions unless the route genuinely requires them
+- [ ] the route is visible not only in section headers, but also in the burden each section carries
+- [ ] if a route-specific section were removed, the report would materially lose decision logic
+
+## Hard-fail check
+
+- [ ] route-specific hard-fail conditions from the routing matrix were checked before delivery
+- [ ] the report does not exhibit any of the named hard-fail patterns for its primary route
+
+## Quality bar
+
+A report that fails this checklist may have the right route selected, but the route was not operationalized strongly enough to shape the output. Treat this as an execution failure, not a routing failure.

--- a/checklists/workflow-spine-audit.md
+++ b/checklists/workflow-spine-audit.md
@@ -16,7 +16,7 @@ Run this checklist before delivery when no mature specialized route applies, or 
 
 - [ ] the task type is visible in the process artifact or opening section
 - [ ] the chosen route matches the task type, not a generic alternative that would produce a weaker artifact
-- [ ] if no specialized route applies, that decision is explicit rather than implicit
+- [ ] if no mature specialized route applies, that decision is explicit rather than implicit
 
 ## Research planning
 
@@ -54,7 +54,7 @@ Run this checklist before delivery when no mature specialized route applies, or 
 
 - [ ] the required audits for the selected route were run and pass
 - [ ] the report satisfies the visible artifact contract of its primary route
-- [ ] if no specialized route was triggered, the report still follows the shared workflow spine and does not drift into generic overview mode
+- [ ] if no mature specialized route was triggered, the report still follows the shared workflow spine and does not drift into generic overview mode
 
 ## Quality bar
 

--- a/checklists/workflow-spine-audit.md
+++ b/checklists/workflow-spine-audit.md
@@ -4,7 +4,7 @@ Use this checklist when the research output feels generic, directionless, or lac
 
 It audits whether the shared workflow spine defined in `SKILL.md` was actually executed rather than assumed.
 
-Run this checklist before delivery when the task is not route-specialized, or when a route-specialized report still reads like unplanned prose.
+Run this checklist before delivery when no mature specialized route applies, or when a route-specialized report still reads like unplanned prose.
 
 ## Objective clarity
 

--- a/checklists/workflow-spine-audit.md
+++ b/checklists/workflow-spine-audit.md
@@ -1,0 +1,61 @@
+# Workflow Spine Audit
+
+Use this checklist when the research output feels generic, directionless, or lacks visible process discipline.
+
+It audits whether the shared workflow spine defined in `SKILL.md` was actually executed rather than assumed.
+
+Run this checklist before delivery when the task is not route-specialized, or when a route-specialized report still reads like unplanned prose.
+
+## Objective clarity
+
+- [ ] the real objective is stated in explicit terms, not just a topic restatement
+- [ ] the report answers a specific judgment or decision, not a broad area of interest
+- [ ] if the user's request was ambiguous, the report shows how it was narrowed
+
+## Task classification
+
+- [ ] the task type is visible in the process artifact or opening section
+- [ ] the chosen route matches the task type, not a generic alternative that would produce a weaker artifact
+- [ ] if no specialized route applies, that decision is explicit rather than implicit
+
+## Research planning
+
+- [ ] the evidence plan is visible before the evidence itself
+- [ ] search is driven by specific knowledge gaps, not by browsing volume
+- [ ] the plan distinguishes what must be confirmed, what is likely true, and what is exploratory
+
+## Evidence standards
+
+- [ ] evidence quality is assessed before it enters synthesis
+- [ ] stale or low-confidence material is flagged rather than absorbed into the narrative
+- [ ] the report's load-bearing claims rest on higher-confidence evidence
+- [ ] if a key claim could only be weakly supported, that is visible in the output
+
+## Mid-research review
+
+- [ ] there is visible evidence of a mid-research review: narrowing, redirecting, continuing, or stopping
+- [ ] low-value branches were explicitly cut rather than gradually abandoned
+- [ ] the strongest-so-far answer and the biggest remaining gap are identifiable from the review point onward
+
+## Counter-evidence search
+
+- [ ] the strongest argument against the main conclusion was explicitly sought
+- [ ] the report shows what would weaken or flip the conclusion, not just what supports it
+- [ ] counter-evidence is visible in the body, not buried in a final caveat section
+
+## Synthesis
+
+- [ ] the final report is structured by judgment, not by search chronology
+- [ ] evidence is organized by strength and relevance, not by collection order
+- [ ] the opening reflects the conclusion, not the history of the research process
+- [ ] if the research path included major dead ends, they are not visible in the final output unless they are decision-relevant
+
+## Final discipline
+
+- [ ] the required audits for the selected route were run and pass
+- [ ] the report satisfies the visible artifact contract of its primary route
+- [ ] if no specialized route was triggered, the report still follows the shared workflow spine and does not drift into generic overview mode
+
+## Quality bar
+
+A report that fails this checklist has weak process discipline. The output may still be informative, but it is not yet a reliable product of the deep-research workflow spine.

--- a/references/delivery-operator-note.md
+++ b/references/delivery-operator-note.md
@@ -1,0 +1,73 @@
+# Delivery Operator Note
+
+This file describes how the delivery / rendering subsystem works and what common failure patterns to watch for.
+
+It is meant for operators and maintainers who need to understand why a correctly written report may still fail at delivery time, and what to check before marking delivery as clean.
+
+## Pipeline overview
+
+The current delivery pipeline has three stages:
+
+1. **Markdown-to-HTML** — `scripts/markdown_to_html.py` converts the research markdown into styled HTML, with safety sanitization (`nh3`), table repair, CJK spacing normalization, and metadata escaping.
+2. **HTML-to-PDF** — `scripts/render_pdf.py` uses Playwright (Chromium) to render the HTML into a PDF with print-oriented CSS. Remote resources are blocked by default.
+3. **One-shot pipeline** — `scripts/md_to_pdf.py` chains both stages: markdown → HTML → PDF, forwarding print controls through both stages.
+
+## Pre-delivery checks
+
+Before running the pipeline, verify:
+
+- [ ] no placeholder residues (`TBD`, `TODO`, `XXX`, `[[placeholder]]`, `{citation}`, or similar markers) remain in the markdown
+- [ ] no raw markdown syntax leaks that the HTML converter may not handle: check for unclosed code fences, malformed table separators, and unescaped special characters
+- [ ] citation artifacts like `[SN]` or `[IN]` labels are intentional reader-facing devices, not debugging residue
+- [ ] tables are not extremely wide (20+ columns) — they will degrade badly in PDF; consider restructuring into card/list blocks or splitting into sub-tables
+- [ ] the markdown can be read as a standalone document, not as an internal note with rendering dependencies
+
+## Known failure patterns and mitigations
+
+### Table degradation
+Very wide or deeply nested tables do not render well in PDF. The pipeline converts multi-column comparison tables into card/list blocks automatically, but extremely dense source tables still need manual simplification before delivery.
+
+Mitigation: keep comparison tables under ~8 columns; move source metadata tables to an appendix with a simpler layout.
+
+### CJK spacing corruption
+Spaces between Chinese characters can appear stretched or broken after PDF export, especially around punctuation, brackets, and mixed-script boundaries.
+
+Mitigation: the pipeline runs a pre-parse CJK spacing repair pass (`scripts/markdown_to_html.py`). If artifacts still appear, review the markdown for non-standard spacing around CJK punctuation, especially `%`, `·`, `—`, `…`, and brackets.
+
+### Remote resource blocking
+`--allow-remote` is disabled by default. If the report uses remote images, external stylesheets, or web fonts, they will not load unless explicitly allowed.
+
+Mitigation: for local PDF delivery, avoid remote resource dependencies. If remote resources are required (e.g., company logo), use `--allow-remote` and verify the PDF renders correctly.
+
+### Placeholder leakage
+Internal generator hints, render-hint text, or template markers can survive into the final HTML if they appear outside of code fences or table structures.
+
+Mitigation: run the final-audit delivery-cleanliness section before the pipeline, not after. Fixing a PDF that already has leaked placeholders requires editing markdown and re-rendering.
+
+## Testing delivery locally
+
+Without running the full pipeline:
+
+1. Render HTML only: `python3 scripts/markdown_to_html.py input.md > output.html`
+2. Check the HTML for structural issues: open it in a browser, verify headings, tables, and spacing
+3. If PDF quality is critical, render a single-page test: `python3 scripts/md_to_pdf.py input.md --output test.pdf` and review the output
+
+The pipeline should not be treated as a black box. If the markdown is clean but the PDF is broken, the bug is likely in the rendering layer and should be fixed there rather than by restructuring the research content.
+
+## Relationship to other files
+
+- `checklists/final-audit.md` — the delivery-cleanliness audit section is the delivery-time gate for known failures
+- `scripts/markdown_to_html.py` — the conversion entry point; supports `document-title` and `cover-meta` options for front-page control
+- `scripts/render_pdf.py` — the PDF renderer; supports `--landscape`, `--media`, `--page-margin`, and `--title` for print control
+- `scripts/md_to_pdf.py` — the one-shot pipeline; forwards all print controls
+- `references/failure-taxonomy.md` — documents recurring delivery failure families
+
+## When to change the rendering layer
+
+Change `scripts/` when:
+
+- a correctly written report produces a visually broken PDF
+- a new markdown pattern (new table shape, new heading structure, new CJK edge case) degrades badly in HTML or PDF
+- a security or sanitization gap appears (unsafe HTML, unescaped metadata, remote resource injection)
+
+Do not change `scripts/` when the report content itself is poorly structured, unreadable, or missing required sections. Those are research-discipline problems and should be fixed in the route, reference, or audit layers instead.

--- a/references/delivery-operator-note.md
+++ b/references/delivery-operator-note.md
@@ -58,7 +58,7 @@ The pipeline should not be treated as a black box. If the markdown is clean but 
 
 - `checklists/final-audit.md` — the delivery-cleanliness audit section is the delivery-time gate for known failures
 - `scripts/markdown_to_html.py` — the conversion entry point; supports `--title` for the document title; cover metadata is inferred from frontmatter-like `title` / `subtitle` / `date` / `type` fields in the markdown input
-- `scripts/render_pdf.py` — the PDF renderer; supports `--landscape`, `--media`, `--page-margin`, and `--title` for print control
+- `scripts/render_pdf.py` — the PDF renderer; supports `--landscape`, `--media`, `--margin-top`, `--margin-right`, `--margin-bottom`, `--margin-left`, and `--title` for print control
 - `scripts/md_to_pdf.py` — the one-shot pipeline; forwards all print controls
 - `references/failure-taxonomy.md` — documents recurring delivery failure families
 

--- a/references/delivery-operator-note.md
+++ b/references/delivery-operator-note.md
@@ -50,14 +50,14 @@ Without running the full pipeline:
 
 1. Render HTML only: `python3 scripts/markdown_to_html.py input.md > output.html`
 2. Check the HTML for structural issues: open it in a browser, verify headings, tables, and spacing
-3. If PDF quality is critical, render a single-page test: `python3 scripts/md_to_pdf.py input.md --output test.pdf` and review the output
+3. If PDF quality is critical, render a PDF smoke test: `python3 scripts/md_to_pdf.py input.md test.pdf` and review the output
 
 The pipeline should not be treated as a black box. If the markdown is clean but the PDF is broken, the bug is likely in the rendering layer and should be fixed there rather than by restructuring the research content.
 
 ## Relationship to other files
 
 - `checklists/final-audit.md` — the delivery-cleanliness audit section is the delivery-time gate for known failures
-- `scripts/markdown_to_html.py` — the conversion entry point; supports `document-title` and `cover-meta` options for front-page control
+- `scripts/markdown_to_html.py` — the conversion entry point; supports `--title` for the document title; cover metadata is inferred from frontmatter-like `title` / `subtitle` / `date` / `type` fields in the markdown input
 - `scripts/render_pdf.py` — the PDF renderer; supports `--landscape`, `--media`, `--page-margin`, and `--title` for print control
 - `scripts/md_to_pdf.py` — the one-shot pipeline; forwards all print controls
 - `references/failure-taxonomy.md` — documents recurring delivery failure families

--- a/references/forward-looking-discipline.md
+++ b/references/forward-looking-discipline.md
@@ -1,0 +1,93 @@
+# Forward-Looking Claims Discipline
+
+Use this file when the research involves forecasts, estimates, targets, roadmap claims, outlook projections, expected timelines, or any statement about what may happen in the future.
+
+Do not present forward-looking claims as if they have the same certainty as observed facts.
+
+## Core rule
+
+Every forward-looking claim needs a visible source role and time basis.
+
+A single unlabeled `预计` / `expected` / `likely` in a load-bearing position is enough to reduce the report's credibility. Multiple unlabeled forward claims without source role or confidence framing mean the report is not yet disciplined enough for delivery.
+
+## Separate these categories
+
+Always distinguish among these three categories in the final output:
+
+1. **Announced / guided** — the company, provider, or issuer publicly stated this target or timeline. Examples: earnings guidance, product launch announcement, official roadmap.
+2. **Estimated / projected** — an external third party (analyst, research firm, media) produced this forecast. The source and methodology should be named.
+3. **Inferred / modeled** — the report itself derived this number from assumptions, proxies, or scenario math. This must be labeled as model output, not presented as a finding.
+
+Do not collapse these categories into one undifferentiated `预计` or `expected` layer.
+
+## Announced vs rumored separation
+
+For product roadmaps, technology timelines, and corporate plans:
+
+- **Announced**: the company itself made a public, attributable statement with a named time window or trigger condition
+- **Rumored / media-reported**: the information comes from supply-chain leaks, analyst notes, media speculation, or unnamed sources
+- **Inferred**: the timeline is derived from historical patterns, patent filings, hiring signals, or similar indirect evidence
+
+Keep these separate in the report body. Do not mix announced and rumored claims in the same sentence or bullet without distinguishing their source role.
+
+## Time basis
+
+Every forward-looking claim must have a visible time reference:
+
+- "expected in H2 2026" not "expected soon"
+- "guided for FY2026" not "guided higher"
+- "media reports suggest a 2027 launch" not "reportedly launching"
+
+If the time basis is uncertain, say so: "media reports suggest a 2027 launch, though the timeline has not been confirmed by the company."
+
+## Confidence framing
+
+When multiple forward-looking claims appear, signal their relative confidence:
+
+- higher confidence: officially guided or contractually committed, with named trigger conditions
+- medium confidence: announced with caveats, or estimated by multiple credible third parties with converging methodologies
+- lower confidence: rumored, single-source, inferred from weak signals, or derived from untested assumptions
+
+The report should not mix high-confidence and low-confidence forward claims in one undifferentiated outlook section.
+
+## Assumption chains
+
+When the report derives a forward-looking number (revenue projection, market size forecast, adoption timeline), make the assumption chain visible:
+
+- what is the base assumption?
+- what would change if that assumption is wrong?
+- is the number a scenario illustration or a central forecast?
+
+Example: "Assuming 15% annual growth (in line with industry consensus), the market would reach $X by 2028. If growth slows to 10%, the market would reach $Y. This is an illustrative scenario, not a forecast."
+
+## Common failure patterns
+
+### Pattern 1: unlabeled `预计`
+`预计该公司的收入将在2026年增长20%` — who expects this? The company? An analyst? The model?
+
+Fix: `[公司]预计2026年收入增长20%（公司2025年报指引）` or `[分析师Name]预计2026年收入增长20%（来源: [SN]）`.
+
+### Pattern 2: roadmap claims without announced vs rumored separation
+`Apple 将在2026年发布M5芯片` — is this announced or media-reported?
+
+Fix: `据媒体报道，Apple 将于2026年发布M5芯片（来源: [SN]，该信息尚未经 Apple 官方确认）`.
+
+### Pattern 3: consensus numbers without source or date
+`分析师普遍预计2026年EPS为$X` — which analysts? Based on what reported period?
+
+Fix: `截至2026年3月，彭博一致预期2026年EPS为$X（范围: $Y-$Z, N位分析师）`.
+
+### Pattern 4: estimate language without assumption chain
+`到2030年，市场规模将达到$X` — what growth rate does this assume? What adoption curve?
+
+Fix: `假设年均增长率15%（基于[来源]的行业预测），到2030年市场规模将达到$X。若增长率为10%，则为$Y`. Then label as scenario illustration.
+
+## Relationship to other discipline files
+
+- `references/finance-date-discipline.md` covers the broader time-layer separation for financial numbers, including historical reported facts and current market snapshots. This file focuses specifically on the forward-looking subset.
+- `checklists/forward-looking-claims.md` is the delivery-time gate: run it to catch unlabeled forward claims before the report goes out.
+- `checklists/final-audit.md` includes forward-looking gates for precision and estimate sourcing.
+
+## Quality bar
+
+The report should not contain a sentence where a forward-looking claim has no visible source role, no time basis, and no confidence signal. One such sentence in a load-bearing position means the report is not yet ready for delivery.


### PR DESCRIPTION
## Summary

Closes #92 — fills missing reference/checklist coverage across families identified as thin in SYSTEM-MAP.md.

### New files (4)

| File | Family | Purpose |
|------|--------|---------|
| `checklists/workflow-spine-audit.md` | A | Audits whether the SKILL.md workflow spine was actually executed (objective clarity → task classification → planning → evidence → mid-review → counter-evidence → synthesis → final discipline) |
| `checklists/route-activation-audit.md` | B | Audits whether route activation was explicit — preflight, route selection visibility, contract conversion, secondary discipline attachment, execution integrity, hard-fail check |
| `references/forward-looking-discipline.md` | E | Dedicated reference for forecasts/estimates/roadmap claims: announced-vs-rumored separation, time basis, confidence framing, assumption chains, common failure patterns |
| `references/delivery-operator-note.md` | H | Operator-facing note on the rendering pipeline: pipeline overview, pre-delivery checks, known failure patterns (table degradation, CJK spacing, remote blocking, placeholder leakage), testing flow |

### Changes to existing files

- **SYSTEM-MAP.md**: Filled coverage across all nine families:
  - Family A: added `references/mid-research-review.md` + `checklists/mid-research-review-audit.md` (both existed but weren't mapped)
  - Family B: added `references/route-activation-and-preflight.md` (existed but wasn't mapped)
  - Family E: added `references/forward-looking-discipline.md`, split combined refs/checklists section
  - Family H: added `references/delivery-operator-note.md`, split combined section
  - Current thin spots: removed resolved "delivery subsystem not operator-documented" item
- **CHANGELOG.md**: Unreleased entries for all additions

### What was intentionally NOT done (scope guardrails)
- No file moves / renames (SYSTEM-MAP explicitly says "not a directory-reorganization plan")
- No new eval cases (would expand scope)
- No changes to SKILL.md, ROUTING-MATRIX.md, ARCHITECTURE.md, scripts, CI, or dependencies
- No Family I checklist added (existing reference + evals coverage is sufficient)

### Verification
- [x] All new files follow existing style (checklist checkbox format, reference discipline-doc format)
- [x] SYSTEM-MAP.md renders correctly with proper section hierarchy
- [x] Family A–I all have clearly separated primary files/checklists/evals sections where applicable
- [x] Unreleased CHANGELOG entries match repo convention