### PR TITLE
fix: remove MiniMax-specific provider from example

### DIFF
--- a/examples/research-pack-example.md
+++ b/examples/research-pack-example.md
@@ -31,9 +31,10 @@ Stop when the top choice, runner-up logic, and ranking-change conditions are sup
 
 ## Degraded-search log
 - Search objective: current transport and logistics sources for candidate meetup cities
-- Primary provider attempted: configured live-search provider
+- Primary discovery path attempted: live-search path selected after capability preflight
 - Fallback trigger: low-yield results for practical source discovery
-- Fallback provider used: secondary discovery provider / browser search
+- Query-shape adjustment before fallback: narrowed to official schedule, route, and venue-constraint pages; yield remained low
+- Fallback path used: browser-based source discovery
 - Why this fallback fits better: broader discovery of current web sources for schedules and logistics pages
 - Candidate-source quality: mixed
 - Claims still needing primary-page verification: exact transport timing, current venue constraints

--- a/examples/research-pack-example.md
+++ b/examples/research-pack-example.md
@@ -31,9 +31,9 @@ Stop when the top choice, runner-up logic, and ranking-change conditions are sup
 
 ## Degraded-search log
 - Search objective: current transport and logistics sources for candidate meetup cities
-- Primary provider attempted: MiniMax web search
+- Primary discovery path attempted: configured live-search provider
 - Fallback trigger: low-yield results for practical source discovery
-- Fallback provider used: Exa
+- Fallback path used: secondary discovery provider / browser search
 - Why this fallback fits better: broader discovery of current web sources for schedules and logistics pages
 - Candidate-source quality: mixed
 - Claims still needing primary-page verification: exact transport timing, current venue constraints

--- a/examples/research-pack-example.md
+++ b/examples/research-pack-example.md
@@ -31,9 +31,9 @@ Stop when the top choice, runner-up logic, and ranking-change conditions are sup
 
 ## Degraded-search log
 - Search objective: current transport and logistics sources for candidate meetup cities
-- Primary discovery path attempted: configured live-search provider
+- Primary provider attempted: configured live-search provider
 - Fallback trigger: low-yield results for practical source discovery
-- Fallback path used: secondary discovery provider / browser search
+- Fallback provider used: secondary discovery provider / browser search
 - Why this fallback fits better: broader discovery of current web sources for schedules and logistics pages
 - Candidate-source quality: mixed
 - Claims still needing primary-page verification: exact transport timing, current venue constraints


### PR DESCRIPTION
## Summary

- Remove MiniMax-specific provider from `examples/research-pack-example.md`
- Align degraded-search log with SKILL.md provider-neutral strategy
- Add query-shape adjustment line per `references/research-pack-contract.md`

## Changes

**File:** `examples/research-pack-example.md`

| Line | Before | After |
|------|--------|-------|
| 34 | `Primary provider attempted: MiniMax web search` | `Primary discovery path attempted: live-search path selected after capability preflight` |
| 35-36 | (missing) | `Query-shape adjustment before fallback: narrowed to official schedule, route, and venue-constraint pages; yield remained low` |
| 37 | `Fallback provider used: Exa` | `Fallback path used: browser-based source discovery` |

## Why

Example files are high-weight references for agent behavior. The old wording could mislead agents into treating MiniMax as the default search path, even though SKILL.md has already moved to a provider-neutral approach.

## Scope

- Only `examples/research-pack-example.md` changed
- `evals/` MiniMax files preserved as historical research samples
- `SYSTEM-MAP.md`, `CHANGELOG.md` unchanged (correct historical references)

Closes #84
