### PR TITLE
feat: Market Outlook 路由纪律强化 — 情景分析 + 利益相关方 + 边界规则 (#147)

### DIFF
--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -199,7 +199,7 @@ Fail if the report:
 Use when the task is mainly about:
 
 - how a market will evolve
-- next 6–12 month outlook
+- next 6–24 month outlook
 - adoption trajectory
 - industry evolution
 - scenario memo
@@ -237,7 +237,7 @@ The final report should visibly show:
 - key drivers of change
 - key blockers or friction points
 - base case
-- structured alternative scenarios (optimistic / base / pessimistic with quantitative ranges and trigger conditions)
+- structured alternative scenarios (at minimum base + one alternative; three scenarios — optimistic / base / pessimistic — when uncertainty is material, which is the default for market-outlook tasks)
 - stakeholder implications covering at least 3 distinct stakeholder types
 - monitoring signals
 - what would change the conclusion
@@ -247,7 +247,7 @@ Fail if the report:
 
 - remains an industry overview instead of an outlook memo
 - mixes observed facts with scenario assumptions
-- gives forecasts without visible scenario structure
+- gives forecasts without visible scenario structure, or rests on a single base case with no alternative scenarios
 - hides stakeholder implications inside generic narrative
 - covers only investor stakeholder implications while ignoring technology developers, policymakers, enterprise buyers, or end users
 - uses Market Outlook for a task whose core output is ranking, prediction, or selection among defined options (wrong route — use Constrained Choice / Shortlist instead)

--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -206,7 +206,7 @@ Use when the task is mainly about:
 
 **Choose this route when:** the task is to explain direction, evolution, trajectory, or structural change rather than pick a winner now.
 
-**Do not use this route when:** the task has a real recommendation, shortlist, or selection burden.
+**Do not use this route when:** the task has a real recommendation, shortlist, or selection burden. Specifically: ranking entities or options, predicting competition outcomes among defined participants, or choosing a provider/supplier. See `references/market-outlook-and-scenario-discipline.md` "When not to use this route" for boundary examples.
 
 **Often confused with:** provider selection or constrained choice.
 
@@ -225,6 +225,7 @@ Use when the task is mainly about:
 - sensitivity analysis when forecasts, market size estimates, or adoption projections materially affect the conclusion
 
 ### Audit
+- `checklists/market-outlook-audit.md`
 - `checklists/forward-looking-claims.md`
 - `checklists/source-traceability.md`
 - `checklists/final-audit.md`
@@ -236,8 +237,8 @@ The final report should visibly show:
 - key drivers of change
 - key blockers or friction points
 - base case
-- alternative scenarios
-- stakeholder implications
+- structured alternative scenarios (optimistic / base / pessimistic with quantitative ranges and trigger conditions)
+- stakeholder implications covering at least 3 distinct stakeholder types
 - monitoring signals
 - what would change the conclusion
 
@@ -248,6 +249,8 @@ Fail if the report:
 - mixes observed facts with scenario assumptions
 - gives forecasts without visible scenario structure
 - hides stakeholder implications inside generic narrative
+- covers only investor stakeholder implications while ignoring technology developers, policymakers, enterprise buyers, or end users
+- uses Market Outlook for a task whose core output is ranking, prediction, or selection among defined options (wrong route — use Constrained Choice / Shortlist instead)
 
 ---
 

--- a/SYSTEM-MAP.md
+++ b/SYSTEM-MAP.md
@@ -67,6 +67,7 @@ Defines the shared research process that applies before any route-specific speci
 - unnecessary browsing loops
 - weak counter-evidence search
 - parallelism used without enough structure
+- structural requirement (e.g. evidence grading boilerplate) displaces judgment from first-screen position
 
 ### First place to change
 - `SKILL.md` if the shared workflow itself is weak
@@ -88,6 +89,7 @@ Makes mature task families explicit so the right discipline set and delivery con
 - `checklists/route-activation-audit.md`
 - `checklists/startup-company-report.md` (for private company route)
 - `checklists/regulatory-analysis-audit.md` (for regulatory route)
+- `checklists/market-outlook-audit.md` (for market outlook route)
 
 ### Supported mature routes
 - provider / vendor selection
@@ -113,6 +115,10 @@ Makes mature task families explicit so the right discipline set and delivery con
 - a regulatory analysis confuses regulatory text with media interpretation
 - an academic review treats preprints as peer-reviewed without labeling
 - an academic review cherry-picks papers to support pre-determined conclusions
+- a secondary route is attached but its hard-fail conditions are not checked before delivery
+- a route is actively declared but violates its own "Do not use" / "Often confused with" clauses for the task type
+- a market-outlook report has only one scenario with no structured alternative paths
+- a market-outlook report covers only investor stakeholder implications
 
 ### First place to change
 - `ROUTING-MATRIX.md` when route selection or attached discipline mapping is wrong
@@ -148,12 +154,18 @@ Protects fast-moving research from stale facts, frozen time layers, and blurred 
 - `evals/cases/intel-current-state-freshness-case.md`
 - `evals/cases/cnooc-judgment-shape-improved-but-freshness-still-leaked-case.md`
 - `evals/cases/reporting-period-and-ttm-confusion-case.md`
+- `evals/cases/amat-listed-company-anchor-and-label-execution-case.md`
+- `evals/cases/evergrande-property-listed-company-execution-case.md`
+- `evals/cases/humanoid-robot-market-outlook-dual-route-case.md`
+- `evals/cases/storage-chip-listed-company-deep-dive-pass-case.md`
 
 ### Typical failure signs
 - stale product or model generation presented as current
 - listing state frozen at an earlier stage
 - present-tense ranking without a time basis
 - reported financials, market snapshot, and estimates blended together
+- research anchor block missing entirely (no explicit time-layer lock before broad analysis)
+- market snapshot absent (share price, multiples, snapshot date) despite route hard requirement
 
 ### First place to change
 - routing layer if current-state-sensitive tasks are not activating the right gates
@@ -183,6 +195,9 @@ Makes load-bearing claims auditable, separates primary evidence from inference-h
 - `evals/cases/apple-product-roadmap-and-investment-case.md`
 - `evals/cases/minimax-company-report-case.md`
 - `evals/cases/cambricon-evidence-weighting-and-traceability-case.md`
+- `evals/cases/amat-listed-company-anchor-and-label-execution-case.md`
+- `evals/cases/innolight-listed-company-execution-case.md`
+- `evals/cases/storage-chip-listed-company-deep-dive-pass-case.md`
 - `evals/comparative-distillation/byd-gpt-vs-minimax-comparative-distillation.md`
 
 ### Typical failure signs
@@ -192,6 +207,7 @@ Makes load-bearing claims auditable, separates primary evidence from inference-h
 - mixed-evidence positioning judgments hide which claims are load-bearing
 - conflicting data from different sources is silently resolved without explanation
 - Chinese-language and English-language sources coexist but cross-language conflicts are not handled
+- evidence-label inflation — labels exist but overstate claim certainty (e.g. third-party ranking labeled as "confirmed fact")
 
 ### First place to change
 - references when evidence structure itself is weak
@@ -272,6 +288,7 @@ Controls forecasts, roadmap statements, target dates, and estimate-heavy claims 
 - `evals/cases/byd-report-format-discipline-case.md`
 - `evals/cases/hnb-industry-report-table-design-case.md`
 - `evals/cases/consensus-and-forward-pe-misuse-case.md`
+- `evals/cases/humanoid-robot-market-outlook-dual-route-case.md`
 - `evals/comparative-distillation/byd-gpt-vs-minimax-comparative-distillation.md`
 
 ### Typical failure signs
@@ -279,6 +296,8 @@ Controls forecasts, roadmap statements, target dates, and estimate-heavy claims 
 - roadmap claims without announced vs rumored separation
 - consensus numbers without source or date
 - estimate language without assumption chain
+- missing structured alternative scenarios in market-outlook tasks
+- stakeholder implications limited to a single type (e.g. investors only)
 
 ### First place to change
 - checklists when forecasts leak through at delivery time
@@ -308,6 +327,8 @@ Supports tasks where the output must help choose among options rather than merel
 - `evals/comparative-distillation/sea-market-entry-gpt-vs-minimax-comparative-distillation.md`
 - `evals/comparative-distillation/multi-origin-meetup-city-selection-gpt-vs-minimax-comparative-distillation.md`
 - `evals/cases/cambricon-first-tier-positioning-case.md`
+- `evals/cases/champions-league-constrained-choice-activation-case.md`
+- `evals/cases/world-cup-constrained-choice-wrong-route-case.md`
 - `evals/comparative-distillation/ai-coding-agent-market-outlook-gpt-vs-minimax-comparative-distillation.md`
 - `evals/templates/decision-utility-rubric.md`
 
@@ -318,6 +339,8 @@ Supports tasks where the output must help choose among options rather than merel
 - ranking memo collapses multiple dimensions into prestige language
 - shortlist recommendation appears without shortlist-construction logic
 - selection recommendation without post-decision execution branching when uncertainty is high
+- wrong route declared (Market Outlook used for ranking/recommendation task despite "Do not use" clause)
+- probability precision illusion (precise percentages for inherently uncertain predictions)
 
 ### First place to change
 - `ROUTING-MATRIX.md` when a mature task family is misrouted or under-specified

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -158,11 +158,13 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] if a valuation range or target price is labeled as inference, the report states the multiple range, comparable selection logic, and key assumptions
 - [ ] metric selection justification is present when the chosen metric is not the obvious default for the company type
 - [ ] these are non-blocker checks: failures indicate areas for improvement but do not block delivery
