### PR TITLE
feat: add structured assumption chain documentation (#118)

### DIFF
--- a/checklists/quantitative-role-audit.md
+++ b/checklists/quantitative-role-audit.md
@@ -14,6 +14,12 @@ If load-bearing numbers materially affect the conclusion, their roles should be 
 - Does uncertainty treatment match the role of the number?
 - If assumptions changed, would the conclusion visibly change? If yes, are those assumptions labeled clearly enough?
 
+## Assumption chain checks
+
+- Each high-sensitivity assumption has a complete assumption chain (supporting evidence, dependency conditions, sensitivity, failure signals, confidence). If the chain cannot be fully populated, one of the following must apply: (a) fill the chain from available evidence, (b) downgrade the assumption's sensitivity classification, or (c) restructure the analysis to reduce dependence on that assumption. Do not leave the chain incomplete without an explicit remediation decision.
+- The dependency conditions in each assumption chain are reasonable for the context.
+- The failure signals in each assumption chain are observable and actionable (not generic disclaimers).
+
 ## Hard fail signs
 
 - Numerical precision exceeds source certainty.

--- a/references/forward-looking-discipline.md
+++ b/references/forward-looking-discipline.md
@@ -60,6 +60,10 @@ When the report derives a forward-looking number (revenue projection, market siz
 
 Example: "Assuming 15% annual growth (in line with industry consensus), the market would reach $X by 2028. If growth slows to 10%, the market would reach $Y. This is an illustrative scenario, not a forecast."
 
+For a general-purpose assumption chain template applicable to non-forward-looking assumptions (proxies, current-state estimates, scoring weights), see `references/quantitative-role-labeling.md` (#假设链).
+
+If the forward-looking assumption is high-sensitivity (the conclusion changes materially when the assumption moves ±10%), use the detailed template in `references/quantitative-role-labeling.md` instead of, or in addition to, the lighter pattern above.
+
 ## Common failure patterns
 
 ### Pattern 1: unlabeled `预计`

--- a/references/quantitative-role-labeling.md
+++ b/references/quantitative-role-labeling.md
@@ -62,6 +62,100 @@ Common failures include:
 - composite score shown without clarifying the role of its inputs
 - precise-looking numbers carrying more certainty than the evidence supports
 
+## 假设链 — Assumption chain documentation
+
+Labeling a number as "assumption" is a necessary first step. It tells the reader what epistemic role the number plays. But it does not explain why that particular value was chosen or what would change if it turned out wrong.
+
+An assumption chain makes the reasoning behind a load-bearing assumption visible, auditable, and testable.
+
+### When to document an assumption chain
+
+Not every assumption needs a full chain. Apply this scope rule:
+
+- **Required** — assumptions whose deviation would materially affect the conclusion (high sensitivity). If a ±10% change in the assumption would alter the recommendation, shift the ranking, or change valuation by more than ±15%, the assumption chain is mandatory.
+- **Optional** — assumptions whose impact on the conclusion is estimated at under ±10% (or under ±15% for valuation only). A lightweight note is sufficient. If the impact falls in the 10–15% range for valuation, analyst judgment applies; err on the side of documenting.
+- **Not needed** — directly observed or officially reported facts (observed metrics). Facts do not become assumptions by being inconvenient.
+
+### Remediation when a chain cannot be completed
+
+If a high-sensitivity assumption cannot support a complete assumption chain, apply one of:
+
+1. **Fill the chain** — search for the missing evidence from available sources. If only partial information exists, document what is known and what remains uncertain, then downgrade confidence accordingly.
+2. **Downgrade sensitivity** — reclassify the assumption as lower-sensitivity if the chain gap reveals the assumption is less load-bearing than initially assessed.
+3. **Restructure the analysis** — reduce dependence on the assumption, or replace it with a more directly verifiable input or a range-based scenario.
+
+Do not leave a high-sensitivity assumption's chain incomplete without an explicit remediation decision and rationale.
+
+### Assumption chain template
+
+For each key assumption, document the following fields. Not every field must be populated; mark genuinely inapplicable fields as `N/A`.
+
+```
+### 假设: [具体假设陈述]
+
+- 类型: [假设 / proxy / 估算 / 模型输出]
+- 支持证据:
+  - 来源 A: [具体依据]
+  - 来源 B: [具体依据]
+- 依赖条件（假设成立的前提）:
+  - 宏观环境: [如不衰退、利率稳定]
+  - 竞争格局: [如无颠覆性对手出现]
+  - 技术路线: [如主流方案不变化]
+- 敏感度:
+  - 假设偏差 ±10% → 结论变化 X%
+  - 假设偏差 ±50% → 结论变化 Y%
+- 失效信号（可观察的事件/数字）:
+  - [如 Q1 增速低于 X%，则假设需调整]
+  - [如核心客户转向竞品，则假设需放弃]
+- 置信度: [高/中/低]
+```
+
+### Template example
+
+```
+### 假设: 该公司年增速在未来 3 年保持 15%
+
+- 类型: 假设（基于行业平均增速推测）
+- 支持证据:
+  - 公司过去 3 年 CAGR 为 14–18%（年报披露）
+  - 行业第三方预测未来 3 年增速 12–16%（IDC 报告 [S01]）
+- 依赖条件:
+  - 宏观环境: 目标市场不出现衰退
+  - 竞争格局: 无新进入者以显著更低价格抢份额
+  - 技术路线: 现有产品路线不被替代方案颠覆
+- 敏感度:
+  - 偏差 ±10%（13.5% 或 16.5%）→ 估值变化约 ±15%
+  - 偏差 ±50%（7.5% 或 22.5%）→ 估值变化约 ±70%，推荐强度需重新评估
+- 失效信号:
+  - Q1 营收增速低于 10% → 假设需下调
+  - 核心产品 ASP 连续两季下降 → 增速假设可能偏乐观
+- 置信度: 中（依赖宏观条件，且竞争格局有不确定性）
+```
+
+### Common failure patterns
+
+#### Pattern 1: Proxy used as assumption without justification
+
+A proxy (e.g., patent count as proxy for innovation capability) is silently treated as a valid assumption without explaining why the proxy is reasonable.
+
+**Fix**: State why this proxy is reasonable for the specific context, or downgrade the claim strength.
+
+#### Pattern 2: Assumption chain omitted for high-sensitivity numbers
+
+A number that drives the recommendation has no visible assumption chain — the reader cannot tell what would change the conclusion.
+
+**Fix**: Add the assumption chain. If the assumption is simple, a compact inline version is sufficient.
+
+#### Pattern 3: Assumption stated but dependency conditions missing
+
+The assumption is named ("assume 15% growth"), but the conditions that must hold for it to be valid are not documented.
+
+**Fix**: Add dependency conditions. At minimum, name the 1–2 external conditions most likely to break the assumption.
+
+### Relationship to other discipline files
+
+- `references/forward-looking-discipline.md` has an "Assumption chains" section for forward-looking numbers (revenue projections, market size forecasts, adoption timelines). The template here is the general-purpose version. For forward-looking claims, that file's lighter pattern may be sufficient; for complex or high-sensitivity assumptions, the full template here applies.
+
 ## Route-specific notes
 
 ### Market entry / regional expansion


### PR DESCRIPTION
## 改动内容

Closes #118

在三个文件中新增假设链（assumption chain）的结构化文档支持：

### `references/quantitative-role-labeling.md`（+84 行）
- 新增 **「假设链 — Assumption chain documentation」** 章节
- Scope rules（Required / Optional / Not needed），使用 ±10% 清晰阈值
- **Remediation when a chain cannot be completed** — 三种降级路径（Fill / Downgrade / Restructure）
- 结构化模板（类型、支持证据、依赖条件、敏感度、失效信号、置信度）+ 完整示例
- 3 个 assumption-chain-specific failure patterns
- Cross-reference 到 `references/forward-looking-discipline.md`

### `checklists/quantitative-role-audit.md`（+3 行）
- 新增 **Assumption chain checks** 小节
- 使用纯 `-` bullet 格式，与本文件现有风格一致
- 第 1 项内置 remediation 路径指引

### `references/forward-looking-discipline.md`（+4 行）
- Cross-reference 指向通用模板（`#假设链`）
- 新增高敏感度 forward-looking 场景的详细模板使用指引

## Round 2 交叉审核（2 个独立 subagent，100% 通过）

| 问题 | 状态 |
|------|------|
| [BLOCKER]/[NON-BLOCKER] 标记无前例 | ✅ 改为纯 `-` bullet |
| `%` 前多余空格违反仓库样式 | ✅ 全文件修复（`±10%` 等） |
| Anchor `#假设链----` 不可解析 | ✅ 改为 `(#假设链)` |
| 缺少 BLOCKER 降级路径 | ✅ 新增 Remediation 节 |
| ±10-20% 阈值歧义 | ✅ 单一 ±10% 阈值 + valuation \> ±15% |
| Cross-reference 不对称 | ✅ 双向覆盖高敏感场景 |
| 阈值 gap（10-15% valuation） | ✅ Optional 中增加 analyst judgment 指引 |

## 设计原则
- 仅追加，不改动已有内容
- Scope rules + Remediation 防止模板被滥用
- 与 forward-looking-discipline.md 互补而非重复
- 未涉及 SKILL.md / ROUTING-MATRIX.md / ARCHITECTURE.md