### PR TITLE
Add meta-evals and route disciplines for scope-completeness and decision-utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,28 @@ This file is intentionally lightweight. Use concise entries that explain:
 - `evals/cases/consensus-and-forward-pe-misuse-case.md`: eval testing consensus target price as fair value, forward PE as reported fact, and stale consensus after earnings.
 - `evals/cases/reporting-period-and-ttm-confusion-case.md`: eval testing TTM vs fiscal year confusion, preliminary vs audited, and restated figures.
 
+### Added
+- `evals/meta/scope-completeness-discipline.md`: Family F meta-eval — root-cause diagnosis for scope-completeness failures (missing rule / missing trigger / route misclassification / execution failure / data unavailability).
+- `evals/meta/decision-utility-discipline.md`: meta-eval for decision-utility failures — root-cause diagnosis (missing route / weak contract / template gap / execution failure / wrong route). Distinguishable from `evals/templates/decision-utility-rubric.md` (scoring tool) by focus on "which repo layer should change".
+- `references/scope-completeness-discipline.md`: reusable minimum-coverage standard for global/comprehensive claims — geography coverage matrix, common failure patterns, acceptable partial scope rules.
+- `ROUTING-MATRIX.md`: added scope completeness and decision utility as cross-cutting disciplines with attach triggers, visible signs, and hard-fail conditions.
+- `ROUTING-MATRIX.md`: wired scope completeness and decision utility into relevant route `### Attach` lists (provider/vendor selection, market entry, market outlook, first-tier positioning, constrained choice, equipment selection, listed-company).
+- `SKILL.md`: added scope completeness and decision utility to core shared disciplines list.
+- `checklists/route-activation-audit.md`: added visible-execution checks for scope completeness and decision utility.
+- `checklists/final-audit.md`: added recall-discipline entries for scope completeness and decision utility.
+
+### Changed
+- `references/failure-taxonomy.md`:
+  - Family E: added decision-utility rubric and meta-eval to existing evals; updated priority direction from "add evaluation" to "checklist-level gate / route activation hardening".
+  - Family F: added `references/scope-completeness-discipline.md` and updated coverage status; updated priority direction from "dedicated eval" to "route-trigger consistency / final-audit recall".
+  - "What this taxonomy implies should happen next": marked scope-completeness eval and decision-utility rubric as done, with remaining next steps documented.
+  - Short classification table: updated Family F and Meta-Rule-Activation status to reflect current coverage.
+- `SYSTEM-MAP.md`: mapped `evals/meta/scope-completeness-discipline.md` and `evals/meta/decision-utility-discipline.md` to Family G.
+- `ROADMAP.md`: split P1 meta-eval item into completed (scope/decision meta-evals + route discipline) and remaining (checklist gate / market-outlook validation / remaining route hardening).
+
+### Why
+- Per issue #97 (P1), failure-taxonomy families lacked corresponding meta-evals and route-trigger coverage. Added meta-evals for scope completeness and decision utility, wired them into the execution chain (SKILL.md, ROUTING-MATRIX.md route Attach, checklists), and created a reusable reference-level rule for scope completeness that was previously missing.
+
 ### Changed
 - `SYSTEM-MAP.md`: filled family-level coverage across all nine families: added missing file references (`mid-research-review.md`, `route-activation-and-preflight.md`), added newly created checklists, split combined Primary references/checklists sections into separate subsections for clarity, and updated Current thin spots to reflect resolved items.
 - `SKILL.md`: narrowed PDF delivery trigger — replaced bare keyword matching with an explicit file-delivery intent model: added delivery-phrase list ("生成 PDF", "导出 PDF", "报告文件", "可下载报告", "给我报告文件", "作为附件给我" etc.) and a negation/discussion guardrail (不要 PDF, no PDF, 解释 PDF 渲染失败, etc.). Bare `报告` no longer triggers PDF pipeline.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,6 @@ This file is intentionally lightweight. Use concise entries that explain:
 - `references/reporting-period-handling.md`: P2 reference — reporting-period definitions: FY vs CY, TTM/LTM/NTM, preliminary/unaudited/restated, post-period events.
 - `evals/cases/consensus-and-forward-pe-misuse-case.md`: eval testing consensus target price as fair value, forward PE as reported fact, and stale consensus after earnings.
 - `evals/cases/reporting-period-and-ttm-confusion-case.md`: eval testing TTM vs fiscal year confusion, preliminary vs audited, and restated figures.
-
-### Added
 - `evals/meta/scope-completeness-discipline.md`: Family F meta-eval — root-cause diagnosis for scope-completeness failures (missing rule / missing trigger / route misclassification / execution failure / data unavailability).
 - `evals/meta/decision-utility-discipline.md`: meta-eval for decision-utility failures — root-cause diagnosis (missing route / weak contract / template gap / execution failure / wrong route). Distinguishable from `evals/templates/decision-utility-rubric.md` (scoring tool) by focus on "which repo layer should change".
 - `references/scope-completeness-discipline.md`: reusable minimum-coverage standard for global/comprehensive claims — geography coverage matrix, common failure patterns, acceptable partial scope rules.
@@ -40,11 +38,6 @@ This file is intentionally lightweight. Use concise entries that explain:
   - Short classification table: updated Family F and Meta-Rule-Activation status to reflect current coverage.
 - `SYSTEM-MAP.md`: mapped `evals/meta/scope-completeness-discipline.md` and `evals/meta/decision-utility-discipline.md` to Family G.
 - `ROADMAP.md`: split P1 meta-eval item into completed (scope/decision meta-evals + route discipline) and remaining (checklist gate / market-outlook validation / remaining route hardening).
-
-### Why
-- Per issue #97 (P1), failure-taxonomy families lacked corresponding meta-evals and route-trigger coverage. Added meta-evals for scope completeness and decision utility, wired them into the execution chain (SKILL.md, ROUTING-MATRIX.md route Attach, checklists), and created a reusable reference-level rule for scope completeness that was previously missing.
-
-### Changed
 - `SYSTEM-MAP.md`: filled family-level coverage across all nine families: added missing file references (`mid-research-review.md`, `route-activation-and-preflight.md`), added newly created checklists, split combined Primary references/checklists sections into separate subsections for clarity, and updated Current thin spots to reflect resolved items.
 - `SKILL.md`: narrowed PDF delivery trigger — replaced bare keyword matching with an explicit file-delivery intent model: added delivery-phrase list ("生成 PDF", "导出 PDF", "报告文件", "可下载报告", "给我报告文件", "作为附件给我" etc.) and a negation/discussion guardrail (不要 PDF, no PDF, 解释 PDF 渲染失败, etc.). Bare `报告` no longer triggers PDF pipeline.
 - `evals/cases/pdf-delivery-trigger-regression-case.md`: added acceptance matrix to prevent trigger-boundary drift.
@@ -70,6 +63,9 @@ This file is intentionally lightweight. Use concise entries that explain:
 - `checklists/listed-company-report.md`: softened consensus analyst-count requirement; clarified target price must not be treated as fair value.
 - `evals/cases/consensus-and-forward-pe-misuse-case.md`: fixed Tesla earnings date (Jan 28); converted to fixed-scenario prompt with hypothetical bounds; clarified implied upside is acceptable if attributed.
 - `evals/cases/reporting-period-and-ttm-confusion-case.md`: fixed TTM example to use only available quarters; converted to fixed-scenario prompt.
+
+### Why
+- Per issue #97 (P1), failure-taxonomy families lacked corresponding meta-evals and route-trigger coverage. Added meta-evals for scope completeness and decision utility, wired them into the execution chain (SKILL.md, ROUTING-MATRIX.md route Attach, checklists), and created a reusable reference-level rule for scope completeness that was previously missing.
 
 ## 0.4.0 - 2026-03-31
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,13 +4,20 @@ This file tracks likely next improvements and helps keep repo evolution intentio
 
 ## Current priorities
 
-### P1
+### P1 — Done
+- **Meta-evals for scope completeness and decision utility** ✅
+  - `evals/meta/scope-completeness-discipline.md` (Family F diagnosis)
+  - `evals/meta/decision-utility-discipline.md` (diagnosis, distinct from existing rubric)
+  - `references/scope-completeness-discipline.md` (reusable minimum-coverage rule)
+  - Wired into execution chain: SKILL.md, ROUTING-MATRIX.md route Attach, route-activation-audit.md, final-audit.md
+
+### P1 — Remaining
 - Use `SYSTEM-MAP.md` to tighten family-level coverage and identify where a dedicated family map, route-supporting reference, checklist hardening, or delivery note is still missing.
 - Add more evals for freshness, counter-evidence, and decision-quality regressions.
 - Test the skill against more real fast-moving company/product cases.
 - Tighten current-state verification if stale facts still leak into reports.
 - Continue testing whether the stale-anchor hard gate (added to `checklists/listed-company-report.md`) reliably triggers during real listed-company synthesis, and harden route activation if the gate keeps being skipped.
