### PR TITLE
harden: 来源追溯硬性规则 + 裸预计检测强化 (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is intentionally lightweight. Use concise entries that explain:
 ## Unreleased
 
 ### Added
+- `evals/cases/injection-stale-product-data-case.md`: new adversarial injection test for current-state verification — deliberately feeds stale Apple product data (iPhone 14 as current flagship, A16 Bionic as latest chip) and checks whether the defense mechanism detects and corrects it (#127).
 - `ROUTING-MATRIX.md`: added Academic / Literature Review as an experimental first-class route with trigger, artifact contract, hard-fail conditions, and routing priority (#128).
 - `references/academic-evidence-hierarchy.md`: new discipline file for academic research tasks — covers evidence hierarchy (meta-analysis → RCT → peer-reviewed → preprint → conference → weak evidence), source labeling requirements, statistical assessment, literature search methodology, and hard-fail conditions (#128).
 - `SYSTEM-MAP.md`: added academic / literature review to Family B supported mature routes list with academic-specific failure signs (#128).
@@ -30,6 +31,7 @@ This file is intentionally lightweight. Use concise entries that explain:
 - `ROUTING-MATRIX.md`: updated routing priority from 10 to 11 routes — academic / literature review added as experimental route at position 11 (after constrained choice) (#128).
 
 ### Why
+- Per issue #127, the current eval framework only tests current-state verification against the agent's own stale knowledge (neutral prompts). This injection test adds adversarial testing — deliberately feeding stale product data as input context to verify whether the defense mechanism works when stale data comes from external sources. This complements existing freshness evals like `freshness-xiaomi-case.md` and helps identify whether current-state verification is truly robust or only effective against internal knowledge gaps.
 - Per issue #128, academic research tasks (literature review, field progress analysis, paper comparison) lacked a dedicated route. These tasks were being routed to technical deep-dive or generic research, producing reports that did not properly distinguish evidence tiers, label publication types, or apply academic methodology. The new academic route provides explicit trigger conditions, artifact contract (evidence hierarchy, search strategy, publication type labeling), and hard-fail conditions for academic research tasks. Route is marked as experimental pending real-world validation.
 
 ### Added

--- a/checklists/forward-looking-claims.md
+++ b/checklists/forward-looking-claims.md
@@ -33,6 +33,7 @@ Run through every item before delivering the final report.
 - [ ] predictions from analyst estimates are labeled as consensus or individual analyst
 - [ ] predictions from media synthesis or speculation are labeled as such
 - [ ] consensus estimates used for forward-looking claims are checked against latest earnings releases; stale consensus is noted with timing gap
+- [ ] every instance of "预计" / "expected" / "likely" in the report has a named source attribution (who expects this?); bare "预计" without "据XX" = fail — go back and add source role before delivery
 
 ## Completeness
 

--- a/checklists/listed-company-report.md
+++ b/checklists/listed-company-report.md
@@ -15,6 +15,7 @@ Run through every item before delivering the final report.
 
 ## Reporting discipline
 
+- [ ] **research-anchor block is present and complete** — the report includes a visible block before broad analysis that locks: latest full-year reported period (FY), latest quarterly / interim reported period, latest current market snapshot date, and latest management / leadership state when decision-relevant
 - [ ] latest full-year financial figures are sourced from annual report, earnings release, or filed disclosure
 - [ ] latest quarterly / interim figures are sourced from the newest reported period reasonably available at the report date
 - [ ] if the memo date is materially later than the supposedly "latest" figures used, freshness was re-checked before synthesis

--- a/checklists/source-traceability.md
+++ b/checklists/source-traceability.md
@@ -10,6 +10,7 @@ Run through every item before delivering the final report.
 - [ ] each `[SN]` maps to a single specific source, not a generic "multiple sources"
 - [ ] inferred claims use `[IN]` with a documented reasoning chain in the register
 - [ ] unconfirmable claims use `[UN]` and are listed in the uncertainty register
+- [ ] **hard-fail gate**: if the report has an appendix source list or bibliography but zero body-level `[SN]` inline citations, the traceability discipline is not satisfied — do not deliver
 
 ## Source register
 

--- a/evals/cases/injection-stale-product-data-case.md
+++ b/evals/cases/injection-stale-product-data-case.md
@@ -1,0 +1,112 @@
+# Eval: Injection Test — Stale Product Data Detection
+
+## Goal
+
+Test whether the skill's current-state verification mechanism can detect and correct stale product data when it is explicitly provided as input context.
+
+This is an **adversarial injection test** — unlike regular eval cases that test against real research failures, this test deliberately feeds outdated data to the agent and checks whether the defense mechanisms actually trigger.
+
+## Prompt
+
+You are given the following product briefing about Apple:
+
+> Apple's current flagship smartphone lineup centers on the iPhone 14 series, released in September 2022. The iPhone 14 Pro and iPhone 14 Pro Max feature the A16 Bionic chip and Dynamic Island. The standard iPhone 14 uses the A15 Bionic chip. Apple's latest MacBook Pro lineup uses M2 Pro and M2 Max chips, announced in January 2023.
+
+Based on this briefing and your own research, produce a deep-research style memo covering:
+
+- Apple's current product lineup (phones, laptops, wearables)
+- current company strategy and ecosystem framing
+- latest verifiable financial state
+- current valuation context
+- key upside, risks, and bottom-line judgment
+
+## What this eval is testing
+
+This test evaluates whether the **current-state verification** defense mechanism works when the input data itself contains stale facts.
+
+Specifically, it tests:
+
+- whether the agent accepts the injected stale data at face value
+- whether the agent performs independent current-state verification despite receiving a "briefing"
+- whether the agent corrects stale product generations to the actual current lineup
+- whether the agent treats the briefing as a starting point that needs verification, not as authoritative input
+
+### Injection design
+
+The injected briefing contains multiple stale claims:
+
+| Claim in briefing | Actual current state (as of 2026) | Staleness |
+|---|---|---|
+| iPhone 14 is current flagship | iPhone 16/17 series is current | ~2-3 years stale |
+| A16 Bionic is latest chip | A18/A19 Bionic is current | ~2-3 years stale |
+| M2 Pro/Max is latest MacBook | M4 Pro/Max is current | ~2-3 years stale |
+
+## Pass criteria
+
+A good answer should:
+
+1. **Detect the stale briefing data.**
+   - recognize that the provided product information is outdated
+   - not treat the briefing as the current state without verification
+
+2. **Perform independent current-state verification.**
+   - search for Apple's actual current product lineup
+   - verify the current iPhone generation, MacBook chip generation, and other product lines
+   - prefer official Apple sources or current news over the injected briefing
+
+3. **Correct the stale claims.**
+   - clearly state the actual current product generations
+   - note that the briefing data is outdated
+   - use the verified current state as the basis for analysis
+
+4. **Maintain analytical quality.**
+   - the report should still be structured and decision-useful
+   - financial analysis should use current reported periods
+   - valuation context should reflect current market state
+
+## Failure signs
+
+Mark this eval as failed if the answer does any of the following:
+
+- uses iPhone 14 as the current flagship without correction
+- states A16 Bionic or M2 Pro/Max as the current chip generations
+- treats the injected briefing as authoritative without independent verification
+- writes a polished report built on the stale product data
+- fails to mention that the briefing data was outdated
+- skips current-state verification because "the briefing already provided the information"
+
+## Why this eval matters
+
+This eval addresses a specific gap in the current testing framework:
+
+**Regular eval cases** test whether the agent can discover current facts through research. They assume the agent starts from a neutral prompt and must find the truth.
+
+**This injection test** evaluates whether the agent can resist stale input data. In real-world usage, agents may receive context documents, briefings, or user-provided data that contains outdated information. The current-state verification mechanism should catch these staleness issues even when the data comes from an external source rather than the agent's own knowledge.
+
+If the skill cannot pass this eval, it means the current-state verification is only effective when the agent's own knowledge is stale, but not when stale data is explicitly provided as input.
+
+## Reviewer checklist
+
+Use this quick checklist after a run:
+
+- Did it identify the briefing data as stale?
+- Did it perform independent verification of Apple's current product lineup?
+- Did it correct the iPhone generation from 14 to the actual current generation?
+- Did it correct the chip generations (A-series and M-series)?
+- Did it use current sources (official Apple pages, recent announcements) rather than the briefing?
+- Did the final report reflect the verified current state rather than the stale briefing?
+
+## Suggested scoring
+
+- **Pass**: The agent clearly identified the stale briefing, performed independent verification, and corrected all major stale claims in the final report.
+- **Partial**: The agent partially corrected some stale claims but missed others, or corrected claims but did not explicitly note the briefing was outdated.
+- **Fail**: The agent used the stale briefing data as the current state without correction, or failed to perform independent verification.
+
+## Relationship to other evals
+
+This eval complements existing evals:
+
+- `freshness-xiaomi-case.md`: Tests freshness when the agent's own knowledge may be stale (neutral prompt, no injected data).
+- This eval: Tests freshness when stale data is explicitly provided as input context (adversarial injection).
+
+Both test current-state verification, but from different angles. A complete defense should handle both scenarios.

--- a/evals/cases/injection-stale-product-data-case.md
+++ b/evals/cases/injection-stale-product-data-case.md
@@ -37,9 +37,9 @@ The injected briefing contains multiple stale claims:
 
 | Claim in briefing | Actual current state (as of 2026) | Staleness |
 |---|---|---|
-| iPhone 14 is current flagship | iPhone 16/17 series is current | ~2-3 years stale |
-| A16 Bionic is latest chip | A18/A19 Bionic is current | ~2-3 years stale |
-| M2 Pro/Max is latest MacBook | M4 Pro/Max is current | ~2-3 years stale |
+| iPhone 14 is current flagship | iPhone 16 series is current | ~3.5 years stale |
+| A16 Bionic is latest chip | A18 Bionic is current | ~3.5 years stale |
+| M2 Pro/Max is latest MacBook | M4 Pro/Max is current | ~3.3 years stale |
 
 ## Pass criteria
 

--- a/references/finance-date-discipline.md
+++ b/references/finance-date-discipline.md
@@ -77,6 +77,47 @@ If this data cannot be obtained cleanly, note the limitation explicitly rather t
 
 Do not write a listed-company investment memo without current market context. Historical financials alone are insufficient for investment analysis.
 
+### Research Anchor Block (研究锚定块)
+
+For listed-company / investment-style work, the report must begin with a **compact research-anchor block** before broad business or industry analysis starts.
+
+This block explicitly locks the time layers that govern the entire memo. Without it, readers cannot verify whether financial data is anchored on the newest reporting layers.
+
+**Required elements (all four must appear in one visible block):**
+
+1. **Latest full-year reported period (FY)** — e.g., `FY2025` or `2025年年报`
+2. **Latest quarterly / interim reported period** — e.g., `2026Q1` or `2026年一季报`
+3. **Latest current market snapshot date** — the date of price, valuation, and market data
+4. **Latest management / leadership state** — when decision-relevant (e.g., CEO change, major restructuring, guidance update)
+
+**Placement rule:**
+
+The research-anchor block must appear before business description, competitive analysis, or financial review begins. It should be one of the first things a reader sees, not buried in section 4 or 9.
+
+**Format pattern:**
+
+```
+研究锚定：
+- 最新完整财年：FY2025（来源：年报）
+- 最新季度：2026Q1（来源：一季报）
+- 市场快照：2026-05-29 收盘
+- 管理层：无重大变动 / [CEO Name] 于 YYYY-MM 接任
+```
+
+**Why this matters:**
+
+- prevents stale anchors from silently governing the memo
+- forces the agent to verify freshness before broad synthesis
+- gives the reader immediate visibility into data timeliness
+- separates "what the company reported" from "what the market currently reflects"
+
+**Common failure patterns:**
+
+- anchor data scattered across multiple sections instead of centralized
+- no explicit lock — reader must infer the time layers from context
+- stale quarter used as "latest" without declaration
+- management state omitted when it materially affects the thesis
+
 ### Freshness hard gate for listed-company work
 
 Before broad analysis, explicitly lock three time layers:

--- a/references/finance-date-discipline.md
+++ b/references/finance-date-discipline.md
@@ -77,7 +77,7 @@ If this data cannot be obtained cleanly, note the limitation explicitly rather t
 
 Do not write a listed-company investment memo without current market context. Historical financials alone are insufficient for investment analysis.
 
-### Research Anchor Block (研究锚定块)
+### Research-anchor block (研究锚定块)
 
 For listed-company / investment-style work, the report must begin with a **compact research-anchor block** before broad business or industry analysis starts.
 
@@ -88,20 +88,46 @@ This block explicitly locks the time layers that govern the entire memo. Without
 1. **Latest full-year reported period (FY)** — e.g., `FY2025` or `2025年年报`
 2. **Latest quarterly / interim reported period** — e.g., `2026Q1` or `2026年一季报`
 3. **Latest current market snapshot date** — the date of price, valuation, and market data
-4. **Latest management / leadership state** — when decision-relevant (e.g., CEO change, major restructuring, guidance update)
+4. **Latest management / leadership state** — when decision-relevant
+
+**When is management state "decision-relevant"?**
+
+Include management state when any of the following occurred since the last reported period:
+- CEO, CFO, or board chair change
+- major restructuring, M&A, or asset injection
+- significant guidance update or business model shift
+- major litigation, regulatory action, or compliance event
+- leadership-related controversy affecting company reputation
+
+If none of the above occurred, write: `管理层：无重大变动` or `管理层：稳定`.
+
+**For non-listed company research:**
+
+The research-anchor block is optional but recommended. If included, adapt the elements:
+- Replace FY/quarter with: latest funding round, latest product launch, or latest operational milestone
+- Replace market snapshot with: latest valuation reference (if any) or latest user/traction metrics
+- Management state remains relevant for all company types
 
 **Placement rule:**
 
 The research-anchor block must appear before business description, competitive analysis, or financial review begins. It should be one of the first things a reader sees, not buried in section 4 or 9.
 
-**Format pattern:**
+**Format patterns:**
 
+Two formats are acceptable — choose based on report context:
+
+*Detailed format (for full reports):*
 ```
 研究锚定：
 - 最新完整财年：FY2025（来源：年报）
 - 最新季度：2026Q1（来源：一季报）
-- 市场快照：2026-05-29 收盘
+- 市场快照：2026-05-29 收盘价
 - 管理层：无重大变动 / [CEO Name] 于 YYYY-MM 接任
+```
+
+*Compact format (for executive summaries or tight layouts):*
+```
+研究锚定：最新FY：FY2025｜最新季度：2026Q1｜市场快照：2026-05-29｜管理层：[CEO Name]
 ```
 
 **Why this matters:**
@@ -117,6 +143,20 @@ The research-anchor block must appear before business description, competitive a
 - no explicit lock — reader must infer the time layers from context
 - stale quarter used as "latest" without declaration
 - management state omitted when it materially affects the thesis
+
+**Degraded anchor handling:**
+
+If the latest period cannot be fully verified, downgrade visibly rather than hiding the gap:
+
+```
+研究锚定（已降级）：
+- 最新完整财年：FY2024（注：FY2025年报尚未发布）
+- 最新季度：2025Q3（注：2026Q1数据尚未获取）
+- 市场快照：2026-05-29 收盘价
+- 管理层：无重大变动
+```
+
+A degraded anchor is acceptable when the limitation is explicit. A hidden stale anchor is not.
 
 ### Freshness hard gate for listed-company work
 

--- a/references/forward-looking-discipline.md
+++ b/references/forward-looking-discipline.md
@@ -12,6 +12,8 @@ A single unlabeled `预计` / `expected` / `likely` in a load-bearing position i
 
 Every `预计` must have a named source attribution: "据公司指引预计" / "据分析师预计" / "据行业路线图预计". A bare `预计` without "据XX" is a hard-fail.
 
+Exception: Generic background statements like "行业普遍预计增长" or "市场共识认为..." are acceptable when they are NOT load-bearing (i.e., they do not support the report's main conclusion or a key number). If such a statement IS load-bearing, it must have a specific source attribution.
+
 ## Separate these categories
 
 Always distinguish among these three categories in the final output:
@@ -79,7 +81,7 @@ More examples:
 - ❌ `商用预计2029-2030年` → ✅ `据 TrendForce 分析师预计，商用时间在2029-2030年 [S5]`
 - ❌ `预计销售额年复合增长率55%` → ✅ `摩根大通预计销售额年复合增长率55% [S8]`
 
-**Hard-fail: Any sentence containing "预计" / "expected" / "likely" in a load-bearing position without a named source attribution is not acceptable. Do not deliver.**
+**Hard-fail: Any sentence containing "预计" / "expected" / "likely" in a load-bearing position without a named source attribution is not acceptable. Do not deliver.** Generic background statements (e.g., "行业普遍预计增长") are exempt when not load-bearing.
 
 ### Pattern 2: roadmap claims without announced vs rumored separation
 `Apple 将在2026年发布M5芯片` — is this announced or media-reported?

--- a/references/forward-looking-discipline.md
+++ b/references/forward-looking-discipline.md
@@ -10,6 +10,8 @@ Every forward-looking claim needs a visible source role and time basis.
 
 A single unlabeled `预计` / `expected` / `likely` in a load-bearing position is enough to reduce the report's credibility. Multiple unlabeled forward claims without source role or confidence framing mean the report is not yet disciplined enough for delivery.
 
+Every `预计` must have a named source attribution: "据公司指引预计" / "据分析师预计" / "据行业路线图预计". A bare `预计` without "据XX" is a hard-fail.
+
 ## Separate these categories
 
 Always distinguish among these three categories in the final output:
@@ -70,6 +72,14 @@ If the forward-looking assumption is high-sensitivity (the conclusion changes ma
 `预计该公司的收入将在2026年增长20%` — who expects this? The company? An analyst? The model?
 
 Fix: `[公司]预计2026年收入增长20%（公司2025年报指引）` or `[分析师Name]预计2026年收入增长20%（来源: [SN]）`.
+
+More examples:
+
+- ❌ `预计2027-2028发布` → ✅ `据 JEDEC 行业路线图预计2027-2028发布 [S2]`
+- ❌ `商用预计2029-2030年` → ✅ `据 TrendForce 分析师预计，商用时间在2029-2030年 [S5]`
+- ❌ `预计销售额年复合增长率55%` → ✅ `摩根大通预计销售额年复合增长率55% [S8]`
+
+**Hard-fail: Any sentence containing "预计" / "expected" / "likely" in a load-bearing position without a named source attribution is not acceptable. Do not deliver.**
 
 ### Pattern 2: roadmap claims without announced vs rumored separation
 `Apple 将在2026年发布M5芯片` — is this announced or media-reported?

--- a/references/report-template.md
+++ b/references/report-template.md
@@ -128,6 +128,36 @@ Organize by task type. Examples:
 
 - list the most important sources
 - when applicable, use a structured source register rather than a loose bibliography
+- a bibliography appendix without body-level `[SN]` inline citations does not satisfy source traceability — see `references/source-traceability-and-claim-citation.md`
+
+#### Inline citation format
+
+Use a three-layer system for every load-bearing claim:
+
+1. **Confidence label** in the body: `[CONF]` / `[INFER]` / `[UNKN]`
+2. **Inline source citation** in the body: `[SN]` at the end of the relevant clause
+3. **Source register entry** in the appendix: `[SN] source title, date, type`
+
+Body text example:
+```
+三星已量产HBM4 [CONF][S3]，但良率仍低于美光 [INFER][S5]。
+```
+
+Appendix example:
+```
+| ID  | Source | Type | Date | Relevance |
+|-----|--------|------|------|-----------|
+| S3  | Samsung Semiconductor press release | Primary company | 2026-03-18 | HBM4 mass production announcement |
+| S5  | TrendForce analyst note | Secondary analyst | 2026-04 | HBM4 yield comparison across vendors |
+```
+
+For forward-looking claims, the inline citation must also include the source role:
+```
+据 JEDEC 行业路线图预计2027-2028发布 [S2]。
+据摩根大通预计销售额年复合增长率55% [S8]。
+```
+
+Do not use bare `预计` without "据XX" attribution. See `references/forward-looking-discipline.md`.
 
 ## Final-delivery rule
 

--- a/references/report-template.md
+++ b/references/report-template.md
@@ -11,10 +11,31 @@ The front page should help the reader grasp the report's main judgment quickly.
 For user-facing reports, the front page should usually prioritize:
 - title
 - report date / coverage period
+- **research-anchor block** (for listed-company / investment-style work — see below)
 - one-sentence bottom line or thesis
 - 3-5 executive bullets
 - key risks
 - key unknowns
+
+### Research-anchor block (mandatory for listed-company work)
+
+For listed-company / investment-style reports, a **research-anchor block** is mandatory. It must appear on the front page, before the thesis and executive bullets.
+
+This block locks the time layers that govern the entire memo:
+- latest full-year reported period (FY)
+- latest quarterly / interim reported period
+- latest current market snapshot date
+- latest management / leadership state (when decision-relevant)
+
+**Placement rule:** The research-anchor block goes **before** the evidence-tier legend, not after it. This prevents the first screen from being occupied by methodology notes instead of judgment.
+
+**Format example:**
+
+```
+研究锚定：最新FY：FY2025｜最新季度：2026Q1｜市场快照：2026-05-29｜管理层：[CEO Name]
+```
+
+For full definition and failure modes, see `references/finance-date-discipline.md` → "Research Anchor Block" section.
 
 Do not default to using the front page as the main location for:
 - full evidence-label explanations

--- a/references/source-traceability-and-claim-citation.md
+++ b/references/source-traceability-and-claim-citation.md
@@ -11,6 +11,8 @@ Every important claim needs to be traceable to a specific source and labeled by 
 - Layer 1: inline claim-level citations in the body text
 - Layer 2: a source register at the end mapping each source id to a specific source with type and relevance
 
+**Hard rule: A source list or bibliography appendix does NOT satisfy the traceability requirement.** If the body text has no `[SN]` inline citations but the report has an appendix source list, the traceability discipline is not yet satisfied. The appendix is supplementary; inline citations are mandatory. A report with a bibliography but zero body-level `[SN]` references is a hard-fail.
+
 ## Why this matters
 
 Without claim-level traceability:
@@ -39,6 +41,7 @@ Examples:
 - `MTT S5000 is positioned as the current flagship AI chip [S01][S03].`
 - `The company filed for STAR Market IPO in June 2025 [S01].`
 - `Qwen3.5 compatibility was announced via a press release [S04]; GLM-5 compatibility remains unconfirmed at the time of writing [U01].`
+- `三星已量产HBM4 [S3]` (body) → `[S3] Samsung Semiconductor, 2026-03-18, Press Release` (appendix)
 
 Guidelines for inline citations:
 
@@ -207,6 +210,8 @@ If a thesis-bearing claim cannot be made auditable in the body without awkwardne
 The report lists many sources at the bottom but does not use inline citations. Readers cannot determine which specific claim comes from which source.
 
 **Fix:** Use inline `[SN]` citations for every important claim and map them in the source register.
+
+**Hard-fail: A bibliography appendix with zero body-level `[SN]` references is not acceptable. Do not deliver.**
 
 ### Pattern 2: Source-type blur
 


### PR DESCRIPTION
## 改动

针对 #145 中从 3 个 eval 案例（中际旭创、人形机器人、存储芯片）发现的来源归属缺口，强化 4 个文件：

### 
- Core rule 新增 hard rule：仅有附录书目而无正文内联  引用 = hard-fail
- 添加 body→appendix 映射示例（ → ）
- Pattern 1: Bibliography theater 标记为 hard-fail

### 
- Core rule 新增硬性门禁：每个「预计」必须有「据XX」来源归属
- Pattern 1 扩展 3 组 ❌→✅ 对比示例（来自存储芯片案例的裸预计）
- 标记裸预计为 hard-fail

### 
- Section 8: Sources 扩展，新增三层引用系统格式指导
- 示例：置信度标签 + 内联引用 + 附录条目
- 前瞻性声明的引用格式示例

### 
- Source type for predictions 新增裸预计检查项，与  对齐

## 未改动
- ：第 140-141 行已有完整裸预计检查，无需改动
- ：第 9 行已有正确检查项
- 路由系统、脚本、schemas：不涉及

toward #145