### PR TITLE
harden: 路由激活前置流程 — 排除条款检查 + 次路由 hard-fail 验证 + 执行契约 (#148)

### DIFF
--- a/checklists/route-activation-audit.md
+++ b/checklists/route-activation-audit.md
@@ -9,8 +9,8 @@ It audits whether route activation was explicit and whether the route actually s
 - [ ] the primary route was consciously chosen before deep collection began, not retrofitted during writing
 - [ ] the closest alternative route was identified and a reason exists for why the chosen route wins
 - [ ] the selected route's "Do not use" / "Often confused with" clauses from `ROUTING-MATRIX.md` were checked before finalizing; if the task matched a disqualifying condition, the route was reconsidered or the boundary judgment was documented
-- [ ] if a secondary route is declared, its hard-fail conditions were verified at selection time (not deferred to delivery); if a condition is inapplicable, the reason is documented
-- [ ] a compact execution contract exists before synthesis: opening mandate, mandatory sections, hard-fail conditions, minimize/move-later items
+- [ ] if a secondary route is declared, its hard-fail conditions from `ROUTING-MATRIX.md` were verified at selection time (not deferred to delivery); if a condition is inapplicable, the reason is documented
+- [ ] a compact execution contract exists before synthesis: opening mandate, mandatory sections, hard-fail conditions, minimize / move later
 - [ ] all required audits for this route (from `ROUTING-MATRIX.md` `### Audit` section) are identified and confirmed executed before delivery (results visible in the artifact or process log); if any required audit is missing, it is run before the report is considered ready; if any required audit was intentionally skipped, the reason is documented
 
 ## Route selection visibility
@@ -45,6 +45,8 @@ It audits whether route activation was explicit and whether the route actually s
 - [ ] if a route-specific section were removed, the report would materially lose decision logic
 
 ## Hard-fail check
+
+Preflight hard-fail verification (above) identifies conditions at selection time. This delivery-time check re-verifies them — the task context or evidence may have changed during research.
 
 - [ ] route-specific hard-fail conditions from the routing matrix were checked before delivery
 - [ ] the report does not exhibit any of the named hard-fail patterns for its primary route

--- a/checklists/route-activation-audit.md
+++ b/checklists/route-activation-audit.md
@@ -8,7 +8,9 @@ It audits whether route activation was explicit and whether the route actually s
 
 - [ ] the primary route was consciously chosen before deep collection began, not retrofitted during writing
 - [ ] the closest alternative route was identified and a reason exists for why the chosen route wins
-- [ ] a compact execution contract exists before synthesis: opening mandate, mandatory sections, hard-fail conditions
+- [ ] the selected route's "Do not use" / "Often confused with" clauses from `ROUTING-MATRIX.md` were checked before finalizing; if the task matched a disqualifying condition, the route was reconsidered or the boundary judgment was documented
+- [ ] if a secondary route is declared, its hard-fail conditions were verified at selection time (not deferred to delivery); if a condition is inapplicable, the reason is documented
+- [ ] a compact execution contract exists before synthesis: opening mandate, mandatory sections, hard-fail conditions, minimize/move-later items
 - [ ] all required audits for this route (from `ROUTING-MATRIX.md` `### Audit` section) are identified and confirmed executed before delivery (results visible in the artifact or process log); if any required audit is missing, it is run before the report is considered ready; if any required audit was intentionally skipped, the reason is documented
 
 ## Route selection visibility

--- a/references/route-activation-and-preflight.md
+++ b/references/route-activation-and-preflight.md
@@ -41,7 +41,9 @@ If one route mainly changes wording while another changes structure and audit ex
 
 After identifying candidate routes and before finalizing route selection, execute these verification steps.
 
-### Step 1: Exclusion clause check
+If no specialized route applies to this task (shared-workflow path), skip these steps — the workflow-spine audit replaces route-specific preflight.
+
+### Step 1: "Do not use" / "Often confused with" clause check
 
 Before committing to a route, check the route's **"Do not use"** and **"Often confused with"** clauses in `ROUTING-MATRIX.md`.
 
@@ -51,7 +53,9 @@ Before committing to a route, check the route's **"Do not use"** and **"Often co
 
 ### Step 2: Secondary-route hard-fail verification
 
-If the preflight identifies a secondary route (in addition to the primary route), its hard-fail conditions must be verified **at selection time**, not deferred to delivery.
+A secondary route is present when one of the "Secondary disciplines" identified in the Preflight questions above is itself a specialized route (e.g., Listed Company attached to a Market Outlook primary) rather than a cross-cutting discipline like source traceability.
+
+If the preflight identifies a secondary route, its hard-fail conditions must be verified **at selection time**, not deferred to delivery.
 
 - Read the secondary route's hard-fail conditions from `ROUTING-MATRIX.md`.
 - If a condition is genuinely inapplicable to the task (e.g., "market snapshot hard-fail does not apply because the secondary route is listed-company but the task does not involve company-level market data"), document the inapplicability reason explicitly.
@@ -59,14 +63,17 @@ If the preflight identifies a secondary route (in addition to the primary route)
 
 ### Step 3: Execution contract
 
-Before deep collection begins, write a compact execution contract that the final artifact must satisfy.
+Before deep collection begins, write a compact execution contract that the final artifact must satisfy. This contract operationalizes the "Required artifact contract" field from the Minimal internal shape below.
 
 This contract must include at minimum:
+- **opening mandate** — what the opening 20-30% of the report must accomplish
 - **mandatory sections** — which sections are non-negotiable because the route would fail without them
 - **hard-fail conditions** — which route-specific failure patterns must be checked before delivery
-- **minimize / move-later items** — which tempting generic sections should be compressed or placed after the primary decision logic
+- **minimize / move later** — which tempting generic sections should be compressed or placed after the primary decision logic
 
 For tasks where the option set is small or obvious (e.g., binary choice), still state the selection boundary explicitly: "only these options are credible because…" rather than leaving it implicit.
+
+The full contract format (including "visible proof the route fired") is defined in `ROUTING-MATRIX.md` under "Route execution contract."
 
 The contract belongs in the research plan, not only in the final audit. A route is not fully selected until this contract exists in operational form.
 

--- a/references/route-activation-and-preflight.md
+++ b/references/route-activation-and-preflight.md
@@ -37,6 +37,39 @@ Choose the route that most strongly determines:
 
 If one route mainly changes wording while another changes structure and audit expectations, choose the latter.
 
+## Preflight steps
+
+After identifying candidate routes and before finalizing route selection, execute these verification steps.
+
+### Step 1: Exclusion clause check
+
+Before committing to a route, check the route's **"Do not use"** and **"Often confused with"** clauses in `ROUTING-MATRIX.md`.
+
+- If the task matches a "Do not use" condition → do not use this route. Reconsider route selection.
+- If the boundary is ambiguous (the task partially overlaps with "Often confused with" routes) → document the boundary judgment: why this route still wins despite the overlap, or switch to the more appropriate route.
+- Do not skip this check because the route "feels right" for the topic — topic label is not the same as decision burden.
+
+### Step 2: Secondary-route hard-fail verification
+
+If the preflight identifies a secondary route (in addition to the primary route), its hard-fail conditions must be verified **at selection time**, not deferred to delivery.
+
+- Read the secondary route's hard-fail conditions from `ROUTING-MATRIX.md`.
+- If a condition is genuinely inapplicable to the task (e.g., "market snapshot hard-fail does not apply because the secondary route is listed-company but the task does not involve company-level market data"), document the inapplicability reason explicitly.
+- Do not skip this step because the secondary route is "secondary" — the hard-fail conditions of all declared routes apply equally.
+
+### Step 3: Execution contract
+
+Before deep collection begins, write a compact execution contract that the final artifact must satisfy.
+
+This contract must include at minimum:
+- **mandatory sections** — which sections are non-negotiable because the route would fail without them
+- **hard-fail conditions** — which route-specific failure patterns must be checked before delivery
+- **minimize / move-later items** — which tempting generic sections should be compressed or placed after the primary decision logic
+
+For tasks where the option set is small or obvious (e.g., binary choice), still state the selection boundary explicitly: "only these options are credible because…" rather than leaving it implicit.
+
+The contract belongs in the research plan, not only in the final audit. A route is not fully selected until this contract exists in operational form.
+
 ## Common route confusions
 
 ### Market entry vs constrained choice


### PR DESCRIPTION
Closes #148

## 改动

### `references/route-activation-and-preflight.md`
新增 `## Preflight steps` 小节，包含 3 个前置验证步骤：
- **Step 1: "Do not use" / "Often confused with" clause check** — 选定路由前检查该路由的排除条款
- **Step 2: Secondary-route hard-fail verification** — 附加次路由时，其 hard-fail 条件必须在选择时验证，不能推延到交付
- **Step 3: Execution contract** — 收集前写定执行契约

同时处理了边界场景：
- 共享工作流路径（无专业路线）→ 跳过 preflight steps
- Secondary route 与 Preflight questions 中 secondary disciplines 的关联说明
- Step 3 执行契约与 Minimal internal shape 的关系说明
- 指向 ROUTING-MATRIX.md 的完整契约模板的引用

### `checklists/route-activation-audit.md`
Preflight 部分新增 2 个检查项，完善 1 个现有项：
- `Do not use` / `Often confused with` 条款已检查（或边界理由已记录）
- 次路由 hard-fail 在 selection time 已验证（或不适用的理由已记录）
- 执行契约包含 `minimize / move later`

Hard-fail check 部分增加说明：preflight 在选择时标记条件，delivery-time 重新验证（研究过程中任务上下文或证据可能变化）。

## 背景
三个真实 eval case（欧冠决赛、人形机器人、世界杯）暴露了同一个根因：路由选择前缺少排除条款检查、次路由 hard-fail 前置验证、执行契约写定的系统步骤。本次改动填补这三个流程缺失。

## Review 修复（第 2 轮）
交叉审核发现 7 个 non-blocker/nit 级问题，均已修复：
1. Step 1 标题使用非标准术语 `Exclusion clause check` → 改为标准术语
2. 缺少 shared-workflow 退出条件 → 增加
3. Step 2 中 secondary route ↔ secondary disciplines 连接不清晰 → 增加桥接说明
4. Step 3 缺少 `opening mandate` → 补上
5. Step 3 未引用 ROUTING-MATRIX.md 完整模板 → 增加引用
6. `minimize / move-later` 连字符与 ROUTING-MATRIX.md 不一致 → 统一去连字符
7. Preflight 与 delivery-time hard-fail 检查的关系未说明 → 增加说明

## 风险
无。纯新增流程步骤和检查项，未修改/删除任何现有规则。