### PR TITLE
[P1] 执行一致性强化 — 审计运行状态可追溯 + 跨章节标签一致性检查

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,12 +137,13 @@ This file is intentionally lightweight. Use concise entries that explain:
 - Per issue #124 (P2), selection tasks with major execution uncertainty lacked structured post-decision branch planning. The existing scenario logic (Step 7) and change-the-conclusion sections handle pre-decision ranking changes, but do not cover post-decision execution branching (success / blocked / all-blocked paths with trigger conditions and monitoring signals). Added a focused reference file and wired it into option-selection discipline and audit checklist.
 
 ### Changed
-- `SKILL.md`: strengthened Step 6 — audit verification now requires explicit run status per audit (**已通过** / **已跳过+理由** / **未运行+理由**) rather than a binary "run or not" check (#176).
+- `SKILL.md`: strengthened Step 6 — audit verification now requires explicit tri-state run status per audit (**已通过（附证据）** / **已跳过（附理由）** / **未运行（附理由）**) rather than a binary "run or not" check (#176).
 - `checklists/final-audit.md`: added two non-blocker checks — cross-chapter label consistency (same data, same label across chapters) and required audits run-status visibility in artifact or process log (#176).
-- `checklists/route-activation-audit.md`: hardened Preflight audit-status item — each required audit must carry an explicit run-status marker with evidence or documented skip/inapplicability reason (#176).
+- `checklists/route-activation-audit.md`: hardened Preflight audit-status item — each required audit must carry an explicit tri-state run-status marker with evidence or documented skip/inapplicability reason (#176).
+- `ROUTING-MATRIX.md`: synced Final check section to tri-state wording, matching SKILL.md Step 6 (#176).
 
 ### Why
-Round 3 execution revealed that audit checklists were sometimes skipped or their run status was not recoverable. Three eval cases confirmed the pattern (Tencent vs Meituan label consistency gap, Meituan near-zero inline citations, Dark Matter required audits not run). The fix does not add new rules — it makes audit execution status visible and traceable before delivery, targeting execution drift rather than missing rules (#176).
+Round 3 execution revealed that audit checklists were sometimes skipped or their run status was not recoverable. Three eval cases confirmed the pattern (Tencent vs Meituan label consistency gap, Meituan near-zero inline citations, Dark Matter required audits not run). No new audit checklist files were added — the fix hardens existing rules with explicit tri-state status recording and synchronizes ROUTING-MATRIX.md with SKILL.md's updated workflow, targeting execution drift rather than missing rules (#176).
 
 ## 0.4.0 - 2026-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,14 @@ This file is intentionally lightweight. Use concise entries that explain:
 - Per issue #96 (P1), 11 comparative distillation cases existed but lacked a cross-case candidate rule registry. The registry confirms all PROMOTE_NOW candidates are already covered by existing checklists and references; no new promotion is needed. The main gap has shifted from missing rules to execution/activation discipline.
 - Per issue #124 (P2), selection tasks with major execution uncertainty lacked structured post-decision branch planning. The existing scenario logic (Step 7) and change-the-conclusion sections handle pre-decision ranking changes, but do not cover post-decision execution branching (success / blocked / all-blocked paths with trigger conditions and monitoring signals). Added a focused reference file and wired it into option-selection discipline and audit checklist.
 
+### Changed
+- `SKILL.md`: strengthened Step 6 — audit verification now requires explicit run status per audit (**已通过** / **已跳过+理由** / **未运行+理由**) rather than a binary "run or not" check (#176).
+- `checklists/final-audit.md`: added two non-blocker checks — cross-chapter label consistency (same data, same label across chapters) and required audits run-status visibility in artifact or process log (#176).
+- `checklists/route-activation-audit.md`: hardened Preflight audit-status item — each required audit must carry an explicit run-status marker with evidence or documented skip/inapplicability reason (#176).
+
+### Why
+Round 3 execution revealed that audit checklists were sometimes skipped or their run status was not recoverable. Three eval cases confirmed the pattern (Tencent vs Meituan label consistency gap, Meituan near-zero inline citations, Dark Matter required audits not run). The fix does not add new rules — it makes audit execution status visible and traceable before delivery, targeting execution drift rather than missing rules (#176).
+
 ## 0.4.0 - 2026-03-31
 
 ### Added

--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -980,9 +980,9 @@ Before delivery:
 - run `checklists/route-activation-audit.md` when a specialized route was selected
 - run `checklists/workflow-spine-audit.md`
 - run `checklists/final-audit.md`
-- verify that the required audits for the task were executed:
-  - if a specialized route was selected: confirm all audits listed in that route's `### Audit` section were run
-  - if no specialized route applies (shared-workflow path): confirm at least `workflow-spine-audit.md` and `final-audit.md` were run
+- verify that all required audits for the task have been executed, with each audit's run status recorded:
+  - if a specialized route was selected: for each audit listed in that route's `### Audit` section, confirm its run status: **已通过** (passed), **已跳过（附理由）** (skipped, with documented reason), or **未运行（附理由）** (not run, with documented reason)
+  - if no specialized route applies (shared-workflow path): confirm at least `workflow-spine-audit.md` and `final-audit.md` were run, with run status recorded
 
 Then ask (route-selected only — skip these if no specialized route applies):
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -380,10 +380,11 @@ Before delivery:
 5. confirm that the required artifact contract is visibly satisfied:
    - if a specialized route was selected, confirm the route's artifact contract is visibly executed in the final artifact
    - if no specialized route applies (shared-workflow path), confirm the shared workflow spine is visibly executed instead
-6. verify that all required audits for the task have been executed:
-   - if a specialized route was selected, confirm all audits listed in its `### Audit` section in `ROUTING-MATRIX.md` were run
-   - if no specialized route applies (shared-workflow path), confirm at least `workflow-spine-audit.md` and `final-audit.md` were run
-   - if a required audit is missing, run it before proceeding
+6. verify that all required audits for the task have been executed, with each audit's run status recorded:
+   - if a specialized route was selected, list all audits listed in its `### Audit` section in `ROUTING-MATRIX.md`
+   - if no specialized route applies (shared-workflow path), list at least `workflow-spine-audit.md` and `final-audit.md`
+   - for each listed audit, confirm one of these statuses: **已通过** (passed), **已跳过+理由** (skipped, with documented reason), or **未运行+理由** (not run, with documented reason)
+   - if any required audit is missing or not run, run it before proceeding, or document why it should not apply
 
 A report that sounds informed but does not visibly satisfy its required artifact contract (route-specific or shared-workflow) is not ready.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -383,8 +383,8 @@ Before delivery:
 6. verify that all required audits for the task have been executed, with each audit's run status recorded:
    - if a specialized route was selected, list all audits listed in its `### Audit` section in `ROUTING-MATRIX.md`
    - if no specialized route applies (shared-workflow path), list at least `workflow-spine-audit.md` and `final-audit.md`
-   - for each listed audit, confirm one of these statuses: **已通过** (passed), **已跳过+理由** (skipped, with documented reason), or **未运行+理由** (not run, with documented reason)
-   - if any required audit is missing or not run, run it before proceeding, or document why it should not apply
+   - for each listed audit, confirm one of these statuses: **已通过** (passed, with evidence visible in the artifact or process log), **已跳过（附理由）** (skipped, with documented reason), or **未运行（附理由）** (not run, with documented reason)
+   - if any required audit is missing or not run, run it before proceeding, or document the reason (skipped / not run / not applicable)
 
 A report that sounds informed but does not visibly satisfy its required artifact contract (route-specific or shared-workflow) is not ready.
 

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -50,6 +50,8 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] meaningful uncertainties are recorded rather than only implied
 - [ ] where the task warrants it, counter-evidence handling is recoverable from the process artifact
 - [ ] required audits are named and statused rather than merely assumed
+- [ ] (非阻塞) each declared route's required audits have a visible run status (passed / skipped+reason / not run+reason) in the artifact or process log
+- [ ] (非阻塞) cross-chapter label consistency: the same data point uses the same evidence label across all chapters; if the uncertainty register lists an item, bull/bear sections that reference it should cross-reference or maintain a consistent confidence level
 - [ ] if the task used a specialized route, there is visible evidence that the route was turned into an execution contract before full drafting
 
 ## Route execution integrity

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -50,7 +50,7 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] meaningful uncertainties are recorded rather than only implied
 - [ ] where the task warrants it, counter-evidence handling is recoverable from the process artifact
 - [ ] required audits are named and statused rather than merely assumed
-- [ ] (非阻塞) each declared route's required audits have a visible run status (passed / skipped+reason / not run+reason) in the artifact or process log
+- [ ] (非阻塞) each declared route's required audits have a visible run status — **已通过** (passed), **已跳过（附理由）** (skipped, with documented reason), or **未运行（附理由）** (not run, with documented reason) — in the artifact or process log
 - [ ] (非阻塞) cross-chapter label consistency: the same data point uses the same evidence label across all chapters; if the uncertainty register lists an item, bull/bear sections that reference it should cross-reference or maintain a consistent confidence level
 - [ ] if the task used a specialized route, there is visible evidence that the route was turned into an execution contract before full drafting
 

--- a/checklists/route-activation-audit.md
+++ b/checklists/route-activation-audit.md
@@ -14,7 +14,7 @@ It audits whether route activation was explicit and whether the route actually s
 - [ ] the total route count (primary + secondary) was reviewed: if it exceeds 3, scope focus was re-examined and the decision to keep the current route set is documented
 - [ ] secondary body-text share is reasonable (secondary-route content does not exceed roughly 25% of body text when the primary route requires minimizing those sections; if it does, consider shared-workflow declaration or route simplification)
 - [ ] a compact execution contract exists before synthesis: opening mandate, mandatory sections, hard-fail conditions, minimize / move later
-- [ ] all required audits for this route (from `ROUTING-MATRIX.md` `### Audit` section) are identified and each has an explicit run status: **已通过** (passed, with evidence visible in the artifact or process log), **已跳过+理由** (skipped, with documented reason), or **未运行+理由** (not run, with documented reason); if any required audit is missing, it is run before the report is considered ready
+- [ ] all required audits for this route (from `ROUTING-MATRIX.md` `### Audit` section) are identified and each has an explicit run status: **已通过** (passed, with evidence visible in the artifact or process log), **已跳过（附理由）** (skipped, with documented reason), or **未运行（附理由）** (not run, with documented reason); if any required audit is missing, it is run before the report is considered ready
 
 ## Route selection visibility
 

--- a/checklists/route-activation-audit.md
+++ b/checklists/route-activation-audit.md
@@ -14,7 +14,7 @@ It audits whether route activation was explicit and whether the route actually s
 - [ ] the total route count (primary + secondary) was reviewed: if it exceeds 3, scope focus was re-examined and the decision to keep the current route set is documented
 - [ ] secondary body-text share is reasonable (secondary-route content does not exceed roughly 25% of body text when the primary route requires minimizing those sections; if it does, consider shared-workflow declaration or route simplification)
 - [ ] a compact execution contract exists before synthesis: opening mandate, mandatory sections, hard-fail conditions, minimize / move later
-- [ ] all required audits for this route (from `ROUTING-MATRIX.md` `### Audit` section) are identified and confirmed executed before delivery (results visible in the artifact or process log); if any required audit is missing, it is run before the report is considered ready; if any required audit was intentionally skipped, the reason is documented
+- [ ] all required audits for this route (from `ROUTING-MATRIX.md` `### Audit` section) are identified and each has an explicit run status: **已通过** (passed, with evidence visible in the artifact or process log), **已跳过+理由** (skipped, with documented reason), or **未运行+理由** (not run, with documented reason); if any required audit is missing, it is run before the report is considered ready
 
 ## Route selection visibility
 


### PR DESCRIPTION
## 问题

Round 3 中 5/10 案例暴露了执行一致性问题：Round 1 和 Round 2 的修复规则存在，但不同输出之间执行质量差异巨大。

最典型的对比是腾讯 vs 美团——同一天、同一系统产出：

| 维度 | 腾讯 (R3#2) | 美团 (R3#3) |
|------|-----------|-----------|
| 行内引用 | 800+ 一致标签 + 完整 register | 448 行仅 1 个 `[S6]` |
| 裸"预计" | 0 | §0 和 §4.4 各 1 处 |
| 锚定块 | ✅ 完整 | ✅ 完整 |
| Hard-fail | 全部通过 | 全部通过 |

根本原因不是规则缺失（Round 1 #145 + Round 2 #163/164 已有规则），而是**交付前 checklist 是否被实际运行不可追溯**。

## 改动范围

### `SKILL.md`
Step 6 强化：从二元确认（"已运行/未运行"）升级为三态记录——
- 列出所有声明的路由的 required audits
- 逐一确认运行状态：**已通过（附证据）** / **已跳过（附理由）** / **未运行（附理由）**
- 缺失或未运行的处理规则

### `checklists/final-audit.md`
新增两项非阻塞检查：
- **跨章节标签一致性**：同一数据点在不同章节使用相同证据标签；uncertainty register 与 bull/bear 中引用的同一数据应保持一致
- **Required audits 运行状态**：每个声明的路由的 required audits 有可见的三态运行状态记录

### `checklists/route-activation-audit.md`
Preflight audit-status 项强化：每项 required audit 必须有显式三态运行状态标记，带证据或已记录跳过理由

### `ROUTING-MATRIX.md`
Final check 区段同步更新至三态措辞，与 SKILL.md Step 6 保持一致

## 交叉审核修复

经两个独立 subagent 交叉审核后修复的问题：
- ROUTING-MATRIX.md Final check 未同步 → 已补齐
- final-audit.md 三态名与核心文件格式不一致 → 已统一为粗体中文 + （附理由）
- SKILL.md "已通过"缺少 evidence 可见性要求 → 已补充
- "should not apply" 范围偏窄 → 已扩展为 (skipped / not run / not applicable)
- CHANGELOG "does not add new rules" 表述有误导 → 已澄清为 "No new audit checklist files were added"

## 验证标准
- 每个声明的路由的 required audits 运行状态在交付前可追溯（已通过 / 已跳过+理由 / 未运行+理由）
- 同一数据点在不同章节使用一致的证据标签
- 三态名称在 5 个文件中完全一致

Closes #176