### PR TITLE
feat: 估值推断依据文档化 + 多空逻辑结构对称性 (#146)

### DIFF
--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -158,11 +158,13 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] if a valuation range or target price is labeled as inference, the report states the multiple range, comparable selection logic, and key assumptions
 - [ ] metric selection justification is present when the chosen metric is not the obvious default for the company type
 - [ ] these are non-blocker checks: failures indicate areas for improvement but do not block delivery
+- [ ] this check complements the metric-scope audit above: metric-scope checks focus on data quality and precision, while this check focuses on methodology transparency
 
 ## Bull/bear structural symmetry (non-blocker)
 
 - [ ] when both bull and bear case sections exist, they use the same structural format (same column breakdown, same evidence-label discipline)
 - [ ] this is a non-blocker check: asymmetric structure is a quality signal, not a hard fail
+- [ ] this check complements the "Risks and counter-evidence" section of the report template: the template requires counter-evidence content, this check requires structural symmetry
 
 ## Unknown-to-conclusion linkage
 

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -153,6 +153,17 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] if metric scope is incomplete or ambiguous, the claim is rewritten or downgraded with visible caveats
 - [ ] valuation precision matches data quality and company characteristics: loss-making companies do not get precise PE valuations, cyclical companies do not get valuations based on peak/trough earnings, and forward metrics are labeled as estimate-based
 
+## Valuation inference transparency (non-blocker)
+
+- [ ] if a valuation range or target price is labeled as inference, the report states the multiple range, comparable selection logic, and key assumptions
+- [ ] metric selection justification is present when the chosen metric is not the obvious default for the company type
+- [ ] these are non-blocker checks: failures indicate areas for improvement but do not block delivery
+
+## Bull/bear structural symmetry (non-blocker)
+
+- [ ] when both bull and bear case sections exist, they use the same structural format (same column breakdown, same evidence-label discipline)
+- [ ] this is a non-blocker check: asymmetric structure is a quality signal, not a hard fail
+
 ## Unknown-to-conclusion linkage
 
 - [ ] for each major unknown or unresolved current-state gap, the report explains whether it limits directional judgment, quantitative precision, valuation confidence, ranking confidence, timing confidence, or recommendation strength

--- a/references/report-template.md
+++ b/references/report-template.md
@@ -127,6 +127,8 @@ Rules:
 - both sides apply the same evidence-label discipline ([CONF] / [INFER] / [UNKN])
 - if one side has a table, the other side should have a comparable table
 - do not let the bear case become a bullet list of generic risks while the bull case is a structured analysis
+- if one side has significantly less evidence than the other, still use the same structure but mark empty cells as "无相关证据" or "暂无数据" rather than omitting the structure
+- asymmetric evidence strength is acceptable; asymmetric structure is not
 
 This symmetry matters because asymmetric structure signals to the reader that one side was analyzed more rigorously than the other, even if the substance is equally strong.
 

--- a/references/report-template.md
+++ b/references/report-template.md
@@ -112,6 +112,24 @@ Organize by task type. Examples:
 - include the strongest reasons the main conclusion could be wrong
 - include limits, contradictions, or competing explanations
 
+#### Bull/bear structural symmetry
+
+When the report includes both bull (看多) and bear (看空) case sections, they must use the same structural format. Do not give one side a rigorous epistemic breakdown while the other side is loose prose.
+
+Recommended three-column structure for both sides:
+
+| 事实依据 | 推断依据 | 不确定性/限制条件 |
+|----------|----------|-------------------|
+| confirmed facts supporting this case | inferences or assumptions | what could invalidate this case |
+
+Rules:
+- both bull and bear sections use the same column breakdown
+- both sides apply the same evidence-label discipline ([CONF] / [INFER] / [UNKN])
+- if one side has a table, the other side should have a comparable table
+- do not let the bear case become a bullet list of generic risks while the bull case is a structured analysis
+
+This symmetry matters because asymmetric structure signals to the reader that one side was analyzed more rigorously than the other, even if the substance is equally strong.
+
 ### 6. Uncertainty and missing evidence
 
 - if confidence depends on assumptions or modeled numbers, make that dependency visible instead of letting the numbers read like confirmed facts