-- Add meta-evals and trigger-routing improvements for failure families identified in `references/failure-taxonomy.md`, especially rule activation, scope completeness, decision utility, and market-outlook routing.
+- Harden checklist-level gates for scope-completeness and decision-utility enforcement (final-audit recall discipline).
 - Keep eval subtype formalization limited to naming conventions (`evals/README.md#naming-conventions`) unless eval volume justifies new folders.
 - Run at least 2-3 more real comparative-distillation cases and promote only the recurring candidate rules.
 - Validate the new market-outlook routing against 2-3 more real cases before hardening further wording or adding more specialized sub-checklists.

--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -570,9 +570,6 @@ Fail if:
 ### Scope completeness
 Attach when the task claims broad or global scope (global market / industry-wide / full landscape / comprehensive coverage).
 
-Read:
-- `references/failure-taxonomy.md` — Family F: Scope Completeness and Coverage Geometry
-
 Visible sign:
 - the report states its real scope clearly
 - load-bearing geographies, segments, or regulatory regimes are covered proportionally to their importance
@@ -585,9 +582,6 @@ Fail if:
 
 ### Decision utility
 Attach when the task carries a recommendation, choice, judgment, or investment-style decision burden.
-
-Read:
-- `evals/templates/decision-utility-rubric.md`
 
 Visible sign:
 - the decision frame is explicit and drives report structure

--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -98,6 +98,7 @@ Use when the task is mainly about:
 ### Attach
 - current-state verification
 - source traceability
+- decision utility
 - quantitative role labeling when pricing, benchmarks, or scoring matter
 
 ### Audit
@@ -158,6 +159,7 @@ Use when the task is mainly about:
 ### Attach
 - current-state verification
 - source traceability
+- decision utility
 - quantitative role labeling when market size, payback, cost assumptions, sequencing thresholds, or scenario-style numbers materially affect the recommendation
 
 ### Audit
@@ -216,6 +218,7 @@ Use when the task is mainly about:
 - current-state verification
 - forward-looking claims discipline
 - source traceability
+- scope completeness when the report claims global or broad market scope
 - quantitative role labeling when forecasts or scenario math appear
 
 ### Audit
@@ -270,6 +273,7 @@ Use when the task is mainly about:
 - current-state verification
 - source traceability
 - evidence-weight separation
+- scope completeness when the positioning claim is global or multi-region
 - quantitative role labeling when numbers materially affect the positioning judgment
 
 ### Audit
@@ -325,6 +329,7 @@ Use when the task is mainly about:
 - `references/decision-report-template.md`
 
 ### Attach
+- decision utility
 - quantitative role labeling when scoring, weighting, burden proxies, cost comparisons, or scenario comparisons materially affect ranking or recommendation
 
 ### Audit
@@ -389,6 +394,7 @@ Use when the task is mainly about:
 
 ### Attach
 - current-state verification when current market pricing, current platforms, or current device availability materially affect the answer
+- decision utility
 - quantitative role labeling when budgets, power estimates, operating costs, or scoring materially affect the recommendation
 - source traceability when specific hardware, pricing, system constraints, or long-run suitability claims carry the conclusion
 
@@ -462,6 +468,8 @@ Use when the task is mainly about:
 - current-state verification
 - forward-looking claims discipline when forecasts appear
 - source traceability
+- scope completeness when the report makes global market-position or global competitive claims
+- decision utility
 
 For this route, current-state verification must explicitly lock:
 
@@ -569,6 +577,9 @@ Fail if:
 
 ### Scope completeness
 Attach when the task claims broad or global scope (global market / industry-wide / full landscape / comprehensive coverage).
+
+Read:
+- `references/scope-completeness-discipline.md`
 
 Visible sign:
 - the report states its real scope clearly

--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -567,6 +567,39 @@ Visible sign:
 Fail if:
 - the report body exposes internal syntax, parser debris, or generator hints
 
+### Scope completeness
+Attach when the task claims broad or global scope (global market / industry-wide / full landscape / comprehensive coverage).
+
+Read:
+- `references/failure-taxonomy.md` — Family F: Scope Completeness and Coverage Geometry
+
+Visible sign:
+- the report states its real scope clearly
+- load-bearing geographies, segments, or regulatory regimes are covered proportionally to their importance
+- scope boundaries are explicit when coverage is partial
+
+Fail if:
+- the report is functionally regional while presenting itself as global
+- a top-5 geography, major segment, or binding regulatory regime is missing or barely mentioned
+- scope boundaries are unstated, creating false confidence in the reader
+
+### Decision utility
+Attach when the task carries a recommendation, choice, judgment, or investment-style decision burden.
+
+Read:
+- `evals/templates/decision-utility-rubric.md`
+
+Visible sign:
+- the decision frame is explicit and drives report structure
+- load-bearing variables (3-5) are identified and prioritized
+- the bottom line is sharp and actionable
+- what could change the conclusion is explained
+
+Fail if:
+- the report is informative but leaves the reader unsure what to decide
+- the conclusion is soft, buried, or missing
+- the report answers "what exists" better than "what matters most"
+
 ---
 
 ## Routing priority

--- a/SKILL.md
+++ b/SKILL.md
@@ -68,6 +68,8 @@ Apply these when the route requires them:
 - source traceability
 - forward-looking claims discipline
 - quantitative role labeling
+- scope completeness
+- decision utility
 - delivery cleanliness
 - target-language coherence for final delivery when the report is user-facing
 

--- a/SYSTEM-MAP.md
+++ b/SYSTEM-MAP.md
@@ -320,6 +320,8 @@ Protects against reports that sound smart but still fail as deep, load-bearing d
 - `checklists/final-audit.md`
 - `evals/templates/depth-rubric.md`
 - `evals/templates/decision-utility-rubric.md`
+- `evals/meta/scope-completeness-discipline.md`
+- `evals/meta/decision-utility-discipline.md`
 - `evals/cases/global-market-scope-completeness-case.md`
 - `evals/cases/industry-landscape-depth-case.md`
 

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -57,6 +57,7 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] the required secondary disciplines for the selected route are visibly executed
 - [ ] the report does not collapse back into generic overview mode despite route selection
 - [ ] if the route implies recommendation, ranking, gating, or sequencing burden, the report actually carries that burden
+- [ ] if scope completeness was required, the report's coverage boundaries are explicit; load-bearing geographies or segments are present; omissions are named rather than silent
 - [ ] the opening 20-30% of the report already reflects the chosen route rather than reading like a reusable generic overview
 - [ ] the route is visible not only in headers, but also in section order and burden allocation
 - [ ] there is a visible bridge from route -> mandatory sections -> bottom-line conclusion
@@ -102,6 +103,8 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] current-state verification was run for fast-moving topics
 - [ ] listing status and financial snapshot were verified for listed companies
 - [ ] source traceability was applied for structured or investment-relevant outputs
+- [ ] scope completeness was checked when the report claims global, comprehensive, or industry-wide scope
+- [ ] decision utility was checked when the report carries a recommendation, choice, judgment, or investment-style decision burden
 - [ ] option-selection final audit was run for shortlist, ranking, or constrained-choice outputs
 - [ ] for model/API/provider selection tasks, a current provider snapshot was verified before ranking or recommendation
 - [ ] for China-mainland deployment decisions, accessibility, compliance, data residency, and SLA were treated as part of ranking logic when relevant

--- a/checklists/route-activation-audit.md
+++ b/checklists/route-activation-audit.md
@@ -31,6 +31,8 @@ It audits whether route activation was explicit and whether the route actually s
 - [ ] if source traceability was required, load-bearing claims are auditable in the body
 - [ ] if forward-looking claims discipline was required, forecasts and estimates have visible source role and time basis
 - [ ] if quantitative role labeling was required, important numbers are labeled as observed fact / proxy / assumption / model output
+- [ ] if scope completeness was required, the report states its actual coverage boundaries and covers load-bearing geographies, segments, or regulatory regimes proportionally to their importance
+- [ ] if decision utility was required, the decision frame is explicit and drives report structure, with a clear route-appropriate bottom line
 
 ## Route execution integrity
 

