### PR TITLE
feat: 标签通胀修复 — 厂商声明与媒体估计标注一致性规范 (#164)

### DIFF
--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -154,8 +154,8 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] for constrained-choice / shortlist reports that use composite scoring, important quantitative inputs are labeled as observed fact / proxy / assumption / model output when the distinction affects trust in the recommendation
 - [ ] when evidence buckets are used, the report does not stop at `confirmed / inference / unknown` if important numbers still function as proxy / assumption / planning-model output
 - [ ] heuristic timing, cost, payback, or ROI-style claims are not written as if they were directly observed facts when they are closer to assumptions or planning-model outputs
-- [ ] Source Register 标注 "厂商自述" 的来源在正文引用时附加了内联说明（如 "(厂商自述，非独立验证)"）
-- [ ] 媒体估计数据未在正文中标注为 [已确认事实]（使用 [推断] 或具体来源角色替代）
+- [ ] （非阻塞）Source Register 中类型为 PRIMARY_COMPANY/PRIMARY_PARTNER 或 Notes 标注"厂商自述"的来源，在正文引用时附加了内联说明 `(来源：厂商自述，非独立验证)`（见 `references/source-traceability-and-claim-citation.md` §来源标注一致性）
+- [ ] （非阻塞）SECONDARY_MEDIA / SECONDARY_ANALYST 类型来源（媒体估计、券商研报）未在正文中标注为 [已确认事实]（使用 [推断] 或具体来源角色替代）
 
 ## Metric-scope audit
 

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -154,6 +154,8 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] for constrained-choice / shortlist reports that use composite scoring, important quantitative inputs are labeled as observed fact / proxy / assumption / model output when the distinction affects trust in the recommendation
 - [ ] when evidence buckets are used, the report does not stop at `confirmed / inference / unknown` if important numbers still function as proxy / assumption / planning-model output
 - [ ] heuristic timing, cost, payback, or ROI-style claims are not written as if they were directly observed facts when they are closer to assumptions or planning-model outputs
+- [ ] Source Register 标注 "厂商自述" 的来源在正文引用时附加了内联说明（如 "(厂商自述，非独立验证)"）
+- [ ] 媒体估计数据未在正文中标注为 [已确认事实]（使用 [推断] 或具体来源角色替代）
 
 ## Metric-scope audit
 

--- a/checklists/technical-analysis-audit.md
+++ b/checklists/technical-analysis-audit.md
@@ -25,6 +25,8 @@ This checklist verifies that the technical analysis route was executed correctly
 - [ ] vendor claims are distinguished from independently verified technical facts
 - [ ] benchmarks cite methodology, environment, and date
 - [ ] patent claims cite patent numbers or specific filings, not just counts
+- [ ] 厂商宣称在正文中标注了来源角色（厂商自述 / 独立验证 / 推测）
+- [ ] 行内引用中涉及厂商声称的附加了 caveat
 
 ## Comparison structure (for architecture comparison)
 

--- a/checklists/technical-analysis-audit.md
+++ b/checklists/technical-analysis-audit.md
@@ -25,8 +25,8 @@ This checklist verifies that the technical analysis route was executed correctly
 - [ ] vendor claims are distinguished from independently verified technical facts
 - [ ] benchmarks cite methodology, environment, and date
 - [ ] patent claims cite patent numbers or specific filings, not just counts
-- [ ] 厂商宣称在正文中标注了来源角色（厂商自述 / 独立验证 / 推测）
-- [ ] 行内引用中涉及厂商声称的附加了 caveat
+- [ ] （非阻塞）厂商自述在正文中明确标注了来源角色（如 `(厂商自述)` 或 `(来源：厂商自述，非独立验证)`），见 `references/source-traceability-and-claim-citation.md` §来源标注一致性
+- [ ] （非阻塞）涉及厂商自述的行内引用附加了标准格式 caveat `(来源：厂商自述，非独立验证)` 或等效说明
 
 ## Comparison structure (for architecture comparison)
 

