### PR TITLE
feat: elevate listed-company stale-anchor to explicit sub-family in taxonomy, checklist, and meta-eval

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,7 @@ This file tracks likely next improvements and helps keep repo evolution intentio
 - Add more evals for freshness, counter-evidence, and decision-quality regressions.
 - Test the skill against more real fast-moving company/product cases.
 - Tighten current-state verification if stale facts still leak into reports.
-- Treat **listed-company stale-anchor selection** as a distinct failure family rather than only a generic freshness issue: test whether older-but-plausible annual / quarterly / market snapshots are still silently becoming the memo baseline, and decide whether this needs a dedicated meta-eval or failure-taxonomy entry.
+- Continue testing whether the stale-anchor hard gate (added to `checklists/listed-company-report.md`) reliably triggers during real listed-company synthesis, and harden route activation if the gate keeps being skipped.
 - Add meta-evals and trigger-routing improvements for failure families identified in `references/failure-taxonomy.md`, especially rule activation, scope completeness, decision utility, and market-outlook routing.
 - Decide whether to formalize eval subtypes (`case`, `rubric`, `distillation`, `meta-eval`) in naming or folder structure.
 - Run at least 2-3 more real comparative-distillation cases and promote only the recurring candidate rules.

--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -502,7 +502,7 @@ Fail if the report:
 
 - mixes reported metrics and forward estimates without clear labels
 - uses undated financial numbers
-- names a stale or mis-timed quarterly / interim period in the research-anchor block and still proceeds as if the memo were current
+- names a stale or mis-timed research-anchor layer — latest full-year, quarterly / interim, or current market snapshot — and still proceeds as if the memo were current
 - makes market-position claims without scope
 - lets valuation narrative substitute for business evidence
 - treats A-share uniqueness as supply-side monopoly or industry exclusivity

--- a/SYSTEM-MAP.md
+++ b/SYSTEM-MAP.md
@@ -131,6 +131,8 @@ Protects fast-moving research from stale facts, frozen time layers, and blurred 
 - `evals/cases/ranking-and-current-claims-xiaomi-update-case.md`
 - `evals/cases/finance-and-market-share-cambricon-case.md`
 - `evals/cases/minimax-company-report-case.md`
+- `evals/cases/intel-current-state-freshness-case.md`
+- `evals/cases/cnooc-judgment-shape-improved-but-freshness-still-leaked-case.md`
 
 ### Typical failure signs
 - stale product or model generation presented as current

--- a/checklists/listed-company-report.md
+++ b/checklists/listed-company-report.md
@@ -24,6 +24,10 @@ Run through every item before delivering the final report.
 - [ ] forward-looking targets or estimates are clearly labeled as such, not presented as confirmed facts
 - [ ] older but still useful numbers are visibly labeled as historical background / older snapshot rather than treated as current-state anchors
 
+## Stale-anchor hard-fail gate
+
+- [ ] stale-anchor hard gate: a stale or mis-timed quarterly / interim period in the research-anchor block invalidates the memo unless explicitly corrected before delivery — per SKILL.md fail-fast rule
+
 ## Current product lineup
 
 - [ ] current flagship product generation verified (not stale)

--- a/checklists/listed-company-report.md
+++ b/checklists/listed-company-report.md
@@ -26,7 +26,7 @@ Run through every item before delivering the final report.
 
 ## Stale-anchor hard-fail gate
 
-- [ ] stale-anchor hard gate: a stale or mis-timed quarterly / interim period in the research-anchor block invalidates the memo unless explicitly corrected before delivery — per SKILL.md fail-fast rule
+- [ ] stale-anchor hard gate: a stale or mis-timed research-anchor layer — latest full-year, quarterly / interim, or current market snapshot — invalidates the memo unless synthesis was stopped, the anchor was re-checked, and the anchor was corrected or visibly downgraded before continuing — per SKILL.md fail-fast rule
 
 ## Current product lineup
 