--- a/evals/meta/decision-utility-discipline.md
+++ b/evals/meta/decision-utility-discipline.md
@@ -1,141 +1,101 @@
 # Eval: Decision Utility Discipline
 
-Use this eval when a report sounds informed and well-sourced but does not clearly help the reader make a decision, judgment, or next step.
+Use this meta-eval when a report sounds informed and well-sourced but does not clearly help the reader make a decision, judgment, or next step.
 
-This is a meta-eval. It is not about whether the report's facts are correct. It is about whether the report is structured for decision support rather than informative summary — and whether the route correctly activated decision-utility disciplines at the right level.
+This eval is **not** about scoring a specific report's decision usefulness — use `evals/templates/decision-utility-rubric.md` (6-dimension scoring) for that. This eval is about deciding **which layer of the repo should change** when a decision-utility failure is observed.
 
 ## Goal
 
-Distinguish three different failure types:
+Distinguish five distinct root causes for a decision-utility failure:
 
-1. **Missing decision frame** — the report never identifies what judgment or choice the reader faces
-2. **Weak load-bearing variable selection** — the report covers many dimensions without identifying 3-5 factors that actually determine the answer
-3. **Soft conclusion** — the report stays noncommittal or buries the bottom line even when evidence could support a judgment
+1. **Missing route** — the task was misclassified as informational research when it should have been routed to a decision-focused route (provider selection, market entry, investment memo, etc.)
+2. **Route with weak decision contract** — the correct route was selected, but its visible artifact contract does not require decision frame, load-bearing variables, or bottom-line conclusion
+3. **Template gap** — the route's supporting template provides structure for facts but not for decision logic (no mandatory "what matters most", "bottom line", or "what would change the view" sections)
+4. **Execution failure** — the route, contract, and template all exist, but the final output still reads like an informative overview rather than a decision support memo
+5. **Wrong route for decision type** — the task type calls for a particular decision structure (e.g., go/no-go gates for market entry) but was routed to a route that supplies a different structure (e.g., option comparison)
 
-This distinction matters because these three problems require different fixes (route selection, template structure, execution contract, or checklist hardening).
-
----
-
-## Typical cases where this eval should be used
-
-- provider comparison that reads like a vendor catalog instead of a choice memo
-- market outlook that summarizes trends but does not recommend a position or scenario
-- company report that profiles the business but does not state an investment judgment
-- option analysis that lists pros and cons without a clear recommendation
-- shortlist memo where narrative weight is spread evenly across all options
+This distinction matters because these five causes require completely different fixes (routing guidance / artifact contract / template structure / checklist hardening / re-routing).
 
 ---
 
-## What this eval is testing
+## How to use this meta-eval
 
-### Failure Mode 1: Missing decision frame
+When you observe a decision-utility failure, walk through these questions in order:
 
-The report explains the topic well, but never clarifies what the reader should decide.
+### Step 1: Is it a missing route?
+Check: was the task treated as generic research when it should have been routed to a decision-focused route?
+- The routing matrix has 7 routes, most with explicit decision logic
+- A task like "should we buy from vendor A or B?" should use provider selection, not generic overview
+- If no route was selected → **missing route**
 
-Examples:
-- the practical question is unclear
-- decision context is absent or buried
-- criteria that would change the final answer are unnamed
+### Step 2: Route with weak decision contract?
+Check: the correct route was selected, but does its artifact contract require decision structure?
+- Example: "market outlook / industry evolution" requires scenario structure but does it require a clear bottom-line recommendation?
+- If the route contract does not mandate decision elements → **weak route contract**
 
-### Failure Mode 2: Weak load-bearing variable selection
+### Step 3: Template gap?
+Check: even if the route contract is strong, does the template provide a clear place for decision logic?
+- `references/decision-report-template.md` covers most decision elements
+- But if a specific route's template does not include mandatory decision output → **template gap**
 
-Many facts are presented, but the report does not prioritize the few variables that matter most.
+### Step 4: Execution failure?
+Check: all of the above existed, but the report still reads like an overview.
+- The route was correct, the template has decision sections, but the output filled them with general description instead of sharp judgment
+- → **execution failure** — fix goes in checklist hardening or execution contract
 
-Examples:
-- too many dimensions feel equally weighted
-- the report answers "what exists" better than "what matters most"
-- supporting detail is not subordinated to the primary drivers
-
-### Failure Mode 3: Soft or buried conclusion
-
-The report generates useful analysis but does not convert it into a bottom line.
-
-Examples:
-- the report stays noncommittal when evidence supports a judgment
-- the conclusion exists but is soft, buried, or not operationally useful
-- "what could change the conclusion" is absent even when uncertainty is material
-
----
-
-## Pass criteria
-
-A good answer should:
-
-1. **Make the decision frame explicit.**
-   - state the practical question clearly
-   - show decision context rather than topic summary
-   - name criteria that would change the final answer
-
-2. **Identify load-bearing variables.**
-   - prioritize 3-5 major variables that determine the conclusion
-   - explain why those matter more than the rest
-   - subordinate supporting detail to those variables
-
-3. **Deliver a sharp conclusion.**
-   - give an explicit bottom line
-   - include a recommendation, ranking, or directional judgment when appropriate
-   - state what could change the conclusion
-
-4. **Avoid informative-but-useless shape.**
-   - do not let generic description substitute for decision support
-   - do not leave the reader to infer the bottom line from scattered details
+### Step 5: Wrong route for decision type?
+Check: the task was routed to a route that supplies the wrong kind of decision structure.
+- Example: a "go/no-go market entry" question routed to "constrained choice / shortlist" (option ranking instead of gate decision)
+- If the route's default decision structure differs from what the task actually needs → **wrong route**
 
 ---
 
-## Scoring guide
+## Pass criteria for this meta-eval
 
-Use a simple 0-2 scale.
+A good diagnosis using this meta-eval should:
 
-### 0 = decision-utility failure
-- the report is informative but leaves the reader unsure what to decide
-- no decision frame, no load-bearing variable selection, or no conclusion
+1. **Classify the root cause correctly.**
+   - distinguish missing route from weak contract from execution failure
+   - avoid defaulting to "execution failure" when the real gap is that the route never mandated decision output
 
-### 1 = partial decision usefulness
-- some decision frame exists, but connection to body is weak
-- or load-bearing variables are named but not consistently used
-- or a conclusion exists but is soft or buried
+2. **Point to the narrowest correct fix layer.**
+   - missing route → routing selection guidance or SKILL routing step
+   - weak route contract → update the route's visible artifact contract in `ROUTING-MATRIX.md`
+   - template gap → update the route's supporting template in `references/`
+   - execution failure → checklist hardening or execution-contract update
+   - wrong route → route selection guidance or disambiguation in `ROUTING-MATRIX.md`
 
-### 2 = strong decision usefulness
-- the decision frame is explicit and drives report structure
-- load-bearing variables are clearly identified and prioritized
-- the bottom line is sharp and actionable
-- what could change the conclusion is explained
+3. **Avoid conflating "informative" with "decision-useful".**
+   - a report can be factually solid and well-organized yet still fail the decision-utility test
+   - distinguish factual adequacy from decision support
 
 ---
 
 ## Review questions
 
-When using this eval, ask:
+When applying this meta-eval, ask:
 
-- Does the report identify what judgment or decision the reader faces?
-- Does it identify what matters most, or does it treat all facts as equally important?
-- Does it help the reader choose, prioritize, approve, reject, or investigate further?
-- Does it give a clear bottom line?
-- Does it explain what could change the conclusion?
-- Would a busy decision-maker get value from the first page alone?
-- Is the right fix a route change, a template update, an execution-contract improvement, or a new checklist gate?
+- Was a primary route selected explicitly? If not, fix routing before anything else.
+- Does the selected route's artifact contract require decision elements (bottom line, recommendation, what matters most)? If not, fix the contract.
+- Does the route's supporting template provide a mandatory place for decision output? If not, fix the template.
+- If route, contract, and template are all present, did the report fill them with decision logic or with general description? If description, fix execution.
+- Is the decision gap recurring across multiple reports from the same route? If recurring, escalate from execution fix to structural fix.
 
 ---
 
 ## Output format for reviewers
 
-When you apply this eval, summarize the result as:
+When you apply this meta-eval, summarize the result as:
 