+- [ ] this check complements the metric-scope audit above: metric-scope checks focus on data quality and precision, while this check focuses on methodology transparency
 
 ## Bull/bear structural symmetry (non-blocker)
 
 - [ ] when both bull and bear case sections exist, they use the same structural format (same column breakdown, same evidence-label discipline)
 - [ ] this is a non-blocker check: asymmetric structure is a quality signal, not a hard fail
+- [ ] this check complements the "Risks and counter-evidence" section of the report template: the template requires counter-evidence content, this check requires structural symmetry
 
 ## Unknown-to-conclusion linkage
 

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -123,6 +123,9 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] for market-outlook / industry-evolution tasks, a current market snapshot was verified before forward-looking sections
 - [ ] for market-outlook / industry-evolution tasks, drivers, blockers, scenarios, and stakeholder implications are explicit rather than implied
 - [ ] for market-outlook / industry-evolution tasks, all forward-looking claims have visible source role and time basis; derived, modeled, or load-bearing forecasts also show key assumptions and failure / reversal conditions
+- [ ] for market-outlook / industry-evolution tasks, structured multi-scenario analysis exists (at minimum base case + one alternative) with quantitative ranges and trigger conditions
+- [ ] for market-outlook / industry-evolution tasks, stakeholder implications cover at least 3 distinct stakeholder types, not only investors
+- [ ] for market-outlook / industry-evolution tasks, the task's core output is direction/evolution/trajectory — not ranking, prediction, or selection among defined options
 - [ ] for first-tier / top-tier / multidimensional positioning tasks, scope, metric, timeframe, and dimension-level conclusions are visible before any overall label
 - [ ] for first-tier / top-tier / multidimensional positioning tasks, the report does not collapse geography, current products, roadmap products, ecosystem strength, traction, and capital-markets signaling into one vague prestige tag without an explicit aggregation rule
 - [ ] for technical deep-dive / architecture analysis tasks, the report makes a technical judgment (not just a survey) and the judgment is supported by evidence

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -153,6 +153,17 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] if metric scope is incomplete or ambiguous, the claim is rewritten or downgraded with visible caveats
 - [ ] valuation precision matches data quality and company characteristics: loss-making companies do not get precise PE valuations, cyclical companies do not get valuations based on peak/trough earnings, and forward metrics are labeled as estimate-based
 
