### PR TITLE
[P2] 结构化反方论证体系 — 让 counter-evidence 从走过场变为真压力测试 (#120)

### DIFF
--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -23,6 +23,9 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] the strongest argument against the main conclusion is present
 - [ ] competing explanations are noted where relevant
 - [ ] limitations and risks are explicit, not buried
+- [ ] each high-confidence conclusion has a corresponding structured counter-argument (see `references/counter-evidence.md` template)
+- [ ] counter-arguments are based on real evidence or reasonable logic, not strawman
+- [ ] if a counter-argument is rated "strong", the conclusion has been visibly adjusted (confidence downgrade, constraints, or reversal condition)
 
 ## Uncertainty
 

--- a/references/counter-evidence.md
+++ b/references/counter-evidence.md
@@ -105,3 +105,41 @@ Include some version of:
 - what remains unresolved
 - how counter-evidence affected confidence
 - what would change the conclusion
+
+## Structured counter-evidence template
+
+For each load-bearing conclusion labeled "confirmed" or "high confidence", construct at least one counter-evidence block using this template.
+
+This template exists to prevent counter-evidence from becoming ceremonial. Do not skip it for high-stakes conclusions.
+
+### Conclusion: [one sentence restating the claim]
+
+### Counter-argument: [strongest opposing claim]
+
+- Supporting evidence: [specific source, data point, or logic chain]
+- Argument strength: [strong / medium / weak]
+  - strong: direct data or factual support exists
+  - medium: reasonable inference but lacks direct evidence
+  - weak: pure logical speculation or thin analogy
+
+### Our response
+
+- Why it does not fully hold: [specific rebuttal with data or reasoning]
+- Valid component: [where the counter-argument has a point — do not dismiss entirely]
+- Remaining uncertainty: [what we cannot fully exclude even after rebuttal]
+
+### Impact on conclusion
+
+- Conclusion holds unchanged: [state conditions]
+- Confidence downgrade needed: [state magnitude and reason]
+- Conclusion no longer holds: [state trigger condition]
+
+### Execution rule
+
+If a counter-argument is rated "strong", the corresponding conclusion must either:
+
+1. be downgraded in confidence, or
+2. have explicit constraints added, or
+3. have a visible reversal condition recorded
+
+Do not leave a "strong" counter-argument without visible impact on the conclusion.

--- a/references/counter-evidence.md
+++ b/references/counter-evidence.md
@@ -108,9 +108,13 @@ Include some version of:
 
 ## Structured counter-evidence template
 
-For each load-bearing conclusion labeled "confirmed" or "high confidence", construct at least one counter-evidence block using this template.
+For each load-bearing conclusion (see "Load-bearing conclusions" above), construct at least one counter-evidence block using this template.
+
+Use the search patterns and common angles defined earlier in this file to generate counter-evidence. Do not invent strawman arguments.
 
 This template exists to prevent counter-evidence from becoming ceremonial. Do not skip it for high-stakes conclusions.
+
+If a template field does not apply, write "N/A — [brief reason]" rather than leaving it blank.
 
 ### Conclusion: [one sentence restating the claim]
 
@@ -122,7 +126,7 @@ This template exists to prevent counter-evidence from becoming ceremonial. Do no
   - medium: reasonable inference but lacks direct evidence
   - weak: pure logical speculation or thin analogy
 
-### Our response
+### Response
 
 - Why it does not fully hold: [specific rebuttal with data or reasoning]
 - Valid component: [where the counter-argument has a point — do not dismiss entirely]


### PR DESCRIPTION
## 问题

当前 counter-evidence 要求存在但执行容易弱化，典型症状：
- counter-evidence 段落只有 1-2 句轻描淡写
- 反方论证被放在风险章节角落，不参与 main thesis
- 没有对反方论点的强度做主动评估
- 反方论点没有对应到具体主张

## 方案

### 1. 增强 `references/counter-evidence.md`

在末尾增加结构化反方论证模板（+44行）：

- **模板结构**：对每条 load-bearing 结论，构造一个反方论点块
  - 结论（一句话）
  - 反方论点（最强相反主张）
  - 支撑依据（具体来源/数据/逻辑链）
  - 论证强度（强/中/弱）
  - 回应（反驳理由 + 接受的合理成分 + 剩余不确定性）
  - 对结论的影响（结论成立条件 / confidence 下调幅度 / 不再成立的触发条件）
- **执行规则**：如果反方论点强度为"强"，必须下调 confidence / 增加约束条件 / 记录 reversal condition
- **交叉引用**：引用同文件的搜索模式和常见角度
- **N/A 兜底**：不适用字段写 "N/A — [理由]" 而非留空

### 2. 增强 `checklists/final-audit.md`

在 Counter-evidence 章节增加 3 个验证项（+3行）：

- BLOCKER: 每条高 confidence 结论有对应结构化反方论点
- NON-BLOCKER: 反方论点有真实依据而非 strawman
- NON-BLOCKER: 反方论点为"强"时结论已做相应调整

## 改动范围

| 文件 | 改动 | 行数 |
|------|------|------|
| `references/counter-evidence.md` | 增加结构化模板章节 | +44 |
| `checklists/final-audit.md` | 增加验证项 | +3 |

## Review 修复

Round 1 交叉审核发现并修复了以下问题：
- BLOCKER: PR 混入 Issue #119 改动 → 已 rebase，仅保留 #120 改动
- NON-BLOCKER: 术语不一致 → 统一为 "load-bearing conclusions"
- NON-BLOCKER: 缺少交叉引用 → 添加对搜索模式和常见角度的引用
- NON-BLOCKER: 缺少 N/A 兜底规则 → 添加 "N/A — [brief reason]" 说明
- NIT: "Our response" 口语化 → 改为 "Response"

## 验证

- 纯文档变更，无代码逻辑改动
- 不涉及 SKILL.md / ROUTING-MATRIX.md / report templates
- 模板是指导而非强制格式，保持灵活性

Closes #120