-- **Expected decision frame:**
-- **Load-bearing variables identified:**
-- **Conclusion sharpness:**
-- **Change-the-conclusion clarity:**
-- **Diagnosis:** missing decision frame / weak variable selection / soft conclusion / no failure
-- **Best next fix:** routing update / template update / execution-contract hardening / checklist update / new case eval only
-
----
-
-## Suggested prompts
-
-- Should we partner with this company, buy from it, or wait six months?
-- Which of these three vendors is best for a mid-market deployment, and why?
-- Is this market attractive enough for entry in the next 12 months?
-- Should an investor treat this stock as a growth opportunity, a hold, or an avoid-for-now case?
+- **Observed decision gap:**
+- **Was a route selected?** yes / no
+- **Route used:**
+- **Does the route contract require decision output?** yes / no
+- **Root cause diagnosis:** missing route / weak route contract / template gap / execution failure / wrong route
+- **Evidence for diagnosis:**
+- **Narrowest correct fix layer:** routing / route contract / template / checklist / re-route
+- **Recurring?** yes / no (first observed)
+- **Recommended action:**
 
 ---
 
@@ -143,15 +103,15 @@ When you apply this eval, summarize the result as:
 
 This meta-eval is distinct from `evals/templates/decision-utility-rubric.md`:
 
-- The **rubric** is a reusable scoring template for reviewers to score a specific report across 6 dimensions (0-2 each).
-- This **meta-eval** is used to determine whether a case or family of cases exposes a systematic decision-utility gap, and to decide which layer of the repo should change in response.
+- The **rubric** is a reusable scoring template for reviewers to score a specific report across 6 dimensions (0-2 each). It answers "how decision-useful is this specific report?"
+- This **meta-eval** is used to determine whether a case or family of cases exposes a systematic decision-utility gap. It answers "what should the repo do about it?"
 
-Use the rubric when scoring a specific report. Use this meta-eval when deciding whether the repo itself needs a structural improvement in how it handles decision usefulness.
+Use the rubric when scoring a specific report. Use this meta-eval when deciding whether the repo itself needs a structural improvement.
 
 ---
 
-## Why this eval exists
+## Why this meta-eval exists
 
-The repo has strong discipline for factual correctness (freshness, traceability, evidence weighting) but has been thinner on ensuring the output is actually useful for decision-making.
+The repo has strong discipline for factual correctness (freshness, traceability, evidence weighting) but has been thinner on ensuring the output is actually useful for decision-making. The rubric makes decision-utility measurable; this meta-eval makes it actionable.
 
-This eval exists to prevent the system from producing reports that are factually solid but decisionally weak — and to ensure that decision-utility failures are recognized as a distinct family requiring targeted structural fixes, not just more facts or better wording.
+This meta-eval exists to prevent decision-utility failures from being treated as "just add more facts" problems when the real fix may be routing, contract, or template structure.

--- a/evals/meta/decision-utility-discipline.md
+++ b/evals/meta/decision-utility-discipline.md
@@ -24,19 +24,20 @@ When you observe a decision-utility failure, walk through these questions in ord
 
 ### Step 1: Is it a missing route?
 Check: was the task treated as generic research when it should have been routed to a decision-focused route?
-- The routing matrix has 7 routes, most with explicit decision logic
+- The routing matrix has 7 routes, most with explicit decision or judgment logic
 - A task like "should we buy from vendor A or B?" should use provider selection, not generic overview
 - If no route was selected → **missing route**
 
 ### Step 2: Route with weak decision contract?
-Check: the correct route was selected, but does its artifact contract require decision structure?
-- Example: "market outlook / industry evolution" requires scenario structure but does it require a clear bottom-line recommendation?
-- If the route contract does not mandate decision elements → **weak route contract**
+Check: the correct route was selected, but does its artifact contract require decision-appropriate output?
+- A route with recommendation burden (provider selection, market entry, investment memo) should require clear bottom-line recommendation
+- A route with judgment burden (market outlook, competitive positioning) should require route-appropriate bottom line / judgment / scenario implication — not necessarily a hard recommendation
+- If the route contract does not mandate decision or judgment elements appropriate to its task type → **weak route contract**
 
 ### Step 3: Template gap?
-Check: even if the route contract is strong, does the template provide a clear place for decision logic?
+Check: even if the route contract is strong, does the template provide a clear place for decision or judgment output?
 - `references/decision-report-template.md` covers most decision elements
-- But if a specific route's template does not include mandatory decision output → **template gap**
+- But if a specific route's template does not include mandatory judgment or recommendation output → **template gap**
 
 ### Step 4: Execution failure?
 Check: all of the above existed, but the report still reads like an overview.
@@ -46,6 +47,7 @@ Check: all of the above existed, but the report still reads like an overview.
 ### Step 5: Wrong route for decision type?
 Check: the task was routed to a route that supplies the wrong kind of decision structure.
 - Example: a "go/no-go market entry" question routed to "constrained choice / shortlist" (option ranking instead of gate decision)
+- Example: a market outlook task forced into "provider selection" would produce a false recommendation when the real need is scenario analysis
 - If the route's default decision structure differs from what the task actually needs → **wrong route**
 
 ---
@@ -76,7 +78,7 @@ A good diagnosis using this meta-eval should:
 When applying this meta-eval, ask:
 
 - Was a primary route selected explicitly? If not, fix routing before anything else.
-- Does the selected route's artifact contract require decision elements (bottom line, recommendation, what matters most)? If not, fix the contract.
+- Does the selected route's artifact contract require route-appropriate decision or judgment output (bottom line, recommendation, scenario implication, or what matters most)? If not, fix the contract.
 - Does the route's supporting template provide a mandatory place for decision output? If not, fix the template.
 - If route, contract, and template are all present, did the report fill them with decision logic or with general description? If description, fix execution.
 - Is the decision gap recurring across multiple reports from the same route? If recurring, escalate from execution fix to structural fix.

--- a/evals/meta/decision-utility-discipline.md
+++ b/evals/meta/decision-utility-discipline.md
@@ -1,0 +1,157 @@
+# Eval: Decision Utility Discipline
+
+Use this eval when a report sounds informed and well-sourced but does not clearly help the reader make a decision, judgment, or next step.
+
+This is a meta-eval. It is not about whether the report's facts are correct. It is about whether the report is structured for decision support rather than informative summary — and whether the route correctly activated decision-utility disciplines at the right level.
+
+## Goal
+
+Distinguish three different failure types:
+
+1. **Missing decision frame** — the report never identifies what judgment or choice the reader faces
+2. **Weak load-bearing variable selection** — the report covers many dimensions without identifying 3-5 factors that actually determine the answer
+3. **Soft conclusion** — the report stays noncommittal or buries the bottom line even when evidence could support a judgment
+
+This distinction matters because these three problems require different fixes (route selection, template structure, execution contract, or checklist hardening).
+
+---
+
+## Typical cases where this eval should be used
+
+- provider comparison that reads like a vendor catalog instead of a choice memo
+- market outlook that summarizes trends but does not recommend a position or scenario
+- company report that profiles the business but does not state an investment judgment
+- option analysis that lists pros and cons without a clear recommendation
+- shortlist memo where narrative weight is spread evenly across all options
+
+---
+
+## What this eval is testing
+
+### Failure Mode 1: Missing decision frame
+
+The report explains the topic well, but never clarifies what the reader should decide.
+
+Examples:
+- the practical question is unclear
+- decision context is absent or buried
+- criteria that would change the final answer are unnamed
+
+### Failure Mode 2: Weak load-bearing variable selection
+
+Many facts are presented, but the report does not prioritize the few variables that matter most.
+
+Examples:
+- too many dimensions feel equally weighted
+- the report answers "what exists" better than "what matters most"
+- supporting detail is not subordinated to the primary drivers
+
+### Failure Mode 3: Soft or buried conclusion
+
+The report generates useful analysis but does not convert it into a bottom line.
+
+Examples:
+- the report stays noncommittal when evidence supports a judgment
+- the conclusion exists but is soft, buried, or not operationally useful
+- "what could change the conclusion" is absent even when uncertainty is material
+
+---
+
+## Pass criteria
+
+A good answer should:
+
+1. **Make the decision frame explicit.**
+   - state the practical question clearly
+   - show decision context rather than topic summary
+   - name criteria that would change the final answer
+
+2. **Identify load-bearing variables.**
+   - prioritize 3-5 major variables that determine the conclusion
+   - explain why those matter more than the rest
+   - subordinate supporting detail to those variables
+
+3. **Deliver a sharp conclusion.**
+   - give an explicit bottom line
+   - include a recommendation, ranking, or directional judgment when appropriate
+   - state what could change the conclusion
+
+4. **Avoid informative-but-useless shape.**
+   - do not let generic description substitute for decision support
+   - do not leave the reader to infer the bottom line from scattered details
+
+---
+
+## Scoring guide
+
+Use a simple 0-2 scale.
+
+### 0 = decision-utility failure
+- the report is informative but leaves the reader unsure what to decide
+- no decision frame, no load-bearing variable selection, or no conclusion
+
+### 1 = partial decision usefulness
+- some decision frame exists, but connection to body is weak
+- or load-bearing variables are named but not consistently used
+- or a conclusion exists but is soft or buried
+
+### 2 = strong decision usefulness
+- the decision frame is explicit and drives report structure
+- load-bearing variables are clearly identified and prioritized
+- the bottom line is sharp and actionable
+- what could change the conclusion is explained
+
+---
+
+## Review questions
+
+When using this eval, ask:
+
+- Does the report identify what judgment or decision the reader faces?
+- Does it identify what matters most, or does it treat all facts as equally important?
+- Does it help the reader choose, prioritize, approve, reject, or investigate further?
+- Does it give a clear bottom line?
+- Does it explain what could change the conclusion?
+- Would a busy decision-maker get value from the first page alone?
+- Is the right fix a route change, a template update, an execution-contract improvement, or a new checklist gate?
+
+---
+
+## Output format for reviewers
+
+When you apply this eval, summarize the result as:
+
+- **Expected decision frame:**
+- **Load-bearing variables identified:**
+- **Conclusion sharpness:**
+- **Change-the-conclusion clarity:**
+- **Diagnosis:** missing decision frame / weak variable selection / soft conclusion / no failure
+- **Best next fix:** routing update / template update / execution-contract hardening / checklist update / new case eval only
+
+---
+
+## Suggested prompts
+
+- Should we partner with this company, buy from it, or wait six months?
+- Which of these three vendors is best for a mid-market deployment, and why?
+- Is this market attractive enough for entry in the next 12 months?
+- Should an investor treat this stock as a growth opportunity, a hold, or an avoid-for-now case?
+
+---
+
+## Relation to the decision-utility rubric
+
+This meta-eval is distinct from `evals/templates/decision-utility-rubric.md`:
+
+- The **rubric** is a reusable scoring template for reviewers to score a specific report across 6 dimensions (0-2 each).
+- This **meta-eval** is used to determine whether a case or family of cases exposes a systematic decision-utility gap, and to decide which layer of the repo should change in response.
+
+Use the rubric when scoring a specific report. Use this meta-eval when deciding whether the repo itself needs a structural improvement in how it handles decision usefulness.
+
+---
+
+## Why this eval exists
+
+The repo has strong discipline for factual correctness (freshness, traceability, evidence weighting) but has been thinner on ensuring the output is actually useful for decision-making.
+
+This eval exists to prevent the system from producing reports that are factually solid but decisionally weak — and to ensure that decision-utility failures are recognized as a distinct family requiring targeted structural fixes, not just more facts or better wording.