+## Valuation inference transparency (non-blocker)
+
+- [ ] if a valuation range or target price is labeled as inference, the report states the multiple range, comparable selection logic, and key assumptions
+- [ ] metric selection justification is present when the chosen metric is not the obvious default for the company type
+- [ ] these are non-blocker checks: failures indicate areas for improvement but do not block delivery
+
+## Bull/bear structural symmetry (non-blocker)
+
+- [ ] when both bull and bear case sections exist, they use the same structural format (same column breakdown, same evidence-label discipline)
+- [ ] this is a non-blocker check: asymmetric structure is a quality signal, not a hard fail
+
 ## Unknown-to-conclusion linkage
 
 - [ ] for each major unknown or unresolved current-state gap, the report explains whether it limits directional judgment, quantitative precision, valuation confidence, ranking confidence, timing confidence, or recommendation strength

--- a/checklists/market-outlook-audit.md
+++ b/checklists/market-outlook-audit.md
@@ -1,0 +1,76 @@
+# Market Outlook Audit Checklist
+
+Use this checklist when the task is mainly about how a market, category, product class, or industry is likely to evolve over the next 6–24 months.
+
+Examples:
+- industry evolution or adoption trajectory
+- market direction or structural change
+- scenario memo for a changing market
+- strategic outlook for buyers / operators / investors
+
+Run this checklist before delivery.
+
+## Route boundary check
+
+- [ ] the task's core output is direction, evolution, or trajectory — not ranking, prediction, or selection among defined options
+- [ ] the route's "Do not use" clauses from `ROUTING-MATRIX.md` have been checked against the task
+- [ ] if the task mixes market-evolution and selection/ranking questions, the primary burden has been identified and the correct primary route selected
+
+## Current market snapshot
+
+- [ ] the report starts from a verified current baseline before forward-looking sections
+- [ ] current baseline market state is separated from scenario logic
+- [ ] current leading products / vendors / architectures are identified when relevant
+- [ ] current pricing, policy, or packaging changes that alter the near-term outlook are noted
+- [ ] evidence date basis is explicit
+
+## Drivers and blockers
+
+- [ ] drivers (forces that accelerate) and blockers / frictions (forces that slow) are clearly separated
+- [ ] drivers and blockers are not mixed into a flat trend list
+- [ ] each driver or blocker is specific enough to be decision-relevant, not generic
+
+## Structured multi-scenario analysis
+
+- [ ] at minimum a base case and one credible alternative scenario exist
+- [ ] each scenario has a quantitative range for the load-bearing metric
+- [ ] each scenario has explicitly stated key assumptions
+- [ ] each scenario has observable trigger conditions that would signal it is becoming more or less likely
+- [ ] when uncertainty is material, three scenarios (optimistic / base / pessimistic) are present
+- [ ] probability weights are not assigned with false precision — directional labels used when evidence cannot support precise percentages
+- [ ] the report does not rest on a single base case with no uncertainty structure
+
+## Stakeholder implications
+
+- [ ] at least 3 distinct stakeholder types are covered
+- [ ] investor-only coverage is not the sole stakeholder lens
+- [ ] each covered stakeholder type has a dedicated "what does this mean for them" subsection
+- [ ] for each stakeholder type: who should act now, what they should do, what they should avoid overcommitting to, and what they should monitor next
+- [ ] stakeholder implications are not collapsed into a single generic paragraph
+
+## Quantitative role labeling
+
+- [ ] important numbers are labeled as observed current metric / inferred estimate / scenario assumption / illustrative calculation
+- [ ] readers can tell which kind of number they are reading without guessing
+
+## Forward-looking claims
+
+- [ ] every forward-looking claim has a labeled source role
+- [ ] `预计` / `expected` / `likely` has named source attribution (who expects this?)
+- [ ] forecasts show key assumptions and failure / reversal conditions
+
+## Monitoring and change conditions
+
+- [ ] the report identifies what would change the conclusion
+- [ ] monitoring signals are specific and observable
+- [ ] the report does not give a bottom line without explaining what would flip it
+
+## Decision usefulness
+
+- [ ] the report functions as a decision memo about a changing market, not just an industry overview
+- [ ] the reader knows what to do next based on the outlook
+- [ ] the opening 20–30% already reflects the market-outlook route rather than reading like generic background
+
+## Quality bar
+
+A market-outlook report that fails this checklist may still be informative, but it is not yet a proper decision-useful market memo.

