### PR TITLE
feat: harden checklist activation — workflow-spine to Tier-1, add audit-completeness verification (#114)

### DIFF
--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -628,9 +628,13 @@ Choose the route that most strongly determines report structure and audit burden
 Before delivery:
 
 - run `checklists/route-activation-audit.md` when a specialized route was selected
-- run `checklists/workflow-spine-audit.md` when no mature specialized route applies, or when output shows generic drift despite route selection
+- run `checklists/workflow-spine-audit.md`
+- run `checklists/final-audit.md`
+- verify that the required audits for the task were executed:
+  - if a specialized route was selected: confirm all audits listed in that route's `### Audit` section were run
+  - if no specialized route applies (shared-workflow path): confirm at least `workflow-spine-audit.md` and `final-audit.md` were run
 
-Then ask:
+Then ask (route-selected only — skip these if no specialized route applies):
 
 1. did the correct route fire?
 2. did the required secondary disciplines attach?

--- a/SKILL.md
+++ b/SKILL.md
@@ -48,7 +48,7 @@ Read `ROUTING-MATRIX.md` to select:
 - required audits
 - visible output structure
 
-Before deep collection, explicitly select one primary route. If no mature specialized route applies, treat the task as a shared-workflow task and use `checklists/workflow-spine-audit.md` for the final gate.
+Before deep collection, explicitly select one primary route. If no mature specialized route applies, treat the task as a shared-workflow task (the delivery-time final discipline handles audit selection: see step 3 and 6 below).
 
 Use one primary route plus only the smallest necessary supporting set.
 
@@ -368,11 +368,17 @@ Before delivery:
 
 1. run the route-specific audits required by `ROUTING-MATRIX.md`
 2. run `checklists/route-activation-audit.md` when a specialized route was selected
-3. run `checklists/workflow-spine-audit.md` when no mature specialized route applies, or when output shows generic drift despite route selection
+3. run `checklists/workflow-spine-audit.md`
 4. run `checklists/final-audit.md`
-5. confirm that the selected route is visibly executed in the final artifact
+5. confirm that the required artifact contract is visibly satisfied:
+   - if a specialized route was selected, confirm the route's artifact contract is visibly executed in the final artifact
+   - if no specialized route applies (shared-workflow path), confirm the shared workflow spine is visibly executed instead
+6. verify that all required audits for the task have been executed:
+   - if a specialized route was selected, confirm all audits listed in its `### Audit` section in `ROUTING-MATRIX.md` were run
+   - if no specialized route applies (shared-workflow path), confirm at least `workflow-spine-audit.md` and `final-audit.md` were run
+   - if a required audit is missing, run it before proceeding
 
-A report that sounds informed but does not visibly satisfy the selected route's artifact contract is not ready.
+A report that sounds informed but does not visibly satisfy its required artifact contract (route-specific or shared-workflow) is not ready.
 
 If the failure seems to be:
 - missing rule
@@ -381,7 +387,7 @@ If the failure seems to be:
 
 use `evals/meta/rule-activation-and-execution-discipline.md`.
 
-If no mature specialized route applies, treat the task as a shared-workflow task and run the workflow-spine audit instead.
+If no mature specialized route applies, treat the task as a shared-workflow task — the workflow-spine audit (already run in step 3) replaces route-specific checks; skip the route-dependent parts of steps 5 and 6.
 
 ## Output quality bar
 

--- a/checklists/route-activation-audit.md
+++ b/checklists/route-activation-audit.md
@@ -9,6 +9,7 @@ It audits whether route activation was explicit and whether the route actually s
 - [ ] the primary route was consciously chosen before deep collection began, not retrofitted during writing
 - [ ] the closest alternative route was identified and a reason exists for why the chosen route wins
 - [ ] a compact execution contract exists before synthesis: opening mandate, mandatory sections, hard-fail conditions
+- [ ] all required audits for this route (from `ROUTING-MATRIX.md`) are identified and confirmed executed before delivery; if any required audit is missing, it is run before the report is considered ready
 
 ## Route selection visibility
 

--- a/checklists/workflow-spine-audit.md
+++ b/checklists/workflow-spine-audit.md
@@ -4,7 +4,7 @@ Use this checklist when the research output feels generic, directionless, or lac
 
 It audits whether the shared workflow spine defined in `SKILL.md` was actually executed rather than assumed.
 
-Run this checklist before delivery when no mature specialized route applies, or when a route-specialized report still reads like unplanned prose.
+Run this checklist before every delivery. It is a Tier-1 gate that audits whether the shared workflow spine was executed, regardless of whether a specialized route was selected.
 
 ## Objective clarity
 
@@ -52,9 +52,9 @@ Run this checklist before delivery when no mature specialized route applies, or 
 
 ## Final discipline
 
-- [ ] the required audits for the selected route were run and pass
-- [ ] the report satisfies the visible artifact contract of its primary route
-- [ ] if no mature specialized route was triggered, the report still follows the shared workflow spine and does not drift into generic overview mode
+- [ ] if a specialized route was selected: the required audits for that route were run and pass
+- [ ] if a specialized route was selected: the report satisfies the visible artifact contract of its primary route
+- [ ] if no mature specialized route was triggered: the report follows the shared workflow spine and does not drift into generic overview mode
 
 ## Quality bar
 


### PR DESCRIPTION
## Summary

Addresses the meta-failure identified in #114: **rules exist but do not activate**.

Instead of implementing the full issue (which also proposed per-item weight labels across all checklists), this PR focuses on the highest-impact subset: making checklist activation verifiable and closing the loop on completeness.

### Changes (4 files, +22/-11)

**1. `SKILL.md` — Final discipline (step 3, 5, 6) + routing-rule update**
- Promoted `workflow-spine-audit.md` from conditional to always-run (Tier 1)
- Steps 5-6 now have explicit conditional branches for route-selected vs shared-workflow (no-route) paths
- Updated routing-rule fallback (L51) to reference final discipline instead of hardcoding workflow-spine-audit
- Updated shared-workflow instruction (L388) to clarify: workflow-spine already run in step 3, skip route-dependent parts

**2. `checklists/route-activation-audit.md` — Preflight**
- Added item: confirm all required audits for this route are identified and executed

**3. `ROUTING-MATRIX.md` — Final check**
- Aligned with SKILL.md: workflow-spine-audit always-run, audit-completeness verification with conditional branches
- Route-specific review questions guarded with "route-selected only"

**4. `checklists/workflow-spine-audit.md`**
- Updated run-condition to always-run (was: conditional)
- Items 55-56 now have conditional guards for route-selected only

### Cross-review findings (2 independent subagents) — 3 blockers fixed

| # | Blocker | Fix |
|---|---------|-----|
| 1 | Steps 5-6 unconditionally referenced "the selected route" — broken for shared-workflow | Added explicit conditional branches (IF route-selected / ELSE shared-workflow) in both steps |
| 2 | workflow-spine-audit items 55-56 assumed a route exists but audit is now always-run | Added "if a specialized route was selected:" guards |
| 3 | Three stale conditional references survived | Updated SKILL.md L51, L385, workflow-spine-audit.md L7 |

### Self-review finding — 1 blocker fixed

| # | Issue | Fix |
|---|-------|-----|
| 4 | Step 5 used non-standard term "route-selected artifact" — repo consistently uses "artifact contract" | Changed to "required artifact contract" |

### Edge-case analysis

Both execution paths verified:
- **Route path**: Step 1→2→3→4→5(IF)→6(IF) — all audits identified and verifiable ✅
- **Shared-workflow path**: Step 1(no-op)→2(skip)→3→4→5(ELSE)→6(ELSE) — core audits enforced ✅

No circular dependencies confirmed: route-activation-audit.md is not in any route's `### Audit` section. workf low-spine-audit.md is not in any route's `### Audit` section.

### What is *not* included (deferred)

- **Weight labels** (`[BLOCKER]`/`[NON-BLOCKER]`/`[NIT]`) — deferred pending eval evidence on which checklist items are actually being skipped

### Validation performed

- `grep` for stale "when no mature specialized route applies" references: **0 matches** in delivery files
- `grep` for unconditional "the selected route" in delivery-time instructions: **0 unguarded references**
- All "the selected route" references are either in context-appropriate locations (route-activation-audit.md which only runs when a route exists) or in non-delivery sections (ROUTING-MATRIX.md:51 route execution guidance)
- No Python scripts reference any of the changed markdown files — zero code regression risk
- All 4 files have valid markdown heading structure

Toward #114