--- a/evals/meta/scope-completeness-discipline.md
+++ b/evals/meta/scope-completeness-discipline.md
@@ -24,9 +24,10 @@ When you observe a scope-completeness failure, walk through these questions in o
 
 ### Step 1: Is it a missing rule?
 Check: does the repo have any document that defines what "global scope" must include?
-- Reference: `references/failure-taxonomy.md` — Family F (records the gap but does not define a standard)
-- Reference: `evals/cases/global-market-scope-completeness-case.md` (defines the evaluation but not a reusable rule)
-- If no document defines the minimum coverage for a global claim → **missing rule**
+- Reference: `references/scope-completeness-discipline.md` (defines minimum coverage standards for global/comprehensive claims)
+- Reference: `references/failure-taxonomy.md` — Family F (records the family-level gap context)
+- Reference: `evals/cases/global-market-scope-completeness-case.md` (scoring tool for a specific report)
+- If the report still omitted a load-bearing geography after the rule was available → not a missing rule, proceed to step 2
 
 ### Step 2: Is it a missing route trigger?
 Check: does `ROUTING-MATRIX.md` or any existing route attach a scope-completeness discipline for this task type?
@@ -98,6 +99,7 @@ When you apply this meta-eval, summarize the result as:
 
 ## Related files
 
+- `references/scope-completeness-discipline.md` — reusable minimum-coverage standard for global/comprehensive claims
 - `evals/cases/global-market-scope-completeness-case.md` — concrete scoring tool for a specific report
 - `references/failure-taxonomy.md` — Family F: Scope Completeness and Coverage Geometry
 - `ROUTING-MATRIX.md` — cross-cutting discipline: scope completeness

--- a/evals/meta/scope-completeness-discipline.md
+++ b/evals/meta/scope-completeness-discipline.md
@@ -1,0 +1,158 @@
+# Eval: Scope Completeness Discipline
+
+Use this eval when a report claims broad scope (global / comprehensive / industry-wide / full landscape) but may omit one or more load-bearing markets, geographies, segments, or regulatory regimes.
+
+This is a meta-eval. It is not primarily about whether the report's individual facts are correct. It is about whether the actual coverage matches the implied scope, and whether a scope miss could distort the conclusion.
+
+## Goal
+
+Distinguish four different failure types:
+
+1. **Name-only global coverage** — the report says "global" but effectively covers only the easiest or most visible markets
+2. **Missing load-bearing geography** — a geography that materially affects market size, supply chain, competition, or policy risk is missing or dismissed in one sentence
+3. **Flat competitive map** — the report lists global players but does not distinguish regional champions, incumbents vs emerging local challengers, or geography-dependent competitive dynamics
+4. **Scope boundaries not stated** — the report is actually a partial-scope memo, but it does not say so, creating false confidence in the reader
+
+This distinction matters because these four problems require different fixes (missing data, routing misclassification, template omission, or execution failure).
+
+---
+
+## Typical cases where this eval should be used
+
+- global market report that effectively ignores a top-5 geography
+- competitive map missing a major local player set
+- regulatory analysis that only covers US/EU but not the most constraining regime
+- value-chain report that names all layers but skips the highest-friction or highest-value segment
+- industry landscape that looks broad but is concentrated on the most visible areas
+
+---
+
+## What this eval is testing
+
+### Failure Mode 1: Name-only global coverage
+
+The report says "global" but effectively covers only the easiest or most visible markets.
+
+Examples:
+- mostly US + Europe with little or no China
+- mostly public Western vendors while local leaders in Asia are absent
+- regulatory discussion centered on one regime while other binding regimes are ignored
+
+### Failure Mode 2: Missing load-bearing geography
+
+A geography that materially affects market size, supply chain, competition, or policy risk is missing or dismissed in one sentence.
+
+Examples:
+- the largest demand pool is barely covered
+- the most restrictive regulator is omitted
+- a key manufacturing region is absent from the supply-side analysis
+
+### Failure Mode 3: Flat competitive map
+
+The report lists global players but does not distinguish:
+- regional champions from global leaders
+- incumbents from emerging local challengers
+- where the competitive picture changes by geography
+
+### Failure Mode 4: Scope boundaries not stated
+
+The report is actually a partial-scope memo, but it does not say so.
+
+This creates false confidence because the reader assumes comprehensiveness.
+
+---
+
+## Pass criteria
+
+A good answer should:
+
+1. **State the real scope clearly.**
+   - if the report is truly global, it should behave globally
+   - if it is partial, it should say what is excluded
+
+2. **Cover load-bearing geographies.**
+   - include the top markets or most consequential geographies for demand, supply, or regulation
+   - do not reduce a key geography to a passing mention
+
+3. **Explain why geography changes the conclusion.**
+   - show where market structure, regulation, pricing, or competition differ by region
+   - do not treat global market conclusions as geography-free by default
+
+4. **Handle competitive scope honestly.**
+   - include regional leaders when they materially shape the market
+   - distinguish global leaders from region-specific leaders when needed
+
+5. **Make omissions explicit when evidence is weak.**
+   - if some markets are poorly documented, say so
+   - do not silently downgrade them into irrelevance
+
+---
+
+## Scoring guide
+
+Use a simple 0-2 scale.
+
+### 0 = scope failure
+- one or more load-bearing markets or segments are missing
+- or the report is functionally regional while presenting itself as global
+- or scope boundaries are unstated, creating false confidence
+
+### 1 = partial scope discipline
+- the main geographies are present, but one important region/segment is underdeveloped
+- or coverage exists without showing how geography changes the analysis
+- or scope boundaries are implied but not explicit
+
+### 2 = strong scope completeness
+- the report covers the consequential geographies/segments, states its boundaries honestly, and shows how scope affects conclusions
+
+---
+
+## Review questions
+
+When using this eval, ask:
+
+- What are the top geographies or segments that could materially change the answer?
+- Did the report cover them proportionally to their importance?
+- Did it distinguish demand centers, supply centers, and regulatory centers?
+- Did it include local leaders where they matter?
+- If some major geography is thin, did the report explain why?
+- Would a different conclusion be possible if a missing geography were included?
+- Is the right fix a new rule, a stronger route trigger, a checklist gate, or a new case eval?
+
+---
+
+## Output format for reviewers
+
+When you apply this eval, summarize the result as:
+
+- **Implied scope:**
+- **Actual coverage:**
+- **Load-bearing omissions:**
+- **Scope boundaries stated?**
+- **Diagnosis:** name-only global / missing load-bearing geography / flat competitive map / boundaries not stated / no failure
+- **Best next fix:** routing update / reference update / checklist update / new case eval only / no action
+
+---
+
+## Suggested prompts
+
+- Research the global HNB market and compare major geographies, players, and regulatory constraints.
+- Map the global AI datacenter value chain and explain where value accrues by region.
+- Analyze the global EV battery market, including China, Europe, the US, Korea, and Japan.
+- Compare global cloud security vendors, noting where regional regulation changes adoption dynamics.
+
+---
+
+## Related files
+
+- `evals/cases/global-market-scope-completeness-case.md` — concrete case example for this family
+- `references/failure-taxonomy.md` — Family F: Scope Completeness and Coverage Geometry
+- `ROUTING-MATRIX.md` — cross-cutting discipline: scope completeness
+
+---
+
+## Why this eval exists
+
+Several reports can look broad while still being structurally incomplete.
+
+This eval exists to prevent "global" from becoming a stylistic label instead of a real coverage standard, and to ensure that scope completeness is explicitly evaluated as a cross-cutting discipline rather than assumed by default.

