### PR TITLE
[P2] 路由声明纪律强化 — 反路由膨胀 + 次路由规模控制

### DIFF
--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -57,11 +57,13 @@ Declaring 2+ secondary routes without verifying their hard-fail conditions const
 Rules to prevent route inflation:
 
 - The declared route list must reflect **actual delivery scope**, not the most comprehensive coverage set. If the output behaves as a shared-workflow survey, declare it as shared-workflow rather than inflating the route list.
-- When 2+ secondary routes are declared, each secondary route's hard-fail conditions must be verifiably checked before delivery. Untested secondary route declarations are considered route inflation.
-- If secondary route content (tools, compliance, ROI, market outlook, etc.) exceeds roughly 25% of body text when paired with a primary route that requires minimizing those sections, consider using Shared-Workflow or simplifying the route declaration set.
+- When 2+ secondary routes are declared, the hard-fail check status of each must be explicitly verifiable in the process log or artifact (not assumed covered by the primary route's checks). Absent evidence of per-route verification, the declarations constitute route inflation.
+- If the share of body text consumed by secondary-route content (tools, compliance, ROI, market outlook, etc.) exceeds roughly 25% — especially when the primary route requires minimizing those sections (e.g., Technical Deep-dive minimizes tools-overview sections) — consider using Shared-Workflow or simplifying the route declaration set.
 - If the total route count (primary + secondary) exceeds 3, re-examine scope focus — the task may be better served by a narrower primary route or a shared-workflow path.
 
 When in doubt, declare fewer routes with verified hard-fails rather than more routes with unchecked assumptions.
+
+> **Note on terms:** "Secondary routes" in this section refers only to specialized routes used as secondary disciplines (e.g., Provider Selection attached to a Market Outlook primary), not to cross-cutting disciplines like source traceability or current-state verification. The distinction is defined in `references/route-activation-and-preflight.md` Step 2.
 
 ## Route execution contract
 

--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -50,6 +50,19 @@ Do not activate everything. Activate the smallest set that produces a decision-u
 
 When a report declares multiple routes (primary + secondary), the hard-fail conditions of **all** declared routes must be verified. A secondary route's hard-fail conditions may not be skipped because it is "secondary." If a hard-fail condition is genuinely inapplicable to the task, document the inapplicability reason rather than skipping the check silently.
 
+### Route inflation warning
+
+Declaring 2+ secondary routes without verifying their hard-fail conditions constitutes **route inflation** — the route list suggests structured methodology, but the unchecked hard-fails create a quality-control blind spot.
+
+Rules to prevent route inflation:
+
+- The declared route list must reflect **actual delivery scope**, not the most comprehensive coverage set. If the output behaves as a shared-workflow survey, declare it as shared-workflow rather than inflating the route list.
+- When 2+ secondary routes are declared, each secondary route's hard-fail conditions must be verifiably checked before delivery. Untested secondary route declarations are considered route inflation.
+- If secondary route content (tools, compliance, ROI, market outlook, etc.) exceeds roughly 25% of body text when paired with a primary route that requires minimizing those sections, consider using Shared-Workflow or simplifying the route declaration set.
+- If the total route count (primary + secondary) exceeds 3, re-examine scope focus — the task may be better served by a narrower primary route or a shared-workflow path.
+
+When in doubt, declare fewer routes with verified hard-fails rather than more routes with unchecked assumptions.
+
 ## Route execution contract
 
 Before synthesis, convert the selected route into a compact execution contract.

--- a/SKILL.md
+++ b/SKILL.md
@@ -51,6 +51,7 @@ Read `ROUTING-MATRIX.md` to select:
 Read `references/route-activation-and-preflight.md` when a specialized route is being considered, and complete its preflight steps before finalizing route selection:
 - "Do not use" / "Often confused with" clause check
 - secondary-route hard-fail verification
+- route declaration scale check
 - execution contract formation
 
 Before deep collection, explicitly select one primary route. If no mature specialized route applies, treat the task as a shared-workflow task (the delivery-time final discipline handles audit selection: see step 3 and 6 below).

--- a/checklists/route-activation-audit.md
+++ b/checklists/route-activation-audit.md
@@ -10,6 +10,8 @@ It audits whether route activation was explicit and whether the route actually s
 - [ ] the closest alternative route was identified and a reason exists for why the chosen route wins
 - [ ] the selected route's "Do not use" / "Often confused with" clauses from `ROUTING-MATRIX.md` were checked before finalizing; if the task matched a disqualifying condition, the route was reconsidered or the boundary judgment was documented
 - [ ] if a secondary route is declared, its hard-fail conditions from `ROUTING-MATRIX.md` were verified at selection time (not deferred to delivery); if a condition is inapplicable, the reason is documented
+- [ ] when 2+ secondary routes are declared, each secondary route's hard-fail check status is explicitly listed (not assumed covered by the primary route's checks)
+- [ ] secondary route body-space ratio is reasonable (secondary-route content does not exceed ~25% of body text when the primary route requires minimizing those sections; if it does, consider shared-workflow declaration or route simplification)
 - [ ] a compact execution contract exists before synthesis: opening mandate, mandatory sections, hard-fail conditions, minimize / move later
 - [ ] all required audits for this route (from `ROUTING-MATRIX.md` `### Audit` section) are identified and confirmed executed before delivery (results visible in the artifact or process log); if any required audit is missing, it is run before the report is considered ready; if any required audit was intentionally skipped, the reason is documented
 