--- a/references/market-outlook-and-scenario-discipline.md
+++ b/references/market-outlook-and-scenario-discipline.md
@@ -50,11 +50,11 @@ Boundary examples:
 
 | Task | Correct route | Why |
 |------|--------------|-----|
-| "人形机器人产业链未来 12 个月如何演化" | Market Outlook ✓ | asks for market direction and trajectory |
-| "哪支球队最可能夺冠" | Constrained Choice ✗ | asks for ranking/prediction among defined options |
-| "应该选哪个 AI 模型供应商" | Provider Selection ✗ | asks for selection under constraints |
-| "世界杯足球产业链的商业前景" | Market Outlook ✓ | asks for market evolution, not team ranking |
-| "NAS vs 自建服务器怎么选" | Equipment Selection ✗ | asks for procurement recommendation |
+| "人形机器人产业链未来 12 个月如何演化" | → Market Outlook | asks for market direction and trajectory |
+| "哪支球队最可能夺冠" | → Constrained Choice | asks for ranking/prediction among defined options |
+| "应该选哪个 AI 模型供应商" | → Provider Selection | asks for selection under constraints |
+| "世界杯足球产业链的商业前景" | → Market Outlook | asks for market evolution, not team ranking |
+| "NAS vs 自建服务器怎么选" | → Equipment Selection | asks for procurement recommendation |
 
 If a task mixes market-evolution questions with selection/ranking questions, identify the **primary burden**. If the primary burden is selection or ranking, do not use Market Outlook as the primary route — use the selection route and attach market-outlook discipline as a secondary discipline if market-evolution context is needed.
 