--- a/evals/meta/scope-completeness-discipline.md
+++ b/evals/meta/scope-completeness-discipline.md
@@ -1,158 +1,111 @@
 # Eval: Scope Completeness Discipline
 
-Use this eval when a report claims broad scope (global / comprehensive / industry-wide / full landscape) but may omit one or more load-bearing markets, geographies, segments, or regulatory regimes.
+Use this meta-eval when a report claims broad scope (global / comprehensive / industry-wide / full landscape) but you suspect the actual coverage may not match the implied scope.
 
-This is a meta-eval. It is not primarily about whether the report's individual facts are correct. It is about whether the actual coverage matches the implied scope, and whether a scope miss could distort the conclusion.
+This eval is **not** about scoring a specific report's scope completeness — use `evals/cases/global-market-scope-completeness-case.md` (pass criteria + scoring guide) for that. This eval is about deciding **which layer of the repo should change** when a scope-completeness failure is observed.
 
 ## Goal
 
-Distinguish four different failure types:
+Distinguish five distinct root causes for a scope-completeness failure:
 
-1. **Name-only global coverage** — the report says "global" but effectively covers only the easiest or most visible markets
-2. **Missing load-bearing geography** — a geography that materially affects market size, supply chain, competition, or policy risk is missing or dismissed in one sentence
-3. **Flat competitive map** — the report lists global players but does not distinguish regional champions, incumbents vs emerging local challengers, or geography-dependent competitive dynamics
-4. **Scope boundaries not stated** — the report is actually a partial-scope memo, but it does not say so, creating false confidence in the reader
+1. **Missing rule** — the repo truly lacks guidance on what "global" / "comprehensive" should mean
+2. **Missing route trigger** — the task was not routed into a checklist or reference that checks scope boundaries
+3. **Route misclassification** — the task was routed to a route whose discipline set does not include scope checking (e.g., a global market report routed as "provider selection")
+4. **Execution failure** — the route was correct and the checklists exist, but the final output still omitted load-bearing geographies or segments
+5. **Data unavailability** — the omitted geography/segment genuinely lacks accessible sources, but the report did not state this omission
 
-This distinction matters because these four problems require different fixes (missing data, routing misclassification, template omission, or execution failure).
-
----
-
-## Typical cases where this eval should be used
-
-- global market report that effectively ignores a top-5 geography
-- competitive map missing a major local player set
-- regulatory analysis that only covers US/EU but not the most constraining regime
-- value-chain report that names all layers but skips the highest-friction or highest-value segment
-- industry landscape that looks broad but is concentrated on the most visible areas
+This distinction matters because these five causes require completely different fixes (reference prose / routing matrix / route attachment / checklist hardening / disclosure requirement).
 
 ---
 
-## What this eval is testing
+## How to use this meta-eval
 
-### Failure Mode 1: Name-only global coverage
+When you observe a scope-completeness failure, walk through these questions in order:
 
-The report says "global" but effectively covers only the easiest or most visible markets.
+### Step 1: Is it a missing rule?
+Check: does the repo have any document that defines what "global scope" must include?
+- Reference: `references/failure-taxonomy.md` — Family F (records the gap but does not define a standard)
+- Reference: `evals/cases/global-market-scope-completeness-case.md` (defines the evaluation but not a reusable rule)
+- If no document defines the minimum coverage for a global claim → **missing rule**
 
-Examples:
-- mostly US + Europe with little or no China
-- mostly public Western vendors while local leaders in Asia are absent
-- regulatory discussion centered on one regime while other binding regimes are ignored
+### Step 2: Is it a missing route trigger?
+Check: does `ROUTING-MATRIX.md` or any existing route attach a scope-completeness discipline for this task type?
+- Cross-cutting discipline "scope completeness" now exists in `ROUTING-MATRIX.md`
+- If the task type is global/industry-wide but the route selected does not reference this discipline → **missing route trigger**
 
-### Failure Mode 2: Missing load-bearing geography
+### Step 3: Is it route misclassification?
+Check: was the task routed to a specialized route that does not naturally require scope checking?
+- For example: a global AI market report routed as "provider / vendor selection" would miss scope-completeness entirely
+- If the chosen route's visible artifact contract and secondary disciplines do not include scope → **route misclassification**
 
-A geography that materially affects market size, supply chain, competition, or policy risk is missing or dismissed in one sentence.
+### Step 4: Is it execution failure?
+Check: all of the above existed, but the report still shows scope gaps.
+- The route was correct, the discipline was attached, but the output omitted key geographies
+- The report says "global" but effectively covers only the most visible regions
+- → **execution failure** — fix goes in checklist hardening or execution contract
 
-Examples:
-- the largest demand pool is barely covered
-- the most restrictive regulator is omitted
-- a key manufacturing region is absent from the supply-side analysis
-
-### Failure Mode 3: Flat competitive map
-
-The report lists global players but does not distinguish:
-- regional champions from global leaders
-- incumbents from emerging local challengers
-- where the competitive picture changes by geography
-
-### Failure Mode 4: Scope boundaries not stated
-
-The report is actually a partial-scope memo, but it does not say so.
-
-This creates false confidence because the reader assumes comprehensiveness.
+### Step 5: Is it data unavailability?
+Check: the omitted geography/segment may genuinely be poorly documented.
+- If so, the report should state the omission explicitly rather than silently excluding it
+- If it did not state the omission → still an execution failure (disclosure requirement not met)
 
 ---
 
-## Pass criteria
+## Pass criteria for this meta-eval
 
-A good answer should:
+A good diagnosis using this meta-eval should:
 
-1. **State the real scope clearly.**
-   - if the report is truly global, it should behave globally
-   - if it is partial, it should say what is excluded
+1. **Classify the root cause correctly.**
+   - distinguish missing rule from missing trigger from execution failure
+   - avoid defaulting to "missing rule" when the real gap is route misclassification or execution drift
 
-2. **Cover load-bearing geographies.**
-   - include the top markets or most consequential geographies for demand, supply, or regulation
-   - do not reduce a key geography to a passing mention
+2. **Point to the narrowest correct fix layer.**
+   - missing rule → `references/` or a new reference
+   - missing route trigger → `ROUTING-MATRIX.md` or route attachment update
+   - route misclassification → route selection guidance or route contract
+   - execution failure → checklist hardening or execution-contract update
+   - data unavailability → disclosure requirement (update case eval or reference)
 