--- a/checklists/route-activation-audit.md
+++ b/checklists/route-activation-audit.md
@@ -11,7 +11,8 @@ It audits whether route activation was explicit and whether the route actually s
 - [ ] the selected route's "Do not use" / "Often confused with" clauses from `ROUTING-MATRIX.md` were checked before finalizing; if the task matched a disqualifying condition, the route was reconsidered or the boundary judgment was documented
 - [ ] if a secondary route is declared, its hard-fail conditions from `ROUTING-MATRIX.md` were verified at selection time (not deferred to delivery); if a condition is inapplicable, the reason is documented
 - [ ] when 2+ secondary routes are declared, each secondary route's hard-fail check status is explicitly listed (not assumed covered by the primary route's checks)
-- [ ] secondary route body-space ratio is reasonable (secondary-route content does not exceed ~25% of body text when the primary route requires minimizing those sections; if it does, consider shared-workflow declaration or route simplification)
+- [ ] the total route count (primary + secondary) was reviewed: if it exceeds 3, scope focus was re-examined and the decision to keep the current route set is documented
+- [ ] secondary body-text share is reasonable (secondary-route content does not exceed roughly 25% of body text when the primary route requires minimizing those sections; if it does, consider shared-workflow declaration or route simplification)
 - [ ] a compact execution contract exists before synthesis: opening mandate, mandatory sections, hard-fail conditions, minimize / move later
 - [ ] all required audits for this route (from `ROUTING-MATRIX.md` `### Audit` section) are identified and confirmed executed before delivery (results visible in the artifact or process log); if any required audit is missing, it is run before the report is considered ready; if any required audit was intentionally skipped, the reason is documented
 

--- a/evals/cases/tiktok-ai-technical-deep-dive-route-inflation-case.md
+++ b/evals/cases/tiktok-ai-technical-deep-dive-route-inflation-case.md
@@ -70,7 +70,7 @@ A good answer should:
 2. **Feasibility conclusion present** — technical deep-dive must end with a clear "feasible / conditionally feasible / not feasible" summary
 3. **Vendor claim labeling consistent** — if Source Register says "manufacturer self-reported", body text must also say so (inline caveat, not just register metadata)
 4. **Forward-looking dependency conditions** — each predicted timeline must state the assumption ("if X reaches Y") and the failure trigger ("if Z does not happen by date W")