@@ -278,6 +278,11 @@ The report covers only investor/operator implications but ignores technology dev
 The report uses Market Outlook for a task whose core output is ranking, prediction, or selection among defined options.
 
 **Fix:** Check the "When not to use this route" section and `ROUTING-MATRIX.md` "Do not use" clauses before committing to this route. Redirect to Constrained Choice / Shortlist when ranking/prediction burden is primary.
+
+### Failure mode 9: Probability precision illusion
+The report assigns precise probability percentages (e.g., "15-20%", "23%") to inherently uncertain outcomes where the evidence base cannot support that level of precision.
+
+**Fix:** Use directional labels (more likely / less likely / comparable likelihood) or bounded ranges with explicit uncertainty caveats. Precise probabilities are only justified when backed by robust quantitative models or large-sample statistical evidence.
 
 ---
 

--- a/references/market-outlook-and-scenario-discipline.md
+++ b/references/market-outlook-and-scenario-discipline.md
@@ -35,6 +35,33 @@ If the report mostly explains the topic but does not help the reader act under a
 
 ---
 
+## When not to use this route
+
+Market Outlook is for understanding **direction, evolution, and trajectory**. It is not for **choosing, ranking, or recommending**.
+
+Do not use this route when:
+
+- the task's core output is a **recommendation** among defined options → use Constrained Choice / Shortlist
+- the task requires **ranking** entities or options → use Constrained Choice / Shortlist
+- the task asks **"which one should we pick?"** → use Constrained Choice / Shortlist, Provider Selection, or Equipment Selection depending on domain
+- the task asks **"who will win?"** in a competition with defined participants → use Constrained Choice / Shortlist
+
+Boundary examples:
+
+| Task | Correct route | Why |
+|------|--------------|-----|
+| "人形机器人产业链未来 12 个月如何演化" | Market Outlook ✓ | asks for market direction and trajectory |
+| "哪支球队最可能夺冠" | Constrained Choice ✗ | asks for ranking/prediction among defined options |
+| "应该选哪个 AI 模型供应商" | Provider Selection ✗ | asks for selection under constraints |
+| "世界杯足球产业链的商业前景" | Market Outlook ✓ | asks for market evolution, not team ranking |
+| "NAS vs 自建服务器怎么选" | Equipment Selection ✗ | asks for procurement recommendation |
+
+If a task mixes market-evolution questions with selection/ranking questions, identify the **primary burden**. If the primary burden is selection or ranking, do not use Market Outlook as the primary route — use the selection route and attach market-outlook discipline as a secondary discipline if market-evolution context is needed.
+
+Refer to `ROUTING-MATRIX.md` "Do not use" clauses for this route before finalizing route selection.
+
+---
+
 ## What these tasks are really asking
 
 A market-outlook question is usually not asking:
@@ -91,6 +118,35 @@ A strong market-outlook report should usually flow like this:
 9. Recommended next steps / monitoring signals
 
 This logic matters more than preserving a generic background section order.