-3. **Explain why geography changes the conclusion.**
-   - show where market structure, regulation, pricing, or competition differ by region
-   - do not treat global market conclusions as geography-free by default
-
-4. **Handle competitive scope honestly.**
-   - include regional leaders when they materially shape the market
-   - distinguish global leaders from region-specific leaders when needed
-
-5. **Make omissions explicit when evidence is weak.**
-   - if some markets are poorly documented, say so
-   - do not silently downgrade them into irrelevance
-
----
-
-## Scoring guide
-
-Use a simple 0-2 scale.
-
-### 0 = scope failure
-- one or more load-bearing markets or segments are missing
-- or the report is functionally regional while presenting itself as global
-- or scope boundaries are unstated, creating false confidence
-
-### 1 = partial scope discipline
-- the main geographies are present, but one important region/segment is underdeveloped
-- or coverage exists without showing how geography changes the analysis
-- or scope boundaries are implied but not explicit
-
-### 2 = strong scope completeness
-- the report covers the consequential geographies/segments, states its boundaries honestly, and shows how scope affects conclusions
+3. **Avoid treating every scope failure as a new rule problem.**
+   - most scope failures in a maturing repo will be route or execution failures, not missing rules
 
 ---
 
 ## Review questions
 
-When using this eval, ask:
+When applying this meta-eval, ask:
 
-- What are the top geographies or segments that could materially change the answer?
-- Did the report cover them proportionally to their importance?
-- Did it distinguish demand centers, supply centers, and regulatory centers?
-- Did it include local leaders where they matter?
-- If some major geography is thin, did the report explain why?
-- Would a different conclusion be possible if a missing geography were included?
-- Is the right fix a new rule, a stronger route trigger, a checklist gate, or a new case eval?
+- Does a scope-completeness discipline exist in the routing matrix? If not, that is the first fix.
+- If it exists, was it attached for this task type? If not, the route attachment is the fix.
+- If it was attached, does the report show evidence of scope checking (explicit coverage boundaries, omitted-region disclosure)? If not, execution failed.
+- Is this the first observed scope-completeness failure, or is it recurring? If recurring, escalate from execution fix to structural fix.
+- Would a different route selection have naturally triggered scope checking? If yes, fix route selection guidance.
 
 ---
 
 ## Output format for reviewers
 
-When you apply this eval, summarize the result as:
+When you apply this meta-eval, summarize the result as:
 
-- **Implied scope:**
-- **Actual coverage:**
-- **Load-bearing omissions:**
-- **Scope boundaries stated?**
-- **Diagnosis:** name-only global / missing load-bearing geography / flat competitive map / boundaries not stated / no failure
-- **Best next fix:** routing update / reference update / checklist update / new case eval only / no action
-
----
-
-## Suggested prompts
-
-- Research the global HNB market and compare major geographies, players, and regulatory constraints.
-- Map the global AI datacenter value chain and explain where value accrues by region.
-- Analyze the global EV battery market, including China, Europe, the US, Korea, and Japan.
-- Compare global cloud security vendors, noting where regional regulation changes adoption dynamics.
+- **Observed scope gap:**
+- **Root cause diagnosis:** missing rule / missing route trigger / route misclassification / execution failure / data unavailability
+- **Evidence for diagnosis:**
+- **Narrowest correct fix layer:** references / routing matrix / route attachment / checklist / case eval only
+- **Recurring?** yes / no (first observed)
+- **Recommended action:**
 
 ---
 
 ## Related files
 
-- `evals/cases/global-market-scope-completeness-case.md` — concrete case example for this family
+- `evals/cases/global-market-scope-completeness-case.md` — concrete scoring tool for a specific report
 - `references/failure-taxonomy.md` — Family F: Scope Completeness and Coverage Geometry
 - `ROUTING-MATRIX.md` — cross-cutting discipline: scope completeness
 
 ---
 
-## Why this eval exists
+## Why this meta-eval exists
 
-Several reports can look broad while still being structurally incomplete.
+The case eval (`global-market-scope-completeness-case.md`) can tell you whether a specific report has a scope problem. This meta-eval exists to answer the next question: **what should the repo do about it?**
 
-This eval exists to prevent "global" from becoming a stylistic label instead of a real coverage standard, and to ensure that scope completeness is explicitly evaluated as a cross-cutting discipline rather than assumed by default.
+Without this distinction, every scope failure risks being treated as a missing-rule problem, leading to more prose when the real fix may be routing, attachment, or execution hardening.

--- a/references/failure-taxonomy.md
+++ b/references/failure-taxonomy.md
@@ -257,19 +257,21 @@ A scope miss can distort the final conclusion even when individual facts are cor
 ### Existing evals in this family
 - `evals/cases/hnb-industry-report-table-design-case.md`
 - `evals/cases/industry-landscape-depth-case.md` (partial overlap)
+- `evals/cases/global-market-scope-completeness-case.md`
+- `evals/meta/scope-completeness-discipline.md`
 
 ### Existing rule/checklist coverage
 - partially covered by `references/current-state-verification.md`
 - partially covered by `references/task-types.md`
 - partially covered by `checklists/final-audit.md`
+- partially covered by `ROUTING-MATRIX.md` (cross-cutting discipline: scope completeness)
 
 ### What this family suggests structurally
-This family is not yet fully formalized in the repo. It appears repeatedly enough that it likely deserves its own dedicated eval and possibly a checklist gate for global/industry reports.
+Scope completeness now has a dedicated case eval and a meta-eval discipline file. The remaining gap is formalizing checklist-level gates for global/industry reports, and ensuring the routing matrix triggers scope-completeness checks for broad-scope tasks.
 
 ### Priority improvement direction
-- add a dedicated eval for global-market scope completeness
-- add explicit checks for top geographies, top segments, and omitted load-bearing scope
-- require the report to state its actual coverage boundaries when it is not truly comprehensive
+- strengthen checklist-level gates for global/industry reports
+- ensure the routing matrix consistently triggers scope-completeness checks for broad-scope tasks
 
 ---
 
@@ -341,12 +343,19 @@ The current evidence suggests the next improvements should focus on:
 
 1. **Rule activation / checklist routing**
    - especially for listed companies, fast-moving current-state tasks, ranking claims, and forward-looking claims
+   - see `evals/meta/rule-activation-and-execution-discipline.md`
+   - see `checklists/route-activation-audit.md`
 
-2. **A dedicated scope-completeness eval**
-   - to capture omitted load-bearing geographies or market segments
+2. **A dedicated scope-completeness eval** ✅ done
+   - case: `evals/cases/global-market-scope-completeness-case.md`
+   - meta-eval: `evals/meta/scope-completeness-discipline.md`
+   - cross-cutting discipline: `ROUTING-MATRIX.md`
+   - next: strengthen checklist-level gates for global/industry reports
 
-3. **A decision-utility rubric**
-   - to complement depth scoring with actual decision support quality
+3. **A decision-utility rubric** ✅ done
+   - rubric: `evals/templates/decision-utility-rubric.md`
+   - meta-eval: `evals/meta/decision-utility-discipline.md`
+   - cross-cutting discipline: `ROUTING-MATRIX.md`
 
 4. **A formal distinction between case evals, rubrics, and distillation artifacts**
    - so new additions are easier to classify and maintain
@@ -362,8 +371,8 @@ The current evidence suggests the next improvements should focus on:
 | C. Forward-looking claim discipline | Are predictions structured and sourced? | Checklist exists | Output-time leakage |
 | D. Output structure / information density | Is the report readable and decision-efficient? | Improving template discipline | Measurable enforcement still weak |
 | E. Research depth / briefing drift | Is this deep research or polished summary? | Rubric exists | Decision-utility layer still thin |
-| F. Scope completeness / coverage geometry | Did the report miss a load-bearing part of the scope? | Weakly covered | Needs dedicated eval/gate |
-| Meta: Rule activation | Did the correct rule fire at all? | Recognized implicitly | Needs explicit eval/gate |
+| F. Scope completeness / coverage geometry | Did the report miss a load-bearing part of the scope? | Case + meta-eval + route discipline exist | Checklist-level gate still needed |
+| Meta: Rule activation | Did the correct rule fire at all? | Meta-eval + route checklist exist | Execution-drift enforcement |
 
 ---
 

--- a/references/failure-taxonomy.md
+++ b/references/failure-taxonomy.md
@@ -220,6 +220,8 @@ This is the most subtle failure family. It produces reports that feel good on fi
 ### Existing evals in this family
 - `evals/cases/industry-landscape-depth-case.md`
 - `evals/templates/depth-rubric.md`
+- `evals/templates/decision-utility-rubric.md`
+- `evals/meta/decision-utility-discipline.md`
 - `evals/cases/hnb-industry-report-table-design-case.md` (partial overlap)
 
 ### Existing rule/checklist coverage
@@ -227,14 +229,15 @@ This is the most subtle failure family. It produces reports that feel good on fi
 - `references/counter-evidence.md`
 - `references/decision-report-template.md`
 - `checklists/final-audit.md`