--- a/evals/meta/listed-company-judgment-memo-execution-family.md
+++ b/evals/meta/listed-company-judgment-memo-execution-family.md
@@ -253,6 +253,8 @@ When using this meta-eval, classify the failure primarily as one of:
 ### A. Anchor-governance failure
 The report did not let current reporting layers govern the memo shape.
 
+Common trigger: the report date is materially later than the allegedly latest reporting period in the research-anchor block; older but easier-to-retrieve snapshots silently become the opening baseline. This is the classic stale-anchor pattern documented in `evals/cases/intel-current-state-freshness-case.md` and `evals/cases/cnooc-judgment-shape-improved-but-freshness-still-leaked-case.md`.
+
 ### B. Judgment-shape failure
 The report still reads like a profile or overview rather than a memo.
 

--- a/references/failure-taxonomy.md
+++ b/references/failure-taxonomy.md
@@ -44,6 +44,7 @@ This is one of the highest-severity failure families because it directly breaks 
 - ranking or market-position claim written in present tense without time basis
 - valuation snapshot missing in listed-company research
 - reported financials, market snapshot, and estimates blended into one narrative
+- listed-company stale-anchor selection: older-but-plausible annual / quarterly / market snapshots silently become the memo baseline
 
 ### Existing evals in this family
 - `evals/cases/freshness-xiaomi-case.md`
@@ -52,6 +53,8 @@ This is one of the highest-severity failure families because it directly breaks 
 - `evals/cases/ranking-and-current-claims-xiaomi-update-case.md`
 - `evals/cases/finance-and-market-share-cambricon-case.md` (partial overlap)
 - `evals/cases/minimax-company-report-case.md` (partial overlap)
+- `evals/cases/intel-current-state-freshness-case.md`
+- `evals/cases/cnooc-judgment-shape-improved-but-freshness-still-leaked-case.md`
 
 ### Existing rule/checklist coverage
 - `references/current-state-verification.md`
@@ -63,10 +66,21 @@ This is one of the highest-severity failure families because it directly breaks 
 ### What this family suggests structurally
 The repo already has rules for this family. The remaining problem is often not missing guidance but **failure to trigger the correct gate**.
 
+### Stale-anchor sub-family (listed-company)
+
+This sub-family captures a recurring failure mode within Family A that has become distinct enough to warrant explicit treatment:
+
+- older-but-plausible annual / quarterly / market snapshots silently become the memo's opening baseline
+- the rest of the memo is factually reasonable but structurally anchored on stale time layers
+- the failure is particularly dangerous when the memo shape is otherwise good — a polished artifact makes stale anchors harder to spot
+
+See `evals/meta/listed-company-judgment-memo-execution-family.md` (diagnosis type A — anchor-governance failure) for the execution-family framing route.
+
 ### Priority improvement direction
 - strengthen trigger routing for listed-company, current-position, ranking, and fast-moving product tasks
 - make required current-snapshot fields more visible in delivery-time audit
 - add meta-evals for whether the right checklist was actually activated
+- treat stale-anchor selection as a hard-fail condition in listed-company checklists, not only as a freshness reminder
 
 ---
 


### PR DESCRIPTION
## Summary

根据 Issue #93 的分析结论（详见评审），不做独立失败家族，而是增量加固现有文件：

- **`references/failure-taxonomy.md`** — Family A 中新增显式 stale-anchor sub-family 子节，添加 intel/cnooc case 引用
- **`checklists/listed-company-report.md`** — 新增 "Stale-anchor hard-fail gate" 独立章节，强制 SKILL.md fail-fast rule
- **`evals/meta/listed-company-judgment-memo-execution-family.md`** — 为 A. Anchor-governance failure 补充 Common trigger 描述
- **`SYSTEM-MAP.md`** — Family C 增加 intel/cnooc 两个 stale-anchor case 引用

## Scope 控制

- ❌ 不拆独立失败家族（维持 Family A sub-family 定位）
- ❌ 不加新 meta-eval 文件（Intel + CNOOC case 已覆盖）
- ❌ 不改 SKILL.md / ROUTING-MATRIX.md（已充分覆盖）

Closes #93