--- a/references/valuation-methodology.md
+++ b/references/valuation-methodology.md
@@ -155,8 +155,11 @@ When the report uses one metric as the primary valuation anchor, briefly state w
 - the company has characteristics that could support multiple metrics (e.g., positive earnings AND significant assets)
 - the chosen metric is not the industry default
 - the company is in a transitional state (post-restructuring, cyclical trough, high-growth phase)
+- the company has significant related-party transaction exposure or concentrated ownership that could distort earnings quality
 
-Example pattern: "选用PE而非EV/EBITDA作为主要估值锚，因为[公司]资本结构简单、折旧政策稳定，PE更能反映股东视角的回报预期"
+Example patterns:
+- "选用PE而非EV/EBITDA作为主要估值锚，因为[公司]资本结构简单、折旧政策稳定，PE更能反映股东视角的回报预期"
+- "选用EV/EBITDA而非PE作为主要估值锚，因为[公司]关联方交易占比高，PE可能受非经常性损益影响较大，EV/EBITDA更能反映经营层面的真实估值水平"
 
 For loss-making or cyclical companies, see the precision downgrade rules above. If no metric applies cleanly, say so.
 

--- a/references/valuation-methodology.md
+++ b/references/valuation-methodology.md
@@ -135,6 +135,38 @@ When target price cannot be supported, prefer:
 - valuation range with explicit assumptions
 - "insufficient data for a target price" as a valid conclusion
 
+## Valuation inference documentation
+
+When presenting a valuation range, target price, or fair value estimate labeled as inference, the reader must be able to reconstruct the reasoning chain. Do not present a valuation conclusion without visible methodology.
+
+### Required elements for valuation inference
+
+Every valuation inference must include:
+
+1. **Multiple assumption range** — state the PE (or other metric) range used, not just the final number. Example: "基于2026年预期PE 25-30x" rather than "目标价600元"
+2. **Comparable selection logic** — if comparables are used, state why these companies were chosen and what they share with the target. Do not assume the reader knows why Company X is a valid comp
+3. **Scenario parameters** — if the valuation uses optimistic/base/pessimistic scenarios, state the key variable that differs across scenarios (e.g., margin assumption, growth rate, market share)
+4. **Limitation disclosure** — state what the valuation does not capture or where the methodology is weakest
+
+### Metric selection justification
+
+When the report uses one metric as the primary valuation anchor, briefly state why. This is especially important when:
+
+- the company has characteristics that could support multiple metrics (e.g., positive earnings AND significant assets)
+- the chosen metric is not the industry default
+- the company is in a transitional state (post-restructuring, cyclical trough, high-growth phase)
+
+Example pattern: "选用PE而非EV/EBITDA作为主要估值锚，因为[公司]资本结构简单、折旧政策稳定，PE更能反映股东视角的回报预期"
+
+For loss-making or cyclical companies, see the precision downgrade rules above. If no metric applies cleanly, say so.
+
+### Common failure patterns
+
+- Presenting a target price without stating the multiple or methodology
+- Using "保守区间" or "合理估值" without showing the assumptions behind the range
+- Choosing comparables without explaining the selection logic
+- Stating a PE range without explaining why that range is appropriate for this company's growth/risk profile
+
 ## Common failure patterns
 
 ### Using TTM PE for cyclical stocks


### PR DESCRIPTION
针对 #146 中从 eval 案例发现的方法论缺口，强化 3 个文件：

1. valuation-methodology.md: 新增估值推断依据文档化章节
2. report-template.md: 添加多空逻辑结构对称性要求
3. final-audit.md: 添加非阻断性检查项

基于 innolight-listed-company-execution-case.md 第84-86行的修复建议。

toward #146