+- `ROUTING-MATRIX.md` (cross-cutting discipline: decision utility)
 
 ### What this family suggests structurally
-Depth is already recognized as a target, but the current repo still has stronger discipline for factual hygiene than for decision usefulness.
+Decision-utility evaluation now has a scoring rubric and a meta-eval discipline. The remaining gap is formalizing checklist-level gates for decision-utility enforcement, and ensuring that decision-utility concerns are activated in route execution contracts rather than only evaluated after delivery.
 
 ### Priority improvement direction
-- add explicit decision-utility evaluation, not just depth evaluation
-- identify whether the report names and tests the load-bearing variables
-- make "what would change the conclusion" a stronger required field
+- harden checklist-level gates for decision-utility enforcement (final-audit recall discipline)
+- ensure route execution contracts explicitly require decision output where the task carries recommendation or judgment burden
+- monitor whether the decision-utility discipline is being consistently activated across decision-bearing routes, not only evaluated reactively
 
 ---
 
@@ -261,17 +264,18 @@ A scope miss can distort the final conclusion even when individual facts are cor
 - `evals/meta/scope-completeness-discipline.md`
 
 ### Existing rule/checklist coverage
+- `references/scope-completeness-discipline.md`
 - partially covered by `references/current-state-verification.md`
 - partially covered by `references/task-types.md`
 - partially covered by `checklists/final-audit.md`
 - partially covered by `ROUTING-MATRIX.md` (cross-cutting discipline: scope completeness)
 
 ### What this family suggests structurally
-Scope completeness now has a dedicated case eval and a meta-eval discipline file. The remaining gap is formalizing checklist-level gates for global/industry reports, and ensuring the routing matrix triggers scope-completeness checks for broad-scope tasks.
+Scope completeness now has a reference-level rule, a dedicated case eval, and a meta-eval discipline file. The remaining gap is ensuring the routing matrix consistently triggers scope-completeness checks for broad-scope tasks, and hardening final-audit recall checks.
 
 ### Priority improvement direction
-- strengthen checklist-level gates for global/industry reports
-- ensure the routing matrix consistently triggers scope-completeness checks for broad-scope tasks
+- ensure the routing matrix consistently triggers scope-completeness checks for broad-scope tasks (see route-attach updates)
+- harden final-audit recall discipline for scope-completeness checks on global-scope outputs
 
 ---
 

--- a/references/scope-completeness-discipline.md
+++ b/references/scope-completeness-discipline.md
@@ -1,0 +1,94 @@
+# Scope Completeness Discipline
+
+Use this reference when a task claims global, comprehensive, industry-wide, or full-landscape scope. It defines what minimum coverage should look like so "global" is not just a stylistic label.
+
+This is not about scoring a specific report — use `evals/cases/global-market-scope-completeness-case.md` for that. This reference defines the **reusable rule** for what acceptable scope coverage means.
+
+---
+
+## Core rule
+
+When a report claims a scope label, the actual coverage must match the label.
+
+### Global / industry-wide
+The report must cover at least:
+- **the top 3-5 geographies** by demand, supply, or regulation (whichever most affects the conclusion)
+- **regional leaders** that materially shape the competitive landscape, not only global brands
+- **binding regulatory regimes** — if a regime affects market access, pricing, or product design, it must be discussed proportionally to its impact
+
+If any of these are missing, the report must:
+- state the omission explicitly
+- explain why it does not change the conclusion
+- or downgrade the scope label (e.g., from "global" to "US + Europe focus")
+
+### Comprehensive / full landscape
+The report must not silently skip any major segment, use case, or value-chain layer that could materially change the answer.
+
+- if a segment is excluded, say so
+- if coverage is proportional to data availability rather than importance, flag the gap
+
+### Partial scope (acceptable)
+A report may have deliberately limited scope — e.g., "US market only", "enterprise segment only". This is fine as long as:
+- the scope boundary is stated in the opening
+- the label reflects the boundary (not "global" when it covers only one region)
+- a reader would not reasonably assume broader coverage than what is delivered
+
+---
+
+## Geography coverage matrix
+
+When a report claims global scope, check:
+
+| Dimension | What to cover | Minimum bar |
+|-----------|---------------|-------------|
+| Demand centers | Largest revenue / adoption / user markets | Top 3 geographies by market size |
+| Supply centers | Key manufacturing / sourcing / talent regions | Regions that would disrupt supply if constrained |
+| Regulatory centers | Regimes that control market access or product design | At minimum the most restrictive regime(s) |
+| Competitive map | Players that shape each major region | Regional champions not just global brands |
+
+If the report covers fewer than these by default, it must state which regions were prioritized and why.
+
+---
+
+## When to apply this discipline
+
+Apply scope completeness when:
+- the task asks for "global", "worldwide", "industry-wide", or "full landscape" coverage
+- the report title or scope statement implies breadth that the body may not deliver
+- the recommendation or conclusion depends on multi-region comparison
+- a market-size, market-share, or competitive-rank claim references multiple geographies
+
+Do **not** apply when:
+- the task is explicitly single-region (e.g., "US market only")
+- the report's scope is bounded by the user's constraints (e.g., "providers available in China")
+
+---
+
+## Common failure patterns
+
+| Pattern | Symptom | Fix |
+|---------|---------|-----|
+| Name-only global | Report says "global" but covers US+EU only | Add missing geographies or downgrade scope label |
+| Missing load-bearing geography | A top-3 geography is absent or appears in one sentence | Cover it proportionally or state explicit exclusion |
+| Flat competitive map | Global names listed but local champions absent | Include region-specific leaders |
+| Scope boundary not stated | Partial report reads as if it were comprehensive | State what is excluded in the opening |
+| Data-driven exclusion | Poorly documented markets are silently omitted | Flag data gaps rather than ignoring the region |
+
+---
+
+## Visible output in the report
+
+When scope completeness is applied, the final report should contain:
+
+- a scope statement in the opening that matches actual coverage
+- for global claims, coverage of the consequential geographies/segments proportional to their importance
+- state the exclusion of any load-bearing geography or segment that is not covered (with rationale)
+- avoid silently treating data-poor regions as irrelevant
+
+---
+
+## Related files
+
+- `evals/cases/global-market-scope-completeness-case.md` — concrete scoring tool for a specific report
+- `evals/meta/scope-completeness-discipline.md` — meta-eval for diagnosing which layer of the repo should change when a scope failure occurs
+- `ROUTING-MATRIX.md` — cross-cutting discipline: scope completeness


### PR DESCRIPTION
Closes #97

## 改动摘要

按 #97 要求，逐项检查 failure-taxonomy.md 中的失败家族，为缺失的 meta-eval 和触发路由进行补充。

### 新增文件
- **evals/meta/scope-completeness-discipline.md** — Family F 的 meta-eval，聚焦根因诊断（missing rule / missing trigger / route misclassification / execution failure / data unavailability），与已有 case eval 互补
- **evals/meta/decision-utility-discipline.md** — 决策有用性的 meta-eval，聚焦根因诊断（missing route / weak contract / template gap / execution failure / wrong route），与已有 rubric 互补（rubric 用于打分，meta-eval 用于判断系统性缺口）
- **references/scope-completeness-discipline.md** — 可复用最低覆盖标准规则，含 geography coverage matrix、common failure patterns、acceptable partial scope rules

### 修改文件
- **SKILL.md** — core shared disciplines 新增 scope completeness + decision utility
- **ROUTING-MATRIX.md** — 新增 2 个 cross-cutting discipline 定义；将两个 discipline 接入 7 个 route 的 Attach 列表（provider/vendor selection、market entry、market outlook、first-tier positioning、constrained choice、equipment selection、listed-company）
- **checklists/route-activation-audit.md** — 新增 2 个可视执行检查项
- **checklists/final-audit.md** — 新增 2 个 recall discipline 检查项 + 1 个 route execution 检查项
- **SYSTEM-MAP.md** — Family G 引用新 meta-eval
- **references/failure-taxonomy.md** — 更新 Family E/F 覆盖状态，更新 short classification table，标记 roadmap 完成项
- **ROADMAP.md** — 将 P1 meta-eval 项拆分为已完成（scope/decision meta-evals + route discipline）和待完成（checklist gate / market-outlook validation / remaining route hardening）
- **CHANGELOG.md** — 完整记录本次变动

### 不改（有意控制 scope）
- 不新增 case eval（已有 global-market-scope-completeness-case.md）
- 不重新组织 evals/ 目录结构
- 不改 scripts/、Python 代码、依赖

### 验证
纯 markdown 改动，无代码回归风险。所有交叉引用已验证指向已存在文件。