--- a/references/quantitative-role-labeling.md
+++ b/references/quantitative-role-labeling.md
@@ -194,6 +194,32 @@ The assumption is named ("assume 15% growth"), but the conditions that must hold
 
 - `references/forward-looking-discipline.md` has an "Assumption chains" section for forward-looking numbers (revenue projections, market size forecasts, adoption timelines). The template here is the general-purpose version. For forward-looking claims, that file's lighter pattern may be sufficient; for complex or high-sensitivity assumptions, the full template here applies.
 
+## 厂商声明与媒体估计的特殊标注规则
+
+当定量数字的来源属于以下两类时，必须在正文中显式标注其角色，不能仅依赖 Source Register 的 metadata：
+
+### 厂商自述（manufacturer self-reported）
+
+数据来自公司官网、新闻稿、官方社交媒体、合作伙伴声明等未经过独立第三方验证的来源。
+
+- 正文引用时必须附加内联说明，如 `(来源：厂商自述，非独立验证)`
+- 不得单独标注为 `[已确认事实]`
+
+### 媒体估计（media estimate）
+
+数据来自彭博、T2/T3 媒体等第三方推断性来源。
+
+- 不得标注为 `[已确认事实]`
+- 应使用 `[推断]` 或具体来源角色如 `[彭博 estimate]`
+
+### 何时需要标注
+
+判断标准：如果删除这行内说明后，读者无法区分"独立验证的事实"和"来源主动声称但未独立验证的数字"，就需要标注。
+
+### 与 Source Register 的关系
+
+参见 `references/source-traceability-and-claim-citation.md` 的「来源标注一致性」章节，其中定义了 register 与正文标签强度的一致性原则。
+
 ## Route-specific notes
 
 ### Market entry / regional expansion

--- a/references/quantitative-role-labeling.md
+++ b/references/quantitative-role-labeling.md
@@ -196,7 +196,7 @@ The assumption is named ("assume 15% growth"), but the conditions that must hold
 
 ## 厂商声明与媒体估计的特殊标注规则
 
-当定量数字的来源属于以下两类时，必须在正文中显式标注其角色，不能仅依赖 Source Register 的 metadata：
+当数据的来源属于以下两类时，必须在正文中显式标注其角色，不能仅依赖 Source Register 的 metadata：
 
 ### 厂商自述（manufacturer self-reported）
 
@@ -207,7 +207,7 @@ The assumption is named ("assume 15% growth"), but the conditions that must hold
 
 ### 媒体估计（media estimate）
 
-数据来自彭博、T2/T3 媒体等第三方推断性来源。
+数据来自彭博、券商研究报告等第三方推断性来源（register 类型 `SECONDARY_MEDIA`、`SECONDARY_ANALYST`）。
 
 - 不得标注为 `[已确认事实]`
 - 应使用 `[推断]` 或具体来源角色如 `[彭博 estimate]`

--- a/references/source-traceability-and-claim-citation.md
+++ b/references/source-traceability-and-claim-citation.md
@@ -203,6 +203,18 @@ Good pattern:
 
 If a thesis-bearing claim cannot be made auditable in the body without awkwardness, that is usually a sign the claim should be narrowed, split, or downgraded.
 
+## 来源标注一致性 — Register-to-body label consistency
+
+使用 Source Register 时，register 对某个来源的可靠性/角色标注必须 ≥ 正文引用该来源时使用的标签强度。
+
+具体规则：
+
+- 当 register 标注某来源为 **厂商自述 / manufacturer self-reported**（如 `PRIMARY_COMPANY`、`PRIMARY_PARTNER`、或 register Notes 列注明"厂商自述"），正文引用该来源的数据时必须附加内联说明，如 `(来源：厂商自述，非独立验证)`，不得单独使用 `[已确认事实]`
+- 当来源为 **媒体估计**（彭博、T2/T3 媒体推断），正文不得标注为 `[已确认事实]`；应使用 `[推断]` 或具体角色如 `[彭博 estimate]`
+- 核心原则：**正文标签强度 ≤ register 标签强度**。register 标注弱于正文时触 blocker
+
+例外：如果 register 本身将某个来源明确标为 `PRIMARY_FILING` 或等效高可靠性类型，且正文标签与之匹配，则无需额外 caveat。
+
 ## Common failure patterns
 
 ### Pattern 1: Bibliography theater

