### PR TITLE
ci: add CJK HTML pipeline test to CI gate (partial #126)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
       - run: python3 scripts/validate_research_pack.py examples/research-pack-example.md --strict
       - run: python3 scripts/test_validator_regression.py
       - run: python3 scripts/test_md_to_pdf_preflight.py
-      - run: python3 scripts/test_cjk_pdf_pipeline.py
 
   smoke:
     runs-on: ubuntu-latest
@@ -110,6 +109,7 @@ jobs:
           echo 'Img stripping check OK'
           rm -rf "$temp"
       - run: python3 scripts/test_remote_block.py
+      - run: python3 scripts/test_cjk_pdf_pipeline.py
       - run: |
           temp=$(mktemp -d)
           printf '# Test\n\nHello.\n' > "$temp/in.md"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       - run: python3 scripts/validate_research_pack.py examples/research-pack-example.md --strict
       - run: python3 scripts/test_validator_regression.py
       - run: python3 scripts/test_md_to_pdf_preflight.py
+      - run: python3 scripts/test_cjk_pdf_pipeline.py
 
   smoke:
     runs-on: ubuntu-latest

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,6 +36,7 @@ This file tracks likely next improvements and helps keep repo evolution intentio
   - Both bugs fixed (`\s+` → `[ \t]+`; `NFKC` → `NFC`). Re-validated against 2 reports (5,000+ CJK chars each) — block structure preserved, CJK punctuation intact, no cross-paragraph merging.
   - See `evals/cases/cjk-pdf-validation-findings-case.md` for full results.
   - Remaining: testing against more report types (code-heavy, academic), adding CI gate for rendering regression.
+    - **Partial**: CJK HTML pipeline test (`test_cjk_pdf_pipeline.py`) wired into CI quick job. Still missing: PDF-level rendering tests, English/mixed/table-heavy test scenarios, unified `test_pdf_regression.py` script. (toward #126)
 - Add one more real-case pass on market-entry memo information design so recommendation, hard gates, shortlist, and phased-entry blocks become easier to scan in PDF output.
 - **Validate the new private company / startup evaluation routing** against 2-3 real private company cases and harden the route definition if activation or artifact contract execution is weak. (toward #121)
 - **Validate the new regulatory / policy impact analysis routing** against 2-3 real regulatory analysis cases (export controls, data compliance, industry regulation) and harden the route definition if activation or artifact contract execution is weak. (toward #122)

--- a/scripts/test_cjk_pdf_pipeline.py
+++ b/scripts/test_cjk_pdf_pipeline.py
@@ -204,7 +204,7 @@ def test_normalize_preserves_chinese_punctuation():
 
 def test_full_pipeline_block_integrity():
     """Full pipeline (normalize → markdown → HTML) preserves heading and list counts."""
-    md = "# H1\n\nP1.\n\n## H2\n\n- Li1\n- Li2\n\n### H3\n\nP2.\n\n> Bq\n\n## H4\n\nP3."
+    md = "# H1\n\nP1.\n\n## H2\n\n- Li1\n- Li2\n\n### H3\n\nP2.\n\n> Bq\n\n#### H4\n\nP3."
     errors, _, html = verify_cjk_pipeline(md)
     assert not errors, f"pipeline integrity errors: {errors}"
     # Verify specific heading text is not merged with body


### PR DESCRIPTION
## What

Add `test_cjk_pdf_pipeline.py` to CI smoke job so CJK HTML rendering regressions are caught automatically.

## Scope clarification

This PR addresses **part** of Issue #126. It does NOT:
- Create a unified `test_pdf_regression.py` script
- Add English/mixed/table-heavy test scenarios
- Implement PDF-level checks (file size, text extraction, table structure)

These remain as future work. See "Remaining work" section below.

## What this tests

- Block structure integrity (heading/list counts match source)
- Chinese punctuation fidelity (no ASCII degradation)
- No cross-paragraph merging (headings don't absorb body text)
- CJK spacing integrity (no CJK+space+CJK within lines)

Uses two real test reports from `evals/cases/` (5,000+ CJK chars each).

## Changes

- `.github/workflows/ci.yml`: add `python3 scripts/test_cjk_pdf_pipeline.py` to smoke job (requires `markdown` module)
- `scripts/test_cjk_pdf_pipeline.py`: fix H4 heading in `test_full_pipeline_block_integrity` (`## H4` → `#### H4`)
- `ROADMAP.md`: mark CJK HTML pipeline CI gate as partial, add remaining work items

## Remaining work (toward #126)

- [ ] PDF-level rendering tests (requires playwright, would go in smoke job)
- [ ] English technical report test scenario
- [ ] Mixed-language report test scenario
- [ ] Table-heavy report test scenario
- [ ] Unified `test_pdf_regression.py` entry point
- [ ] PDF file size validation
- [ ] Text extraction completeness check

toward #126
