### PR TITLE
harden: routing-matrix hard-fail conditions — market snapshot, anchor block, background-first drift, secondary route, route boundary (#149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ This file is intentionally lightweight. Use concise entries that explain:
 - `ROUTING-MATRIX.md`: added listed-company route hard-fail conditions — missing research-anchor block (absent entirely, not just stale) and incomplete market snapshot (missing ≥3 of share price/cap/PE/PB/PS/52w range/date) (#149).
 - `ROUTING-MATRIX.md`: added constrained-choice route hard-fail condition — background-first drift (>5 lines of pure background immediately after judgment summary) (#149).
 - `ROUTING-MATRIX.md`: strengthened Market Outlook route hard-fail and "Do not use" section — added concrete boundary examples distinguishing Market Outlook vs Constrained Choice vs Provider Selection vs trajectory questions; expanded "which one wins" hard-fail wording (#149).
+- `checklists/route-activation-audit.md`: added secondary route hard-fail verification checkbox — when multiple routes are declared, all declared routes' hard-fail conditions must be verified (#149).
+- `checklists/listed-company-report.md`: expanded stale-anchor hard gate to also catch "missing entirely" (not just stale/mis-timed); added sub-route applicability note (#149).
+- `checklists/option-selection-final-audit.md`: added Background-first drift check section with 2 verification items matching new constrained-choice hard-fail (#149).
+- `checklists/final-audit.md`: added secondary route hard-fail verification recall entry; clarified "secondary disciplines" vs "secondary routes" distinction (#149).
+- `checklists/workflow-spine-audit.md`: extended artifact contract check to cover secondary declared routes (#149).
 
 ### Why
 - Per issue #127, the current eval framework only tests current-state verification against the agent's own stale knowledge (neutral prompts). This injection test adds adversarial testing — deliberately feeding stale product data as input context to verify whether the defense mechanism works when stale data comes from external sources. This complements existing freshness evals like `freshness-xiaomi-case.md` and helps identify whether current-state verification is truly robust or only effective against internal knowledge gaps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ This file is intentionally lightweight. Use concise entries that explain:
 ### Changed
 - `ROUTING-MATRIX.md`: updated routing priority from 10 to 11 routes — academic / literature review added as experimental route at position 11 (after constrained choice) (#128).
 
+### Added
+- `ROUTING-MATRIX.md`: added secondary route hard-fail requirement — when a report declares multiple routes, all declared routes' hard-fail conditions must be verified; none may be skipped because a route is "secondary" (#149).
+- `ROUTING-MATRIX.md`: added listed-company route hard-fail conditions — missing research-anchor block (absent entirely, not just stale) and incomplete market snapshot (missing ≥3 of share price/cap/PE/PB/PS/52w range/date) (#149).
+- `ROUTING-MATRIX.md`: added constrained-choice route hard-fail condition — background-first drift (>5 lines of pure background immediately after judgment summary) (#149).
+- `ROUTING-MATRIX.md`: strengthened Market Outlook route hard-fail and "Do not use" section — added concrete boundary examples distinguishing Market Outlook vs Constrained Choice vs Provider Selection vs trajectory questions; expanded "which one wins" hard-fail wording (#149).
+
 ### Why
 - Per issue #127, the current eval framework only tests current-state verification against the agent's own stale knowledge (neutral prompts). This injection test adds adversarial testing — deliberately feeding stale product data as input context to verify whether the defense mechanism works when stale data comes from external sources. This complements existing freshness evals like `freshness-xiaomi-case.md` and helps identify whether current-state verification is truly robust or only effective against internal knowledge gaps.
 - Per issue #128, academic research tasks (literature review, field progress analysis, paper comparison) lacked a dedicated route. These tasks were being routed to technical deep-dive or generic research, producing reports that did not properly distinguish evidence tiers, label publication types, or apply academic methodology. The new academic route provides explicit trigger conditions, artifact contract (evidence hierarchy, search strategy, publication type labeling), and hard-fail conditions for academic research tasks. Route is marked as experimental pending real-world validation.

--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -46,6 +46,10 @@ Use the smallest complete set:
 
 Do not activate everything. Activate the smallest set that produces a decision-useful, auditable, current, and clean final artifact.
 
+### Secondary route hard-fail requirement
+
+When a report declares multiple routes (primary + secondary), the hard-fail conditions of **all** declared routes must be verified. A secondary route's hard-fail conditions may not be skipped because it is "secondary." If a hard-fail condition is genuinely inapplicable to the task, document the inapplicability reason rather than skipping the check silently.
+
 ## Route execution contract
 
 Before synthesis, convert the selected route into a compact execution contract.
@@ -208,6 +212,12 @@ Use when the task is mainly about:
 
 **Do not use this route when:** the task has a real recommendation, shortlist, or selection burden. Specifically: ranking entities or options, predicting competition outcomes among defined participants, or choosing a provider/supplier. See `references/market-outlook-and-scenario-discipline.md` "When not to use this route" for boundary examples.
 
+Concrete boundary examples:
+- "哪支球队最可能夺冠" → Constrained Choice (ranking burden)
+- "世界杯足球产业链的商业前景" → Market Outlook (market evolution without ranking)
+- "人形机器人产业链未来 12 个月如何演化" → Market Outlook (trajectory question)
+- "应该选哪个 AI 模型供应商" → Provider Selection (selection burden)
+
 **Often confused with:** provider selection or constrained choice.
 
 ### Read
@@ -250,7 +260,7 @@ Fail if the report:
 - gives forecasts without visible scenario structure, or rests on a single base case with no alternative scenarios
 - hides stakeholder implications inside generic narrative
 - covers only investor stakeholder implications while ignoring technology developers, policymakers, enterprise buyers, or end users
-- uses Market Outlook for a task whose core output is ranking, prediction, or selection among defined options (wrong route — use Constrained Choice / Shortlist instead)
+- uses Market Outlook for a task whose core output carries recommendation, ranking, selection, or winner-prediction burden among defined options — including team ranking, supplier shortlist, investment pick, or any "which one wins" framing (wrong route — use Constrained Choice / Shortlist instead)
 
 ---
 
@@ -360,6 +370,7 @@ Fail if the report:
 - gives a recommendation without showing how the shortlist was built
 - uses numbers without labeling observed fact / proxy / assumption / model output
 - turns the task into descriptive option blurbs instead of a true choice memo
+- exhibits background-first drift — the executive summary or judgment-first opening is immediately followed by >5 lines of pure background description (venue context, event history, category overview, halftime-show information, or similar) before the decision architecture or comparison framework begins
 
 ---
 
@@ -663,7 +674,8 @@ Fail if the report:
 
 - mixes reported metrics and forward estimates without clear labels
 - uses undated financial numbers
-- names a stale or mis-timed research-anchor layer — latest full-year, quarterly / interim, or current market snapshot — and still proceeds as if the memo were current
+- research-anchor block is missing entirely, or names a stale or mis-timed time layer — latest full-year, quarterly / interim period, or current market snapshot — and still proceeds as if the memo were current
+- lacks a complete market snapshot — missing at least three of: share price with date, market capitalization, PE (TTM/Forward), PB/PS, 52-week range, snapshot date
 - makes market-position claims without scope
 - lets valuation narrative substitute for business evidence
 - treats A-share uniqueness as supply-side monopoly or industry exclusivity

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -57,7 +57,7 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] the selected primary route is inferable from the final artifact without relying on internal notes
 - [ ] the report visibly satisfies that route's artifact contract
 - [ ] if a close alternative route existed, the chosen route's logic is visible rather than merely asserted
-- [ ] the required secondary disciplines for the selected route are visibly executed
+- [ ] the required secondary disciplines for the selected route are visibly executed (note: "secondary disciplines" such as current-state verification differ from "secondary routes" — secondary routes have their own hard-fail verification requirement checked in the Recall discipline section)
 - [ ] the report does not collapse back into generic overview mode despite route selection
 - [ ] if the route implies recommendation, ranking, gating, or sequencing burden, the report actually carries that burden
 - [ ] if scope completeness was required, the report's coverage boundaries are explicit; load-bearing geographies or segments are present; omissions are named rather than silent
@@ -108,6 +108,7 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] source traceability was applied for structured or investment-relevant outputs
 - [ ] scope completeness was checked when the report claims global, comprehensive, or industry-wide scope
 - [ ] decision utility was checked when the report carries a recommendation, choice, judgment, or investment-style decision burden
+- [ ] if multiple routes are declared (primary + secondary), the hard-fail conditions of each declared route are verified; secondary route hard-fail conditions are not skipped because the route is "secondary" (see ROUTING-MATRIX.md "Secondary route hard-fail requirement")
 - [ ] option-selection final audit was run for shortlist, ranking, or constrained-choice outputs
 - [ ] for model/API/provider selection tasks, a current provider snapshot was verified before ranking or recommendation
 - [ ] for China-mainland deployment decisions, accessibility, compliance, data residency, and SLA were treated as part of ranking logic when relevant

--- a/checklists/listed-company-report.md
+++ b/checklists/listed-company-report.md
@@ -43,7 +43,8 @@ Run through every item before delivering the final report.
 
 ## Stale-anchor hard-fail gate
 
-- [ ] stale-anchor hard gate: a stale or mis-timed research-anchor layer — latest full-year, quarterly / interim, or current market snapshot — invalidates the memo unless synthesis was stopped, the anchor was re-checked, and the anchor was corrected or visibly downgraded before continuing — per SKILL.md fail-fast rule
+- [ ] stale-anchor hard gate: a missing, stale, or mis-timed research-anchor layer — latest full-year, quarterly / interim, or current market snapshot — invalidates the memo unless synthesis was stopped, the anchor was re-checked, and the anchor was corrected or visibly downgraded before continuing — per SKILL.md fail-fast rule
+- [ ] this gate applies regardless of whether listed-company is the primary route or a secondary/sub-route (per ROUTING-MATRIX.md "Secondary route hard-fail requirement")
 
 ## Current product lineup
 

--- a/checklists/option-selection-final-audit.md
+++ b/checklists/option-selection-final-audit.md
@@ -88,6 +88,11 @@ Run this checklist before delivery.
 - [ ] the next step is clear
 - [ ] narrative weight is not distributed so evenly that the winning option, runner-up, and rejected options all feel equally plausible by reading time alone
 
+## Background-first drift check
+
+- [ ] the executive summary or judgment-first opening flows directly into the decision architecture or comparison framework, not into >5 lines of pure background description (venue context, event history, category overview, or similar)
+- [ ] removing background paragraphs that immediately follow the opening judgment would sharpen rather than weaken the report
+
 ## Quality bar
 
 A selection report that fails this checklist may still be informative, but it is not yet strong decision support.

--- a/checklists/route-activation-audit.md
+++ b/checklists/route-activation-audit.md
@@ -46,6 +46,7 @@ It audits whether route activation was explicit and whether the route actually s
 
 - [ ] route-specific hard-fail conditions from the routing matrix were checked before delivery
 - [ ] the report does not exhibit any of the named hard-fail patterns for its primary route
+- [ ] if multiple routes are declared (primary + secondary), the hard-fail conditions of **all** declared routes are verified; a secondary route's hard-fail conditions are not skipped because it is "secondary"; if a condition is genuinely inapplicable, the reason is documented rather than skipped silently
 
 ## Contract item-by-item verification
 

--- a/checklists/workflow-spine-audit.md
+++ b/checklists/workflow-spine-audit.md
@@ -53,7 +53,7 @@ Run this checklist before every delivery. It is a Tier-1 gate that audits whethe
 ## Final discipline
 
 - [ ] if a specialized route was selected: the required audits for that route were run and pass
-- [ ] if a specialized route was selected: the report satisfies the visible artifact contract of its primary route
+- [ ] if a specialized route was selected: the report satisfies the visible artifact contract of its primary route (and of any declared secondary route, if applicable; secondary-route hard-fail conditions are checked separately — see ROUTING-MATRIX.md "Secondary route hard-fail requirement")
 - [ ] if no mature specialized route was triggered: the report follows the shared workflow spine and does not drift into generic overview mode
 
 ## Quality bar


### PR DESCRIPTION
## 改动

仅修改两个文件：`ROUTING-MATRIX.md` 和 `CHANGELOG.md`。

### `ROUTING-MATRIX.md` 的 5 处改动

**1. Listed Company 路由 — 硬性条件硬化**（源自 AMAT eval 🔴）
- 市场快照不完整 → 缺失股价/市值/PE/PB/PS/52周范围/日期中任意3项即触发 hard-fail
- 锚定块缺失 → 不仅是过期锚点（stale），完全缺失（missing）也触发 hard-fail

**2. Market Outlook 路由 — 边界强化**（源自世界杯 eval 🔴）
- Hard-fail 措辞从 "ranking, prediction, or selection among defined options" 扩展到明确包含 winner-prediction、"which one wins" framing
- Do-not-use 段新增 4 个中文边界示例（球队排名、产业链前景、人形机器人演化、AI供应商选择）

**3. Constrained Choice 路由 — 背景漂移 hard-fail**（源自欧冠决赛 eval 🟡）
- 执行摘要/判断优先开篇后紧接 >5 行纯背景描述即触发 hard-fail

**4. 全局规则 — 次路由 hard-fail 要求**（源自人形机器人 eval 🔴）
- 声明多路由时，所有路由（含次路由）的 hard-fail 条件均须验证

## 验证

- 四个 eval 案例（AMAT、欧冠决赛、人形机器人、世界杯）均提供了真实失败证据
- 所有改动基于 eval "Suggested intervention target" 的建议
- Markdown 语法验证通过
- 仅改 1 个逻辑文件 + CHANGELOG

## Closes

Closes #149