--- a/references/source-traceability-and-claim-citation.md
+++ b/references/source-traceability-and-claim-citation.md
@@ -210,10 +210,14 @@ If a thesis-bearing claim cannot be made auditable in the body without awkwardne
 具体规则：
 
 - 当 register 标注某来源为 **厂商自述 / manufacturer self-reported**（如 `PRIMARY_COMPANY`、`PRIMARY_PARTNER`、或 register Notes 列注明"厂商自述"），正文引用该来源的数据时必须附加内联说明，如 `(来源：厂商自述，非独立验证)`，不得单独使用 `[已确认事实]`
-- 当来源为 **媒体估计**（彭博、T2/T3 媒体推断），正文不得标注为 `[已确认事实]`；应使用 `[推断]` 或具体角色如 `[彭博 estimate]`
-- 核心原则：**正文标签强度 ≤ register 标签强度**。register 标注弱于正文时触 blocker
+- 当来源为 **媒体估计**（SECONDARY_MEDIA 类型，如彭博、券商研究报告等第三方推断），正文不得标注为 `[已确认事实]`；应使用 `[推断]` 或具体角色如 `[彭博 estimate]`
+- 核心原则：**正文标签强度 ≤ register 标签强度**。register 标注弱于正文时视为标签通胀，应修正
+
+> 注：正文标签 `[已确认事实]` 通常对应 register 中的 `PRIMARY_FILING` 或等效高可靠性类型；`[推断]` 对应 `SECONDARY_MEDIA`、`SECONDARY_ANALYST`、`INFERRED`；`[未知]` 对应 `UNCONFIRMED`、`WEAK_SIGNAL`。此映射为经验性参考，具体 case 由审计员根据证据强度判断。
 
 例外：如果 register 本身将某个来源明确标为 `PRIMARY_FILING` 或等效高可靠性类型，且正文标签与之匹配，则无需额外 caveat。
+
+参见 `references/quantitative-role-labeling.md` §厂商声明与媒体估计的特殊标注规则，获取标注时机判断标准。
 
 ## Common failure patterns
 


### PR DESCRIPTION
## 改动

对应 Issue #164：Source Register 与正文的标签强度一致性纪律。

### 改了哪些

| 文件 | 改动 |
|------|------|
| `references/source-traceability-and-claim-citation.md` | 新增「来源标注一致性」章节 — register 标注强度必须 ≥ 正文标签强度；register 标"厂商自述"时正文必须附加内联 caveat；媒体估计不得标 [已确认事实] |
| `references/quantitative-role-labeling.md` | 新增「厂商声明与媒体估计的特殊标注规则」章节 — 厂商自述数据必须附加内联说明，媒体估计应使用 [推断] 或具体来源角色 |
| `checklists/final-audit.md` | 新增 2 个非阻塞检查项（厂商自述 inline caveat、媒体估计标签正确性） |
| `checklists/technical-analysis-audit.md` | 新增 2 个非阻塞检查项（厂商宣称来源角色标注、行内引用 caveat） |

### 不改什么

- 不改已有标签通胀检查（`listed-company-report.md` line 26 已有）
- 不改 eval cases（已记录问题）
- 不新增 hard-fail（所有新检查项为非阻塞）

### 验证

Round 2 以下 4 个 case 暴露的 recurring pattern 被覆盖：

- AI 电子警察（vendor claim register→body 不一致）
- TikTok AI（S19/S40 厂商自述 vs [确认事实]）
- 小红书 2025E（媒体估计标为 [确认事实]）
- 泡泡玛特 2025E（同上）

Closes #164