-5. **Minimize discipline** — secondary-route content (tools, compliance, ROI) does not exceed 20% of body text when primary route is Technical Deep-dive
+5. **Minimize discipline** — secondary-route content (tools, compliance, ROI) does not exceed roughly 25% of body text when primary route is Technical Deep-dive (matching the global rule in `ROUTING-MATRIX.md` Route inflation warning; Technical Deep-dive's tighter minimize discipline may justify a stricter local target in future eval updates)
 
 ## Failure signs
 

--- a/references/route-activation-and-preflight.md
+++ b/references/route-activation-and-preflight.md
@@ -68,9 +68,9 @@ If the preflight identifies a secondary route, its hard-fail conditions must be 
 After verifying secondary-route hard-fail conditions (Step 2), review the overall route declaration scale:
 
 - Count the total declared routes (primary + secondary). If the count exceeds 3, re-examine scope focus. A task that needs 4+ specialized routes may be better served by a shared-workflow path with clear emphasis notes rather than an inflated route list.
-- Estimate the combined body-space share of secondary-route content (tools comparison, compliance, market outlook, ROI, etc.). If this share exceeds roughly 25% of body text and the primary route requires minimizing those sections (e.g., Technical Deep-dive requires minimizing tools-overview sections), consider:
+- Estimate the combined share of body text consumed by secondary-route content (tools comparison, compliance, market outlook, ROI, etc.). If this share exceeds roughly 25% of body text and the primary route requires minimizing those sections (e.g., Technical Deep-dive requires minimizing tools-overview sections), consider:
   - simplifying the secondary route set to only the routes whose hard-fail conditions can be meaningfully verified
-  - or declaring the task as shared-workflow with technical-analysis emphasis rather than inflating the route list
+  - or declaring the task as shared-workflow rather than inflating the route list (a shared-workflow path with [primary route] emphasis is more honest than four declarable but unchecked routes)
 - Document the decision: if the total route count is >3 or secondary content exceeds 25%, explain why the current route set is still the smallest complete set that produces a decision-useful, auditable output.
 
 Treat this step as a **scope-focus gate**, not a hard rejection. The goal is to surface scope diffusion early so the route list can be narrowed or the primary route re-evaluated, rather than discovering at delivery time that declared routes were not executable.

--- a/references/route-activation-and-preflight.md
+++ b/references/route-activation-and-preflight.md
@@ -61,7 +61,21 @@ If the preflight identifies a secondary route, its hard-fail conditions must be 
 - If a condition is genuinely inapplicable to the task (e.g., "market snapshot hard-fail does not apply because the secondary route is listed-company but the task does not involve company-level market data"), document the inapplicability reason explicitly.
 - Do not skip this step because the secondary route is "secondary" — the hard-fail conditions of all declared routes apply equally.
 
-### Step 3: Execution contract
+### Step 3: Route declaration scale check
+
+**This step detects route inflation before it propagates into the report structure.**
+
+After verifying secondary-route hard-fail conditions (Step 2), review the overall route declaration scale:
+
+- Count the total declared routes (primary + secondary). If the count exceeds 3, re-examine scope focus. A task that needs 4+ specialized routes may be better served by a shared-workflow path with clear emphasis notes rather than an inflated route list.
+- Estimate the combined body-space share of secondary-route content (tools comparison, compliance, market outlook, ROI, etc.). If this share exceeds roughly 25% of body text and the primary route requires minimizing those sections (e.g., Technical Deep-dive requires minimizing tools-overview sections), consider:
+  - simplifying the secondary route set to only the routes whose hard-fail conditions can be meaningfully verified
+  - or declaring the task as shared-workflow with technical-analysis emphasis rather than inflating the route list
+- Document the decision: if the total route count is >3 or secondary content exceeds 25%, explain why the current route set is still the smallest complete set that produces a decision-useful, auditable output.
+
+Treat this step as a **scope-focus gate**, not a hard rejection. The goal is to surface scope diffusion early so the route list can be narrowed or the primary route re-evaluated, rather than discovering at delivery time that declared routes were not executable.
+
+### Step 4: Execution contract
 
 Before deep collection begins, write a compact execution contract that the final artifact must satisfy. This contract operationalizes the "Required artifact contract" field from the Minimal internal shape below.
 


### PR DESCRIPTION
## 问题

TikTok AI case 发现：报告声明了 1 条主路由（Technical Deep-dive）+ 3 条次路由（市场展望、服务商对比、合规分析），但 3 条次路由的 hard-fail 条件均未在交付前验证。Provider Selection 的 "变成 vendor overview 而非 choice memo" hard-fail 被触发。

这暴露了两个缺口：
1. **声明多条路由缺乏纪律** — 声明 3+ 次路由但无对应验证 = 路由膨胀
2. **次路由 hard-fail 与主路由 scope 冲突** — Technical Deep-dive 要求"最小化"的章节（工具对比占正文 35%），与声明了 Provider Selection 次路由直接矛盾

Round 1 #148 已经要求在路由激活前置流程中检查次路由 hard-fail。但此 case 显示即使有这条规则，声明过多次路由本身就会导致 scope 扩散——需要更前置的"路由膨胀检测"。

## 改动

### ROUTING-MATRIX.md
在 Global rule 区新增 **Route inflation warning** subsection：
- 声明 2+ 次路由时，各次路由的 hard-fail 条件必须在交付前逐一验证；未验证的次路由声明视为路由膨胀
- 次路由内容合计超过正文 ~25% 时，考虑改用 Shared-Workflow 或精简路由声明
- 路由声明列表应反映实际交付内容，而非"最完整"的覆盖集
- 术语说明："secondary routes" 指专用路由作为次路由，非跨领域规范

### checklists/route-activation-audit.md
Preflight 区新增 3 个检查项：
- [ ] 当声明 2+ 次路由时，列出各次路由的 hard-fail 检查状态
- [ ] 总路由数（主+次）> 3 时，scope focus 已重新审视且记录决策
- [ ] 次路由的正文篇幅占比合理（不超过 ~25%）

### references/route-activation-and-preflight.md
新增 **Step 3: Route declaration scale check**：
- 统计声明的路由总数（主+次）；如果 >3，检查 scope 聚焦性
- 如果工具/合规/ROI 等非技术内容合计 >25%，考虑使用 Shared-Workflow
- 原 Step 3 (Execution contract) 顺延为 Step 4

### SKILL.md
预飞行步骤列表新增本检查步骤

### evals/cases/tiktok-ai-technical-deep-dive-route-inflation-case.md
篇幅阈值 20% → 25%，对齐全局规则

## 验证标准
- 声明 3+ 次路由时，route-activation-audit 会检查各次路由 hard-fail 状态
- 主路由 scope 被次路由内容挤压超过 ~25% 时会被标记

Closes #166