+
+---
+
+## Structured multi-scenario analysis
+
+Market-outlook reports must not rest on a single base case.
+
+Require at minimum:
+
+- **Base case**: the most likely trajectory with quantitative range, key assumptions, and trigger conditions
+- **At least one alternative scenario**: a credible divergent path with its own quantitative range, assumptions, and triggers
+
+When uncertainty is material, produce three scenarios:
+
+| Scenario | Label | What it needs |
+|----------|-------|---------------|
+| Optimistic | Base+ | quantitative range, key assumptions, trigger conditions that would activate it |
+| Base | Base | quantitative range, key assumptions, current evidence basis |
+| Pessimistic | Base− | quantitative range, key assumptions, trigger conditions that would activate it |
+
+For each scenario:
+
+- state the quantitative range (market size, adoption rate, price trajectory, or other load-bearing metric)
+- state the key assumptions that must hold for this scenario to materialize
+- state the observable trigger conditions that would signal this scenario is becoming more or less likely
+
+Probability weight annotation is recommended when evidence supports it, but not required. Do not assign precise probabilities when the evidence base cannot support that precision — use directional labels (more likely / less likely) instead.
+
+A market-outlook report with only one scenario is not an outlook memo. It is a forecast with no uncertainty structure.
 
 ---
 
@@ -152,25 +208,32 @@ Readers should never have to guess which kind of number they are reading.
 
 ## Stakeholder implications discipline
 
-Do not stop at “the market will likely do X.”
+Do not stop at "the market will likely do X."
 
 State who that matters for.
 
+Cover **at least 3 distinct stakeholder types**. Investor-only coverage is not sufficient.
+
 Common stakeholder lenses:
 
-- buyers / enterprise CTOs
+- investors / operators / procurement teams
 - builders / startups / product teams
 - vendors / channels / ecosystem partners
-- investors / operators / procurement teams
+- technology developers / platform teams
+- policymakers / regulators
+- enterprise buyers / CTOs
+- end users / consumers
 
-A good market memo should say:
+For each covered stakeholder type, provide a dedicated subsection that answers:
 
-- who should act now
-- what they should do now
-- what they should avoid overcommitting to
-- what they should monitor next
+- what does this market change mean for them?
+- who should act now, and what should they do?
+- what should they avoid overcommitting to?
+- what should they monitor next?
 
-Without this, the report may be informative but not decision-useful.
+Do not collapse all stakeholder implications into a single investor-focused paragraph. Each stakeholder type has different decision horizons, risk exposures, and action requirements.
+
+Without multi-stakeholder coverage, the report may be informative for one audience but fails as a decision-useful market memo.
 
 ---
 
@@ -201,6 +264,21 @@ The report gives a smart-sounding bottom line but no stakeholder-specific next s
 
 **Fix:** Require actions + monitoring signals.
 
+### Failure mode 6: Single-scenario outlook
+The report has only a base case with no structured alternative scenarios. This is a forecast, not an outlook memo.
+
+**Fix:** Require at minimum a base case and one credible alternative scenario with distinct assumptions and trigger conditions.
+
+### Failure mode 7: Investor-only stakeholder coverage
+The report covers only investor/operator implications but ignores technology developers, policymakers, enterprise buyers, or end users.
+
+**Fix:** Require at least 3 distinct stakeholder types with dedicated "what does this mean for them" subsections.
+
+### Failure mode 8: Wrong route for ranking task
+The report uses Market Outlook for a task whose core output is ranking, prediction, or selection among defined options.
+
+**Fix:** Check the "When not to use this route" section and `ROUTING-MATRIX.md` "Do not use" clauses before committing to this route. Redirect to Constrained Choice / Shortlist when ranking/prediction burden is primary.
+
 ---
 
 ## Final audit questions
@@ -210,9 +288,10 @@ Before delivery, ask:
 - Does the report start from a verified current baseline?
 - Are drivers and blockers clearly separated?
 - Is there a visible base case for the stated time horizon?
-- Is there at least one credible alternative scenario when uncertainty matters?
+- Are there structured alternative scenarios (at minimum base + one alternative) with distinct assumptions and trigger conditions?
 - Are quantitative outlook numbers labeled by role?
-- Does the report tell distinct stakeholders what to do and what to monitor?
+- Does the report cover at least 3 distinct stakeholder types with dedicated implications?
 - Does it explain what would change the conclusion?
+- Is the task actually a market-outlook task, or does it carry ranking/selection burden that belongs to a different route?
 
 If several of these are missing, the report is probably still an overview rather than a proper market-outlook memo.

--- a/references/report-template.md
+++ b/references/report-template.md
@@ -127,6 +127,8 @@ Rules:
 - both sides apply the same evidence-label discipline ([CONF] / [INFER] / [UNKN])
 - if one side has a table, the other side should have a comparable table
 - do not let the bear case become a bullet list of generic risks while the bull case is a structured analysis
