### PR TITLE
feat: 敏感性分析规范强化 — 情景分析 ≠ 敏感性分析 (#165)

### DIFF
--- a/checklists/quantitative-role-audit.md
+++ b/checklists/quantitative-role-audit.md
@@ -24,6 +24,7 @@ If load-bearing numbers materially affect the conclusion, their roles should be 
 
 - [BLOCKER] Has each load-bearing numerical assumption been classified by sensitivity level (low / medium / high) per `references/quantitative-role-labeling.md`?
 - [BLOCKER] High-sensitivity assumptions have a visible sensitivity table with at least ±20% and one wider amplitude (±50% or extreme scenario).
+- [NON-BLOCKER] If the report includes scenario analysis (optimistic / base / pessimistic), verify that key assumptions also have independent sensitivity tables. Multi-variable scenario changes do not satisfy the sensitivity table requirement — scenario analysis and sensitivity analysis are complementary, not substitutes.
 - [NON-BLOCKER] Medium-sensitivity assumptions have at least the tipping point documented (the deviation at which the conclusion would change direction).
 - [NON-BLOCKER] The report states which assumptions are most load-bearing and what would change the conclusion.
 

--- a/references/quantitative-role-labeling.md
+++ b/references/quantitative-role-labeling.md
@@ -120,7 +120,7 @@ Classify each key assumption by its impact on the conclusion. This determines th
 |----------------|------------|-----------------|-------------------|
 | **Low sensitivity** | Conclusion unchanged within ±20% deviation | ±20% | Conclusion is robust; label the sensitive variable |
 | **Medium sensitivity** | Conclusion direction unchanged but strength changes within ±20% | ±20%, ±50% | Conclusion holds conditionally; label the tipping point |
-| **High sensitivity** | Conclusion reverses within ±20% deviation | ±20%, ±50%, extreme scenario | Conclusion is assumption-dependent; reduce confidence or provide scenario analysis |
+| **High sensitivity** | Conclusion reverses within ±20% deviation | ±20%, ±50%, extreme scenario | Conclusion is assumption-dependent; reduce confidence. Both sensitivity table and scenario analysis required. |
 
 **情景分析 ≠ 敏感性分析**：情景分析同时变动多个假设（如乐观/基准/悲观三情景），读者无法看到单一关键假设变化对结论的独立影响。敏感性分析每次只变一个假设，揭示哪个变量是结论的转折点。当报告提供多情景分析时，仍需对高敏感性假设提供独立敏感性表（±20%、±50%）。两者互补而非替代。
 

--- a/references/quantitative-role-labeling.md
+++ b/references/quantitative-role-labeling.md
@@ -122,6 +122,8 @@ Classify each key assumption by its impact on the conclusion. This determines th
 | **Medium sensitivity** | Conclusion direction unchanged but strength changes within ±20% | ±20%, ±50% | Conclusion holds conditionally; label the tipping point |
 | **High sensitivity** | Conclusion reverses within ±20% deviation | ±20%, ±50%, extreme scenario | Conclusion is assumption-dependent; reduce confidence or provide scenario analysis |
 
+**情景分析 ≠ 敏感性分析**：情景分析同时变动多个假设（如乐观/基准/悲观三情景），读者无法看到单一关键假设变化对结论的独立影响。敏感性分析每次只变一个假设，揭示哪个变量是结论的转折点。当报告提供多情景分析时，仍需对高敏感性假设提供独立敏感性表（±20%、±50%）。两者互补而非替代。
+
 **Test amplitude selection**:
 
 - **Routine assumptions** (e.g., market growth rate, cost assumptions): test ±20% and ±50%
@@ -139,7 +141,7 @@ Classify each key assumption by its impact on the conclusion. This determines th
 
 - 敏感度等级: [低/中/高]
 - 临界点: [结论翻转的阈值]
-- 建议: [降低 confidence / 提供情景分析 / 维持现有结论]
+- 建议: [降低 confidence / 补充敏感性分析 / 维持现有结论]
 ```
 
 **When to apply this classification**:


### PR DESCRIPTION
## 背景

小红书 eval case (`evals/cases/xiaohongshu-startup-evaluation-traceability-benchmark-case.md`) 发现：报告提供了乐观/基准/悲观三情景分析，但缺少正式的敏感性分析表。quantitative-role-audit 标记为 BLOCKER。

**情景分析 ≠ 敏感性分析**。情景分析同时变动多个假设，读者无法看到单一关键假设变化对结论的独立影响。敏感性分析每次只变一个假设，揭示哪个变量是结论的转折点。

## 改动

### `references/quantitative-role-labeling.md`
- 在敏感性分类表后新增「情景分析 ≠ 敏感性分析」澄清段落
- 修正 High sensitivity table cell：`reduce confidence or provide scenario analysis` → `reduce confidence. Both sensitivity table and scenario analysis required.`（消除 `or` 的二选一误导）
- 将模板中的「提供情景分析」改为「补充敏感性分析」，避免自相矛盾

### `checklists/quantitative-role-audit.md`
- 在 BLOCKER（高敏感性假设需敏感性表）后新增 NON-BLOCKER 检查项：如果报告使用了情景分析，需验证关键假设是否有独立敏感性表

## Cross-review fix
PR #171 创建后经两个独立 subagent 交叉审核，发现 High sensitivity table cell 的 `or` 与新增段落矛盾（同一屏内读者看到冲突的指导）。已修复。

Closes #165