### PR TITLE
ci: expand trigger conditions — push($default-branch), workflow_dispatch, weekly schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,17 @@ on:
       - 'examples/**'
       - 'requirements.txt'
       - '.github/workflows/ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/**'
+      - 'schemas/**'
+      - 'examples/**'
+      - 'requirements.txt'
+      - '.github/workflows/ci.yml'
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * 1'
 
 jobs:
   quick:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - 'requirements.txt'
       - '.github/workflows/ci.yml'
   push:
-    branches: [main]
+    branches: [$default-branch]
     paths:
       - 'scripts/**'
       - 'schemas/**'


### PR DESCRIPTION
## 改动

在 `.github/workflows/ci.yml` 的触发条件中新增：

| 事件 | 说明 |
|------|------|
| `push` (branches: [$default-branch]) | 合入默认分支后再次验证，自动跟踪分支重命名 |
| `workflow_dispatch` | 手动触发，任意分支/commit 可跑 |
| `schedule` (cron: `0 3 * * 1`) | 每周一凌晨检查外部依赖是否仍可用 |

原有 `pull_request` + path filters 保持不变。

## 与 Issue #85 的差异

| Issue 提出的 | 实际实现 | 理由 |
|---|---|---|
| `push` 全分支 | 只限默认分支 | 避免 PR 分支 double-trigger（push + pull_request 同时触发） |
| 加入 SKILL.md 等文档路径 | 不加入 | CI 测试的是 Python 工具链，文档变化不影响 CI 结果 |
| 移除 path filters | 保留 | README/ARCHITECTURE 等变化不应触发耗时 CI |
| 硬编码 main | 改为 $default-branch | 自动跟踪默认分支名，重命名时不会静默失效 |

## 验证

- main 已有 branch protection（enforce_admins: true），直接 push 绕过 CI 的风险实际已被覆盖
- 新增的触发条件作为防御纵深 + 手动验证能力
- 自审过程发现硬编码 main 的风险，已修复为 $default-branch

Closes #85
