### PR TITLE
feat: 情景定量口径标准化 — 多情景共用量度轴 + 方向性概率标签

### DIFF
--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -134,7 +134,7 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] for market-outlook / industry-evolution tasks, a current market snapshot was verified before forward-looking sections
 - [ ] for market-outlook / industry-evolution tasks, drivers, blockers, scenarios, and stakeholder implications are explicit rather than implied
 - [ ] for market-outlook / industry-evolution tasks, all forward-looking claims have visible source role and time basis; derived, modeled, or load-bearing forecasts also show key assumptions and failure / reversal conditions
-- [ ] for market-outlook / industry-evolution tasks, structured multi-scenario analysis exists (at minimum base case + one alternative) with quantitative ranges and trigger conditions
+- [ ] for market-outlook / industry-evolution tasks, structured multi-scenario analysis exists (at minimum base case + one alternative) with quantitative ranges on the same load-bearing metric and trigger conditions
 - [ ] for market-outlook / industry-evolution tasks, stakeholder implications cover at least 3 distinct stakeholder types, not only investors
 - [ ] for market-outlook / industry-evolution tasks, the task's core output is direction/evolution/trajectory — not ranking, prediction, or selection among defined options
 - [ ] for first-tier / top-tier / multidimensional positioning tasks, scope, metric, timeframe, and dimension-level conclusions are visible before any overall label

--- a/checklists/market-outlook-audit.md
+++ b/checklists/market-outlook-audit.md
@@ -33,7 +33,7 @@ Run this checklist before delivery.
 ## Structured multi-scenario analysis
 
 - [ ] at minimum a base case and one credible alternative scenario exist
-- [ ] each scenario has a quantitative range for the load-bearing metric
+- [ ] all scenarios share the same load-bearing metric as their quantitative axis — no mixing different metrics
 - [ ] each scenario has explicitly stated key assumptions
 - [ ] each scenario has observable trigger conditions that would signal it is becoming more or less likely
 - [ ] when uncertainty is material, three scenarios (optimistic / base / pessimistic) are present

--- a/references/market-outlook-and-scenario-discipline.md
+++ b/references/market-outlook-and-scenario-discipline.md
@@ -146,12 +146,12 @@ For each scenario:
 
 ### Scenario quantitative axis consistency
 
-All scenarios must share the **same load-bearing metric** as their quantitative expression axis. Do not use different metrics across scenarios — the reader must be able to compare all paths on one dimension.
+All scenarios must share the **same load-bearing metric** as their quantitative axis. Do not use different metrics across scenarios — the reader must be able to compare all paths on one dimension.
 
 ✅ Correct: base "30-40% penetration" / upside "50-60%" / downside "15-25%"
 ❌ Incorrect: base "user decline 30-50%" / upside "70%+" / downside no equivalent metric
 
-Probability weight annotation is recommended when evidence supports it, but not required. Do not assign precise probabilities when the evidence base cannot support that precision — use directional labels (most likely / upside / downside) instead of numerical percentages.
+Probability weight annotation is recommended when evidence supports it, but not required. Do not assign precise probabilities when the evidence base cannot support that precision — use directional labels (most likely / upside / downside) or bounded ranges with explicit uncertainty caveats instead of numerical percentages. Precise probabilities are only justified when backed by robust quantitative models or large-sample statistical evidence.
 
 A market-outlook report with only one scenario is not an outlook memo. It is a forecast with no uncertainty structure.
 
@@ -289,7 +289,7 @@ The report uses Market Outlook for a task whose core output is ranking, predicti
 ### Failure mode 9: Probability precision illusion
 The report assigns precise probability percentages (e.g., "15-20%", "23%") to inherently uncertain outcomes where the evidence base cannot support that level of precision.
 
-**Fix:** Use directional labels (more likely / less likely / comparable likelihood) or bounded ranges with explicit uncertainty caveats. Precise probabilities are only justified when backed by robust quantitative models or large-sample statistical evidence.
+**Fix:** Use directional labels (most likely / upside / downside) or bounded ranges with explicit uncertainty caveats. Precise probabilities are only justified when backed by robust quantitative models or large-sample statistical evidence.
 
 ---
 

--- a/references/market-outlook-and-scenario-discipline.md
+++ b/references/market-outlook-and-scenario-discipline.md
@@ -144,7 +144,14 @@ For each scenario:
 - state the key assumptions that must hold for this scenario to materialize
 - state the observable trigger conditions that would signal this scenario is becoming more or less likely
 
-Probability weight annotation is recommended when evidence supports it, but not required. Do not assign precise probabilities when the evidence base cannot support that precision — use directional labels (more likely / less likely) instead.
+### Scenario quantitative axis consistency
+
+All scenarios must share the **same load-bearing metric** as their quantitative expression axis. Do not use different metrics across scenarios — the reader must be able to compare all paths on one dimension.
+
+✅ Correct: base "30-40% penetration" / upside "50-60%" / downside "15-25%"
+❌ Incorrect: base "user decline 30-50%" / upside "70%+" / downside no equivalent metric
+
+Probability weight annotation is recommended when evidence supports it, but not required. Do not assign precise probabilities when the evidence base cannot support that precision — use directional labels (most likely / upside / downside) instead of numerical percentages.
 
 A market-outlook report with only one scenario is not an outlook memo. It is a forecast with no uncertainty structure.
 


### PR DESCRIPTION
Closes #177

## 改动

### `references/market-outlook-and-scenario-discipline.md`

在 Structured multi-scenario analysis 章节新增 **Scenario quantitative axis consistency** 小节：

- 多情景必须使用**同一 load-bearing metric** 作为定量轴线
- 提供正确/错误示例
- 强化概率权重标签措辞：使用方向性标签（most likely / upside / downside）替代数值百分比

已有 Failure mode 9（概率精度幻觉）保持不变，与之互补。

### `checklists/market-outlook-audit.md`

同步强化清单第36条：从 "each scenario has a quantitative range for the load-bearing metric" 改为 "all scenarios share the same load-bearing metric as their quantitative axis — no mixing different metrics"。

## 背景

两个 Round 3 Market Outlook eval case 暴露了此缺口：
- `app-vs-agent-market-outlook-register-scenario-case.md` — 三情景无共同度量轴，被标为 Conditional Pass 扣分项
- `ai-data-center-market-outlook-register-completeness-case.md` — 55%/25%/20% 概率精度问题（#165 已修但执行层尚未完全落地）

## 验证

- diff 只含 2 个文件、+9/-2 行
- 不涉及新文件、新脚本、SKILL.md、ROUTING-MATRIX.md
- 已有 Failure mode 9 与新小节互补不冲突
