### PR TITLE
feat: add evidence-label inflation and inline citation consistency checks to listed-company checklist (#151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This file is intentionally lightweight. Use concise entries that explain:
 ## Unreleased
 
 ### Added
+- `checklists/listed-company-report.md`: added evidence-label inflation check (inferred/third-party claims not labeled as confirmed facts; highest label tier must match source strength) and inline citation format consistency check (unified `[SN]`/`[IN]`/`[UN]` bracket style) — closes remaining gaps from issue #151 after #144/#153, #148, #149.
+
+### Added
 - `evals/cases/injection-stale-product-data-case.md`: new adversarial injection test for current-state verification — deliberately feeds stale Apple product data (iPhone 14 as current flagship, A16 Bionic as latest chip) and checks whether the defense mechanism detects and corrects it (#127).
 - `ROUTING-MATRIX.md`: added Academic / Literature Review as an experimental first-class route with trigger, artifact contract, hard-fail conditions, and routing priority (#128).
 - `references/academic-evidence-hierarchy.md`: new discipline file for academic research tasks — covers evidence hierarchy (meta-analysis → RCT → peer-reviewed → preprint → conference → weak evidence), source labeling requirements, statistical assessment, literature search methodology, and hard-fail conditions (#128).

--- a/checklists/listed-company-report.md
+++ b/checklists/listed-company-report.md
@@ -23,8 +23,8 @@ Run through every item before delivering the final report.
 - [ ] financial figures are labeled by type: audited annual / interim / earnings release / analyst consensus / inferred
 - [ ] historical reported facts are separated from current market snapshot
 - [ ] forward-looking targets or estimates are clearly labeled as such, not presented as confirmed facts
-- [ ] **evidence labels do not inflate claim strength** — inferred or third-party claims are not labeled as "confirmed facts"; the highest label tier per claim matches the actual source strength; if a claim carries [Confirmed] / 已确认事实 label, the source must support that tier (primary filing, company disclosure, or directly observed event); labels that overstate certainty relative to the evidence are downgraded before delivery
-- [ ] inline source citation format is consistent throughout the document — all `[SN]`/`[IN]`/`[UN]` tags use the same bracket style and spacing; mixing formats (e.g. `[SN]` in some sections and unformatted references in others) is flagged and aligned before delivery
+- [ ] evidence labels do not inflate claim strength — inferred or third-party claims are not labeled as "confirmed facts"; the highest label tier per claim matches the actual source strength; if a claim carries [Confirmed] / 已确认事实 label, the source must support that tier (primary filing, company disclosure, or directly observed event); labels that overstate certainty relative to the evidence are downgraded before delivery (see `references/source-quality.md` for source-tier definitions)
+- [ ] inline source citation format is consistent throughout the document — all `[SN]`/`[IN]`/`[UN]` tags use the same bracket style and spacing; mixing formats (e.g. `[SN]` in some sections and unformatted references in others) is flagged and aligned before delivery (see `checklists/source-traceability.md` for citation format requirements)
 - [ ] older but still useful numbers are visibly labeled as historical background / older snapshot rather than treated as current-state anchors
 
 ## Valuation methodology

--- a/checklists/listed-company-report.md
+++ b/checklists/listed-company-report.md
@@ -23,6 +23,8 @@ Run through every item before delivering the final report.
 - [ ] financial figures are labeled by type: audited annual / interim / earnings release / analyst consensus / inferred
 - [ ] historical reported facts are separated from current market snapshot
 - [ ] forward-looking targets or estimates are clearly labeled as such, not presented as confirmed facts
+- [ ] **evidence labels do not inflate claim strength** — inferred or third-party claims are not labeled as "confirmed facts"; the highest label tier per claim matches the actual source strength; if a claim carries [Confirmed] / 已确认事实 label, the source must support that tier (primary filing, company disclosure, or directly observed event); labels that overstate certainty relative to the evidence are downgraded before delivery
+- [ ] inline source citation format is consistent throughout the document — all `[SN]`/`[IN]`/`[UN]` tags use the same bracket style and spacing; mixing formats (e.g. `[SN]` in some sections and unformatted references in others) is flagged and aligned before delivery
 - [ ] older but still useful numbers are visibly labeled as historical background / older snapshot rather than treated as current-state anchors
 
 ## Valuation methodology


### PR DESCRIPTION
## 背景

Issue #151 要求对三个审计清单补全审计项。评审后发现 6/8 项已在 #144/#153、#148、#149 中实现。

本 PR 补齐剩余 2 项（均在 `checklists/listed-company-report.md`）：

### 改动清单

**1. 证据标签通胀检测**（Tier-2，第26行）
- 推断或第三方主张不得标记为"已确认事实"
- 最高标签级别必须匹配实际源强度
- 对应 AMAT 案例 eval（`evals/cases/amat-listed-company-anchor-and-label-execution-case.md`）建议

**2. 内联来源引用格式一致性**（Tier-2，第27行）
- 全文 `[SN]`/`[IN]`/`[UN]` 标签使用统一的括号样式和间距
- 混合格式在交付前需对齐

### 验证

- `checklists/listed-company-report.md` diff 确认新增项与现有条款风格一致
- 无代码改动，无需运行测试

### 关联

Closes #151