### PR TITLE
feat: add private company / startup evaluation route (#121)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -85,6 +85,7 @@ The current first-class routes are:
 - equipment selection / procurement / home-server planning
 - constrained choice / shortlist
 - listed-company / investment-style research
+- private company / startup evaluation
 
 As a rule:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ This file is intentionally lightweight. Use concise entries that explain:
 ## Unreleased
 
 ### Added
+- `checklists/startup-company-report.md`: new checklist for private company / startup evaluation route — covers company status, team/founders, product/PMF signals, funding/financials, market/competition, source quality, judgment shape, and hard-fail gates (#121).
+- `references/startup-evaluation-discipline.md`: new discipline file for private company evaluation — covers stage identification, team assessment, PMF signals, funding/valuation framework, financial metrics, competitive positioning, risk assessment, source hierarchy, and output structure (#121).
+- `evals/cases/startup-evaluation-route-activation-case.md`: new eval case for private company routing — tests whether the skill correctly activates the private company route for startup evaluation tasks and produces a report that satisfies the artifact contract (#121).
+- `ROUTING-MATRIX.md`: added Private Company / Startup Evaluation as a first-class route with trigger, artifact contract, hard-fail conditions, and routing priority (#121).
+- `SYSTEM-MAP.md`: added private company / startup evaluation to Family B supported mature routes list (#121).
+- `ARCHITECTURE.md`: added private company / startup evaluation to first-class routes list (#121).
+- `ROADMAP.md`: added private company route validation task to P2 priorities (#121).
+- `references/source-quality.md`: added private company sources section — 6-tier hierarchy (company materials → Crunchbase/PitchBook → regulatory filings → investor sources → media → social) with labeling rules (#121).
+
+### Changed
+- `ROUTING-MATRIX.md`: updated routing priority from 8 to 9 routes — private company / startup evaluation inserted at position 2 (after listed-company, before market entry) (#121).
+
+### Added
 - `references/technical-analysis-discipline.md`: new discipline file for technical analysis tasks — covers principle analysis, architecture comparison, patent analysis, feasibility assessment, and roadmap evaluation. Includes comparison dimensions, maturity assessment frameworks (TRL, adoption lifecycle), and common failure modes (#116).
 - `checklists/technical-analysis-audit.md`: new checklist for technical deep-dive route — verifies route activation, technical state verification, evidence quality, comparison structure, feasibility assessment, maturity assessment, and judgment quality (#116).
 - `evals/cases/technical-analysis-kubernetes-vs-docker-case.md`: new eval case for technical deep-dive routing — tests whether the skill correctly activates the technical deep-dive route for architecture comparison tasks and produces a report that satisfies the artifact contract (#116).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,6 +36,7 @@ This file tracks likely next improvements and helps keep repo evolution intentio
   - See `evals/cases/cjk-pdf-validation-findings-case.md` for full results.
   - Remaining: testing against more report types (code-heavy, academic), adding CI gate for rendering regression.
 - Add one more real-case pass on market-entry memo information design so recommendation, hard gates, shortlist, and phased-entry blocks become easier to scan in PDF output.
+- **Validate the new private company / startup evaluation routing** against 2-3 real private company cases and harden the route definition if activation or artifact contract execution is weak. (Closes #121)
 
 ### P3
 - Consider scripts for normalizing evidence and claim records only after the protocol is stable.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ This file tracks likely next improvements and helps keep repo evolution intentio
   - See `evals/cases/cjk-pdf-validation-findings-case.md` for full results.
   - Remaining: testing against more report types (code-heavy, academic), adding CI gate for rendering regression.
 - Add one more real-case pass on market-entry memo information design so recommendation, hard gates, shortlist, and phased-entry blocks become easier to scan in PDF output.
-- **Validate the new private company / startup evaluation routing** against 2-3 real private company cases and harden the route definition if activation or artifact contract execution is weak. (Closes #121)
+- **Validate the new private company / startup evaluation routing** against 2-3 real private company cases and harden the route definition if activation or artifact contract execution is weak. (toward #121)
 
 ### P3
 - Consider scripts for normalizing evidence and claim records only after the protocol is stable.

--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -597,6 +597,82 @@ Fail if the report:
 
 ---
 
+## Route: Private Company / Startup Evaluation
+
+### Micro-audit focus
+For this route, be especially strict about:
+
+- whether the report avoids listed-company valuation methods (PE, PB, DCF) when the company has no public market data
+- whether founder-sourced claims are labeled as issuer-sourced rather than confirmed facts
+- whether PMF signals are grounded in available evidence rather than assumed from marketing language
+- whether source reliability levels are explicit rather than treating all sources as equal
+- whether funding and financial data are labeled by source type (company-disclosed / estimated / inferred)
+
+### Trigger
+Use when the task is mainly about:
+
+- private / unlisted company analysis
+- startup due diligence
+- PMF (Product-Market Fit) evaluation
+- funding round analysis
+- early-stage company assessment
+- founder / team evaluation
+
+**Choose this route when:** the core question is evaluating a non-public company's current state, prospects, or investment value.
+
+**Do not use this route when:** the company is publicly listed and trading (use listed-company route). If the company is filing for IPO but not yet listed, use this route but note IPO status.
+
+**Often confused with:** listed-company / investment-style research, first-tier / competitive positioning.
+
+**Key differences from listed-company route:**
+
+- no mandatory financial disclosures → source hierarchy must be redefined
+- founder / team background becomes a primary variable (rarely central in listed-company analysis)
+- PMF signals, funding trajectory, metric quality become key
+- valuation method differs (comparable transactions / latest round / revenue multiples vs PE / DCF)
+- source hierarchy differs (Crunchbase, PitchBook, SEC Form D, founder social media vs SEC filings, exchange disclosures)
+
+### Read
+- `references/startup-evaluation-discipline.md`
+- `references/source-quality.md`
+- `references/source-traceability-and-claim-citation.md`
+- `references/forward-looking-discipline.md` when forward-looking claims appear
+
+### Attach
+- current-state verification (funding status, product stage, team composition)
+- source traceability (especially for unverified founder claims)
+- forward-looking claims discipline (PMF signals, growth projections, runway estimates)
+- decision utility when the task carries investment or partnership judgment
+
+### Audit
+- `checklists/startup-company-report.md`
+- `checklists/source-traceability.md`
+- `checklists/final-audit.md`
+
+### Visible artifact contract
+The final report should visibly show:
+
+- company overview and stage positioning (what the company does, what stage it is in)
+- team assessment (founders, key hires, relevant background)
+- product and PMF signals (what exists, what traction is real vs claimed)
+- market and competitive position (who they compete with, what advantages exist)
+- funding and financial overview (known funding, revenue if disclosed, burn/runway if known — labeled by source type)
+- key strengths and risks (specific to this company, not generic startup risks)
+- 12-24 month key milestones (what to watch for)
+- judgment and recommendation (if applicable, with explicit uncertainty bounds)
+
+### Hard fail
+Fail if the report:
+
+- uses PE / PB / PS / DCF as primary valuation framing for a private company without explicit justification
+- treats unverified founder claims as confirmed facts
+- presents weak or absent financial data as if it were comparable to audited public-company disclosures
+- does not label source reliability levels
+- writes the report as a mini listed-company analysis with private company data gaps hidden
+- uses `唯一` / `only` / `first` / `领先` wording without evidence strong enough for that claim strength
+
+---
+
 ## Cross-cutting disciplines
 
 ### Current-state verification
@@ -687,15 +763,18 @@ Fail if:
 If multiple primary-looking routes apply, use this order:
 
 1. listed-company / investment-style
-2. market entry / regional expansion
-3. provider / vendor selection
-4. first-tier / competitive positioning
-5. technical deep-dive / architecture analysis
-6. equipment selection / procurement / home-server planning
-7. market outlook / industry evolution
-8. constrained choice / shortlist
+2. private company / startup evaluation
+3. market entry / regional expansion
+4. provider / vendor selection
+5. first-tier / competitive positioning
+6. technical deep-dive / architecture analysis
+7. equipment selection / procurement / home-server planning
+8. market outlook / industry evolution
+9. constrained choice / shortlist
 
 Choose the route that most strongly determines report structure and audit burden.
+
+**Borderline case — private company filing for IPO:** Use private company route if not yet trading. Use listed-company route if trading has begun. Note IPO status explicitly in either case.
 
 ---
 

--- a/SYSTEM-MAP.md
+++ b/SYSTEM-MAP.md
@@ -96,6 +96,7 @@ Makes mature task families explicit so the right discipline set and delivery con
 - equipment selection / procurement / home-server planning
 - constrained choice / shortlist
 - listed-company / investment-style research
+- private company / startup evaluation
 
 ### Typical failure signs
 - the correct rule exists but does not activate

--- a/SYSTEM-MAP.md
+++ b/SYSTEM-MAP.md
@@ -86,6 +86,7 @@ Makes mature task families explicit so the right discipline set and delivery con
 
 ### Primary checklists
 - `checklists/route-activation-audit.md`
+- `checklists/startup-company-report.md` (for private company route)
 
 ### Supported mature routes
 - provider / vendor selection
@@ -103,6 +104,8 @@ Makes mature task families explicit so the right discipline set and delivery con
 - the report uses the right vocabulary but the wrong structure
 - the route is implicit in reasoning but invisible in the final artifact
 - a task drifts from choice memo into overview memo
+- a private company evaluation uses listed-company valuation methods (PE, PB, DCF)
+- founder-sourced claims are treated as confirmed facts without labeling
 
 ### First place to change
 - `ROUTING-MATRIX.md` when route selection or attached discipline mapping is wrong

--- a/checklists/startup-company-report.md
+++ b/checklists/startup-company-report.md
@@ -1,0 +1,76 @@
+# Startup / Private Company Report Checklist
+
+Use this checklist when the research is about a private, unlisted, or early-stage company.
+
+Run through every item before delivering the final report.
+
+## Company status
+
+- [ ] current capital-markets state confirmed: private / filed for IPO / under review / other
+- [ ] current stage identified: pre-seed / seed / Series A/B/C... / growth / pre-IPO
+- [ ] source confirming status is primary and current (not stale filing language)
+- [ ] if IPO process is underway, current stage is precise (filed / accepted / under review / approved)
+
+## Team and founders
+
+- [ ] key founders / leadership identified with background
+- [ ] founder track record noted (prior exits, domain experience, relevant credentials)
+- [ ] team composition relevant to the business model is surfaced
+- [ ] claims about team quality are sourced, not promotional language
+- [ ] if founder claims are unverified or self-reported, they are labeled as such
+
+## Product and PMF signals
+
+- [ ] current product / service described with actual capabilities (not just roadmap)
+- [ ] product stage identified: prototype / beta / GA / scaling
+- [ ] PMF signals noted where available: retention, NPS, user growth, revenue growth
+- [ ] distinction between user growth vs paid growth vs burn rate is explicit
+- [ ] if PMF data is unavailable or weak, this is stated rather than assumed
+- [ ] technical readiness / moat assessment is grounded in evidence, not marketing
+
+## Funding and financials
+
+- [ ] funding history with rounds, amounts, dates, and investors (where known)
+- [ ] valuation trajectory noted (last round valuation, if disclosed)
+- [ ] investor quality mentioned when decision-relevant (lead investors, strategic value)
+- [ ] burn rate / runway noted if available; if unavailable, stated explicitly
+- [ ] revenue / ARR / MRR figures labeled by source type: company-reported / estimated / inferred
+- [ ] key metrics labeled: ARR, MRR, CAC, LTV, Churn, Burn Multiple — only if available and sourced
+- [ ] financial data is not presented with false precision when source is weak
+
+## Market and competition
+
+- [ ] target market defined with reasonable scope
+- [ ] competitive landscape identified (direct and adjacent competitors)
+- [ ] competitive positioning is grounded in evidence (product differences, not just claims)
+- [ ] market size claims are sourced or labeled as estimates
+- [ ] resource constraints vs competitive advantages are separated
+
+## Source quality and traceability
+
+- [ ] sources are classified by reliability level (primary / secondary / promotional / social)
+- [ ] founder-sourced claims are labeled as issuer-sourced, not confirmed facts
+- [ ] media coverage is treated as discovery, not as evidence for claims
+- [ ] Crunchbase / PitchBook data is labeled as aggregator data, not primary source
+- [ ] social media (Twitter, LinkedIn, Reddit) is labeled as weak supplemental signal
+- [ ] load-bearing claims have identifiable sources in the body, not just bibliography
+
+## Judgment-shape micro-audit
+
+- [ ] the opening states the current assessment before long company background
+- [ ] the report identifies the 3-5 factors that most determine the company's prospects
+- [ ] what currently supports the thesis, what weakens it, and what remains unknown are separated
+- [ ] the report avoids writing as if it were a mini listed-company analysis
+- [ ] no PE / DCF / public-market valuation framing is used without explicit justification
+- [ ] founder claims and marketing language are not elevated to confirmed facts
+
+## Hard-fail gate
+
+- [ ] the report does not use listed-company valuation methods (PE, PB, PS, DCF) as primary framing for a private company without explicit justification
+- [ ] the report does not treat unverified founder claims as confirmed facts
+- [ ] the report does not present weak or absent financial data as if it were comparable to audited public-company disclosures
+- [ ] the report labels source reliability levels rather than treating all sources as equal
+
+## Flags
+
+If any item above is unchecked or uncertain, note the limitation explicitly in the report before delivery.

--- a/checklists/startup-company-report.md
+++ b/checklists/startup-company-report.md
@@ -70,6 +70,8 @@ Run through every item before delivering the final report.
 - [ ] the report does not treat unverified founder claims as confirmed facts
 - [ ] the report does not present weak or absent financial data as if it were comparable to audited public-company disclosures
 - [ ] the report labels source reliability levels rather than treating all sources as equal
+- [ ] the report does not write as a mini listed-company analysis with private company data gaps hidden
+- [ ] the report does not use `唯一` / `only` / `first` / `领先` wording without evidence strong enough for that claim strength
 
 ## Flags
 

--- a/evals/cases/startup-evaluation-route-activation-case.md
+++ b/evals/cases/startup-evaluation-route-activation-case.md
@@ -1,0 +1,135 @@
+# Eval: Private Company / Startup Evaluation — Anthropic Company Assessment
+
+## Goal
+
+Test whether the skill correctly activates the **private company / startup evaluation** route for a startup company assessment task, and produces a report that satisfies the private company artifact contract.
+
+This eval validates the new private company / startup evaluation routing added in response to issue #121.
+
+## Prompt
+
+Analyze Anthropic as a private company. Focus on:
+
+- company overview and current stage
+- founding team and key leadership
+- product and PMF signals (Claude, API business)
+- funding history and valuation trajectory
+- competitive positioning vs OpenAI, Google, Meta
+- key strengths and risks
+- 12-24 month outlook
+
+## What this eval is testing
+
+- whether the private company route is correctly activated (not listed-company or first-tier positioning)
+- whether the report avoids listed-company valuation methods (PE, PB, DCF)
+- whether founder-sourced claims are labeled as issuer-sourced
+- whether PMF signals are grounded in available evidence
+- whether source reliability levels are explicit
+- whether the artifact contract is satisfied
+
+## Route activation criteria
+
+The private company route should activate because:
+
+- Anthropic is a **private, unlisted company**
+- the core question is about **evaluating a non-public company's state and prospects**
+- the task is not about listed-company investment analysis (no public market data)
+- the task is not about competitive positioning ranking (that would be first-tier / competitive positioning)
+
+If the report uses PE/PB/PS/DCF as primary valuation framing, the wrong route fired.
+
+If the report uses funding round valuation and comparable transactions, the correct route fired.
+
+## Pass criteria
+
+A good answer should:
+
+### 1. Activate the correct route
+- explicitly classify this as a private company evaluation
+- not default to listed-company or generic research
+
+### 2. Avoid listed-company valuation methods
+- does not use PE, PB, PS, or DCF as primary framing
+- uses latest round valuation, comparable transactions, or revenue multiples
+- labels valuation as "latest round valuation" not "company value"
+
+### 3. Label source reliability
+- founder-sourced claims labeled as issuer-sourced
+- Crunchbase/PitchBook data labeled as aggregator estimates
+- media coverage treated as discovery, not evidence
+- social media labeled as weak supplemental signal
+
+### 4. Assess PMF signals with evidence
+- distinguishes user growth from paid growth from revenue growth
+- labels metrics by source type (company-reported / estimated / inferred)
+- states explicitly when PMF data is unavailable
+
+### 5. Evaluate team as primary variable
+- founders and key leadership identified with background
+- track record noted (prior exits, domain experience)
+- claims about team quality sourced, not promotional
+
+### 6. Satisfy the artifact contract
+The report should visibly show:
+- company overview and stage positioning
+- team assessment
+- product and PMF signals
+- market and competitive position
+- funding and financial overview (labeled by source type)
+- key strengths and risks (specific to this company)
+- 12-24 month milestones
+- judgment and recommendation (with explicit uncertainty bounds)
+
+## Failure signs
+
+Mark this eval as failed if the answer does any of the following:
+
+- activates listed-company route instead of private company route
+- uses PE/PB/PS/DCF as primary valuation framing
+- treats unverified founder claims as confirmed facts
+- does not label source reliability levels
+- presents weak or absent financial data as if comparable to audited public-company disclosures
+- writes as a mini listed-company analysis with data gaps hidden
+- uses `唯一` / `only` / `first` / `领先` wording without evidence
+- produces a generic company overview without private-company-specific assessment
+
+## Why this eval matters
+
+This is a high-value regression test because it catches a common routing failure:
+
+- the task sounds like it could be "listed-company investment research" (company analysis)
+- but the real question is about **evaluating a private company with different evidence constraints**
+- if the wrong route fires, the report will try to find non-existent public market data and use inappropriate valuation methods
+
+If the skill cannot pass this eval, the private company route is not yet reliable.
+
+## Reviewer checklist
+
+Use this quick checklist after a run:
+
+- Did it activate the private company route?
+- Did it avoid PE/PB/PS/DCF as primary framing?
+- Did it label source reliability levels?
+- Did it assess PMF signals with evidence?
+- Did it evaluate team as a primary variable?
+- Does the artifact contract sections appear in the report?
+- Does the report look like a startup evaluation, not a listed-company memo?
+
+## Suggested scoring
+
+- Pass: route activation correct, valuation appropriate, sources labeled, artifact contract satisfied
+- Partial: route activation correct but analysis is shallow or sources not labeled
+- Fail: wrong route activated, or report uses listed-company methods for private company
+
+---
+
+## Related evals
+
+- `evals/cases/minimax-company-report-case.md` — tests listed-company routing for a recently-IPO'd company
+- `evals/cases/moore-threads-listing-status-case.md` — tests listing-state awareness
+
+## Related references
+
+- `references/startup-evaluation-discipline.md` — the discipline file for this route
+- `checklists/startup-company-report.md` — the checklist for this route
+- `ROUTING-MATRIX.md` — the route definition

--- a/references/source-quality.md
+++ b/references/source-quality.md
@@ -59,6 +59,28 @@ For audited financials, legal text, filings, architecture docs, and official dis
 - authority matters more than media interpretation
 - primary source should anchor the claim whenever available
 
+## Private company sources
+
+For private, unlisted, or early-stage companies, source availability differs from listed companies. Adjust source hierarchy accordingly.
+
+Preferred order for private companies:
+
+1. **Company official materials** — blog posts, product documentation, whitepapers, official announcements
+2. **Credible third-party databases** — Crunchbase, PitchBook, CB Insights (label as aggregator data, not primary source)
+3. **Regulatory filings** — SEC Form D, state filings, international equivalents (when available)
+4. **Investor-sourced information** — investor blogs, portfolio pages, LP letters (label as investor perspective)
+5. **Media coverage** — TechCrunch, 36氪, The Information (treat as discovery, verify claims independently)
+6. **Social / community** — founder Twitter/LinkedIn, Reddit, V2EX (minimum weight, supplemental only)
+
+Key rules for private company sources:
+
+- **Crunchbase / PitchBook**: Aggregator data, not primary source. Funding amounts and valuations may be approximate. Label as "per [source], estimated."
+- **Media coverage**: Discovery tool, not evidence. Verify load-bearing claims via primary sources when possible.
+- **Founder claims**: Issuer-sourced. Do not elevate to confirmed fact without independent validation.
+- **Social media**: Weak supplemental signal. Do not use as primary evidence for any load-bearing claim.
+
+For detailed private company evaluation methodology, read `references/startup-evaluation-discipline.md`.
+
 ## Conflict handling
 
 When sources conflict:

--- a/references/startup-evaluation-discipline.md
+++ b/references/startup-evaluation-discipline.md
@@ -1,0 +1,207 @@
+# Startup / Private Company Evaluation Discipline
+
+Use this file when the research involves evaluating a private, unlisted, or early-stage company.
+
+Do not default to listed-company evaluation methods (PE, PB, DCF, public-market multiples) when the company has no public market data.
+
+## Core rule
+
+Private company evaluation requires a different framework than listed-company analysis. The absence of mandatory financial disclosures, public market pricing, and analyst consensus changes what evidence is available, how it should be sourced, and what conclusions can be drawn.
+
+Do not force listed-company structure onto a private company report.
+
+## Key differences from listed-company evaluation
+
+| Dimension | Listed company | Private company |
+|-----------|---------------|-----------------|
+| Financial data | Audited filings, quarterly reports | Self-reported, estimated, or absent |
+| Valuation | Market price, PE, PB, DCF | Latest round, comparable transactions, revenue multiples |
+| Key variables | Revenue growth, margins, guidance | PMF signals, burn rate, runway, founder quality |
+| Source quality | SEC filings, exchange disclosures | Company blog, Crunchbase, PitchBook, media |
+| Analyst coverage | Broker research, consensus | Sparse, often investor-sourced |
+| Time horizon | Quarterly / annual cycles | Funding round to funding round |
+
+## Evaluation framework
+
+### 1. Company stage identification
+
+Before analysis, identify the company's current stage:
+
+- **Pre-seed / Seed**: Idea or early product, minimal revenue, founder-dependent
+- **Series A/B**: Product-market fit validation, early revenue, team building
+- **Series C+ / Growth**: Scaling, meaningful revenue, operational complexity
+- **Pre-IPO**: Preparing for public listing, may have filed or be in process
+
+The stage determines which metrics matter and what evidence burden is appropriate.
+
+### 2. Team and founder assessment
+
+For private companies, team quality is often a primary variable, not a secondary one.
+
+Assess:
+- Founder background and track record
+- Domain expertise relevance
+- Prior exits or scaling experience
+- Team composition relative to business model needs
+- Advisory board or investor quality as signal
+
+**Evidence discipline:**
+- Label founder-sourced claims as issuer-sourced
+- Do not treat marketing language ("world-class team", "serial entrepreneur") as confirmed fact
+- Prefer third-party validation (investor quality, prior exit outcomes) over self-description
+
+### 3. PMF (Product-Market Fit) signals
+
+PMF is the central question for early-stage companies. Evaluate based on available signals:
+
+**Strong signals (if available):**
+- Retention curves (cohort analysis)
+- Net Revenue Retention (NRR) for SaaS
+- Organic growth vs paid growth ratio
+- Customer testimonials or case studies with verifiable outcomes
+- Revenue growth rate relative to burn rate
+
+**Weak signals (use with caution):**
+- User count without retention context
+- Press coverage or social media buzz
+- Awards or recognition without revenue validation
+- Founder claims about traction
+
+**Evidence discipline:**
+- Distinguish user growth from paid growth from revenue growth
+- If PMF data is unavailable, state this explicitly rather than inferring from adjacent signals
+- Label metrics by source type: company-reported / third-party estimate / inferred
+
+### 4. Funding and valuation
+
+Private company valuation is fundamentally different from public market valuation.
+
+**Preferred valuation anchors:**
+1. Most recent funding round valuation (if disclosed)
+2. Comparable transaction multiples (revenue, ARR, user base)
+3. Secondary market pricing (if available and current)
+4. Investor-reported valuations (if credible and recent)
+
+**Do not use as primary framing:**
+- PE / PB / PS multiples (no public market price)
+- DCF models (too many assumptions for early-stage)
+- Public market comparable without explicit adjustment for illiquidity, stage, and disclosure differences
+
+**Evidence discipline:**
+- Label valuation as "latest round valuation" not "company value"
+- Note whether valuation is primary (investor-confirmed) or secondary (media-reported)
+- If valuation is stale (older than 12 months for fast-moving companies), flag this
+- Distinguish between pre-money and post-money when relevant
+
+### 5. Financial metrics for private companies
+
+Available financial data varies dramatically by stage. Use what exists, do not fabricate what does not.
+
+**Common metrics (when available):**
+- ARR / MRR (Annual / Monthly Recurring Revenue)
+- Gross margin
+- Burn rate (monthly cash consumption)
+- Runway (months of cash remaining)
+- CAC (Customer Acquisition Cost)
+- LTV (Customer Lifetime Value)
+- Churn rate
+- Burn Multiple (net burn / net new ARR)
+
+**Evidence discipline:**
+- Label all financial figures by source: company-disclosed / investor-reported / estimated / inferred
+- If revenue is estimated by third parties (Crunchbase, PitchBook), label as estimate
+- Do not present estimated figures with the same confidence as audited public-company financials
+- If key metrics are unknown, state this rather than using proxies without labeling
+
+### 6. Competitive positioning
+
+Private companies often compete with both incumbents and other startups.
+
+Assess:
+- Direct competitors (same market, similar solution)
+- Adjacent competitors (different approach to same problem)
+- Incumbent threat (large companies that could enter)
+- Resource constraints vs competitive advantages
+- Moat durability (network effects, data advantages, switching costs, brand)
+
+**Evidence discipline:**
+- Competitive claims should be grounded in verifiable product differences, not marketing
+- Market share claims for private companies are often weak or absent; label accordingly
+- Do not treat "first mover" or "only player" claims as confirmed without evidence
+
+### 7. Risk assessment
+
+Private company risks differ from public company risks:
+
+**Key risk categories:**
+- Funding risk (runway, next round dependency)
+- Key-person risk (founder departure impact)
+- Market risk (PMF may not scale)
+- Regulatory risk (especially for fintech, healthtech, crypto)
+- Execution risk (scaling challenges)
+- Competitive risk (incumbent response, new entrants)
+
+**Evidence discipline:**
+- Risks should be specific to the company, not generic startup risks
+- Quantify when possible (runway in months, burn rate trajectory)
+- Label risk assessment as judgment, not fact
+
+## Source hierarchy for private companies
+
+Private companies have different source availability than listed companies.
+
+### Preferred order
+
+1. **Company official materials** — blog posts, product documentation, whitepapers, official announcements
+2. **Credible third-party databases** — Crunchbase, PitchBook, CB Insights (label as aggregator data)
+3. **Regulatory filings** — SEC Form D, state filings, international equivalents (when available)
+4. **Investor-sourced information** — investor blogs, portfolio pages, LP letters (label as investor perspective)
+5. **Media coverage** — TechCrunch, 36氪, The Information (treat as discovery, verify claims)
+6. **Social / community** — founder Twitter/LinkedIn, Reddit, V2EX (minimum weight, supplemental only)
+
+### Source quality rules
+
+- **Crunchbase / PitchBook**: Aggregator data, not primary source. Funding amounts and valuations may be approximate. Label as "per [source], estimated."
+- **Media coverage**: Discovery tool, not evidence. Verify load-bearing claims via primary sources when possible.
+- **Founder claims**: Issuer-sourced. Do not elevate to confirmed fact without independent validation.
+- **Social media**: Weak supplemental signal. Do not use as primary evidence for any load-bearing claim.
+
+## Output structure
+
+A private company report should include:
+
+1. **Company overview and stage positioning** — what the company does, what stage it is in
+2. **Team assessment** — founders, key hires, relevant background
+3. **Product and PMF signals** — what exists, what traction is real
+4. **Market and competitive position** — who they compete with, what advantages exist
+5. **Funding and financial overview** — known funding, revenue (if disclosed), burn/runway (if known)
+6. **Key strengths and risks** — specific to this company
+7. **12-24 month milestones** — what to watch for
+8. **Judgment and recommendation** — if applicable, with explicit uncertainty bounds
+
+Do not force listed-company sections (current market snapshot, PE/PB, analyst consensus) into a private company report.
+
+## Hard-fail conditions
+
+Fail if the report:
+
+- uses PE / PB / PS / DCF as primary valuation framing for a private company without explicit justification
+- treats unverified founder claims as confirmed facts
+- presents weak or absent financial data as if it were comparable to audited public-company disclosures
+- does not label source reliability levels
+- writes the report as a mini listed-company analysis with private company data gaps hidden
+- uses `唯一` / `only` / `first` / `领先` wording without evidence strong enough for that claim strength
+
+## Borderline cases
+
+### Company is filing for IPO but not yet listed
+
+Use the private company route, but note IPO status. The analysis should be forward-looking about what changes post-IPO (access to capital, disclosure requirements, valuation anchoring).
+
+### Recently listed company with mostly pre-IPO data
+
+Use the listed-company route if trading has begun. Note that financial data is primarily from prospectus / pre-IPO disclosures, and current market data should be included as the primary valuation anchor.
+
+### Large private company with extensive public data (e.g., OpenAI, Stripe)
+
+Use the private company route, but note that data availability is unusually high. The evaluation framework still applies, but evidence burden may be easier to meet.


### PR DESCRIPTION
## Summary

Add a new routing path for private / unlisted / startup company evaluation, addressing the gap where the existing  route assumes public market data, audited financials, and analyst consensus that private companies do not have.

## Changes

### New files
- **** — Checklist for private company evaluation covering: company status, team/founders, product/PMF signals, funding/financials, market/competition, source quality, judgment shape, and hard-fail gates.
- **** — Methodology for startup assessment including: stage identification, team evaluation, PMF signals, funding/valuation framework, financial metrics, competitive positioning, risk assessment, source hierarchy, and output structure.

### Modified files
- **** — Added route definition with Trigger, Read, Attach, Audit, Visible artifact contract, and Hard fail sections. Updated routing priority to position private company route #2 (after listed-company).
- **** — Added route to Family B supported mature routes.
- **** — Added private company source hierarchy section (company materials → Crunchbase/PitchBook → regulatory filings → investor sources → media → social).
- **** — Added validation task for the new route.

## Key design decisions

1. **Route priority #2** — Positioned after listed-company since listed companies have stronger disclosure requirements and more structured data. Borderline case (IPO-in-progress) documented in routing priority section.

2. **Different source hierarchy** — Private companies lack SEC filings and exchange disclosures. Source hierarchy redefined: company official materials → aggregator databases (Crunchbase/PitchBook, labeled as estimates) → regulatory filings (SEC Form D) → investor sources → media → social.

3. **Different valuation framework** — No PE/PB/PS/DCF as primary framing. Instead: latest round valuation, comparable transaction multiples, revenue multiples. All labeled by source type.

4. **PMF as central variable** — Unlike listed companies where financial metrics dominate, private company evaluation centers on PMF signals (retention, growth quality, burn rate).

5. **Founder/team as primary variable** — Team assessment is a first-class section, not a sidebar.

## Hard-fail conditions

The route explicitly fails if:
- Uses listed-company valuation methods without justification
- Treats unverified founder claims as confirmed facts
- Does not label source reliability levels
- Writes as mini listed-company analysis with data gaps hidden

## Next steps

- Validate against 2-3 real private company cases
- Harden route definition if activation or artifact contract execution is weak

Closes #121