+- if one side has significantly less evidence than the other, still use the same structure but mark empty cells as "无相关证据" or "暂无数据" rather than omitting the structure
+- asymmetric evidence strength is acceptable; asymmetric structure is not
 
 This symmetry matters because asymmetric structure signals to the reader that one side was analyzed more rigorously than the other, even if the substance is equally strong.
 

--- a/references/report-template.md
+++ b/references/report-template.md
@@ -112,6 +112,24 @@ Organize by task type. Examples:
 - include the strongest reasons the main conclusion could be wrong
 - include limits, contradictions, or competing explanations
 
+#### Bull/bear structural symmetry
+
+When the report includes both bull (看多) and bear (看空) case sections, they must use the same structural format. Do not give one side a rigorous epistemic breakdown while the other side is loose prose.
+
+Recommended three-column structure for both sides:
+
+| 事实依据 | 推断依据 | 不确定性/限制条件 |
+|----------|----------|-------------------|
+| confirmed facts supporting this case | inferences or assumptions | what could invalidate this case |
+
+Rules:
+- both bull and bear sections use the same column breakdown
+- both sides apply the same evidence-label discipline ([CONF] / [INFER] / [UNKN])
+- if one side has a table, the other side should have a comparable table
+- do not let the bear case become a bullet list of generic risks while the bull case is a structured analysis
+
+This symmetry matters because asymmetric structure signals to the reader that one side was analyzed more rigorously than the other, even if the substance is equally strong.
+
 ### 6. Uncertainty and missing evidence
 
 - if confidence depends on assumptions or modeled numbers, make that dependency visible instead of letting the numbers read like confirmed facts

--- a/references/route-activation-and-preflight.md
+++ b/references/route-activation-and-preflight.md
@@ -54,6 +54,19 @@ Use provider selection when the task is to choose.
 
 Use market outlook when the task is to understand market direction, industry evolution, or future structure rather than select an option.
 
+### Market outlook vs constrained choice
+Use market outlook when the task is to understand **direction, evolution, or trajectory** of a market, industry, or category.
+
+Use constrained choice when the task's core output is **ranking, prediction, or selection** among defined options — even if the topic sounds like a market or industry question.
+
+Key test: does the task ask "how will this market evolve?" (market outlook) or "which option will win?" (constrained choice)?
+
+Examples:
+- "人形机器人产业链未来 12 个月如何演化" → market outlook (direction/trajectory)
+- "哪支球队最可能夺冠" → constrained choice (ranking among defined options)
+- "世界杯足球产业链的商业前景" → market outlook (market evolution)
+- "AI 编程工具市场中哪家会领先" → constrained choice (selection/prediction)
+
 ### Regulatory / policy impact analysis vs market outlook
 Use regulatory analysis when the core question is understanding the regulatory environment, assessing policy risk, or judging compliance impact. The report structure is organized around current regulations → business impact → scenarios → implications.
 
@@ -99,6 +112,7 @@ Common failures include:
 - route chosen too late, after report shape has already drifted
 - route selected, but output still reads like generic overview
 - required secondary disciplines named but not actually visible
+- wrong route declared for the task type (e.g., Market Outlook used for ranking/prediction tasks; check "Do not use" clauses before committing)
 
 ## Scope
 

--- a/references/valuation-methodology.md
+++ b/references/valuation-methodology.md
@@ -155,8 +155,11 @@ When the report uses one metric as the primary valuation anchor, briefly state w
 - the company has characteristics that could support multiple metrics (e.g., positive earnings AND significant assets)
 - the chosen metric is not the industry default
 - the company is in a transitional state (post-restructuring, cyclical trough, high-growth phase)
+- the company has significant related-party transaction exposure or concentrated ownership that could distort earnings quality
 
-Example pattern: "选用PE而非EV/EBITDA作为主要估值锚，因为[公司]资本结构简单、折旧政策稳定，PE更能反映股东视角的回报预期"
+Example patterns:
+- "选用PE而非EV/EBITDA作为主要估值锚，因为[公司]资本结构简单、折旧政策稳定，PE更能反映股东视角的回报预期"
+- "选用EV/EBITDA而非PE作为主要估值锚，因为[公司]关联方交易占比高，PE可能受非经常性损益影响较大，EV/EBITDA更能反映经营层面的真实估值水平"
 
 For loss-making or cyclical companies, see the precision downgrade rules above. If no metric applies cleanly, say so.
 

--- a/references/valuation-methodology.md
+++ b/references/valuation-methodology.md
@@ -135,6 +135,38 @@ When target price cannot be supported, prefer:
 - valuation range with explicit assumptions
 - "insufficient data for a target price" as a valid conclusion
 
+## Valuation inference documentation
+
+When presenting a valuation range, target price, or fair value estimate labeled as inference, the reader must be able to reconstruct the reasoning chain. Do not present a valuation conclusion without visible methodology.
+
+### Required elements for valuation inference
+
+Every valuation inference must include:
+
+1. **Multiple assumption range** — state the PE (or other metric) range used, not just the final number. Example: "基于2026年预期PE 25-30x" rather than "目标价600元"
+2. **Comparable selection logic** — if comparables are used, state why these companies were chosen and what they share with the target. Do not assume the reader knows why Company X is a valid comp
+3. **Scenario parameters** — if the valuation uses optimistic/base/pessimistic scenarios, state the key variable that differs across scenarios (e.g., margin assumption, growth rate, market share)
+4. **Limitation disclosure** — state what the valuation does not capture or where the methodology is weakest
+
+### Metric selection justification
+
+When the report uses one metric as the primary valuation anchor, briefly state why. This is especially important when:
+
+- the company has characteristics that could support multiple metrics (e.g., positive earnings AND significant assets)
+- the chosen metric is not the industry default
+- the company is in a transitional state (post-restructuring, cyclical trough, high-growth phase)
+
+Example pattern: "选用PE而非EV/EBITDA作为主要估值锚，因为[公司]资本结构简单、折旧政策稳定，PE更能反映股东视角的回报预期"
+
+For loss-making or cyclical companies, see the precision downgrade rules above. If no metric applies cleanly, say so.
+
+### Common failure patterns
+
+- Presenting a target price without stating the multiple or methodology
+- Using "保守区间" or "合理估值" without showing the assumptions behind the range
+- Choosing comparables without explaining the selection logic
+- Stating a PE range without explaining why that range is appropriate for this company's growth/risk profile
+
 ## Common failure patterns
 
 ### Using TTM PE for cyclical stocks


### PR DESCRIPTION
## What

Market Outlook 路由纪律强化，解决两个 eval case 暴露的系统性缺口：

1. **结构化多情景分析要求** — 强制包含乐观/基准/悲观三情景，每情景有定量范围 + 关键假设 + 触发条件
2. **利益相关方覆盖要求** — 强制覆盖 ≥3 类利益相关方（不再允许仅覆盖投资者）
3. **边界规则** — 明确何时不能使用 Market Outlook（有推荐/排序/选择负荷时应走 Constrained Choice）

## Why

两个真实 eval case 暴露了 Market Outlook 路由的执行缺口：

- **人形机器人 case** 🔴：Market Outlook 路由被选对，但缺少结构化多情景分析（仅一个基准场景 + 一句悲观参考），利益相关方仅覆盖投资者
- **世界杯 case** 🔴：错误声明 Market Outlook 路由（实际应为 Constrained Choice），触发 2 个 hard-fail 条件

## Changes

| 文件 | 改动 |
|------|------|
|  | 新增多情景分析章节、强化利益相关方覆盖（≥3 类）、新增边界规则章节、新增 3 个 failure mode |
|  | hard-fail 增加利益相关方覆盖和路由边界检查、visible artifact contract 更新、Audit 增加 market-outlook-audit.md、Do not use 条款强化 |
|  | 新增 Market Outlook vs Constrained Choice 辨析、failure mode 增加错误路由声明 |
|  | **新建** Market Outlook 专用 checklist |
|  | Family B checklists 和 failure signs 更新 |
|  | recall discipline 增加多情景、利益相关方、路由边界条目 |

## Evidence

-  — 执行不完备（缺多情景、利益相关方单一）
-  — 路由选择错误（排序任务误用 Market Outlook）

## Scope

- 纯文档/纪律强化，无代码逻辑变更
- 不改 SKILL.md workflow 步骤
- 不改其他路由

toward #147