### PR TITLE
[P1] 量化角色标签表格化 — 让数字角色成为表格的默认列 (#183)

### DIFF
--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -162,6 +162,7 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] heuristic timing, cost, payback, or ROI-style claims are not written as if they were directly observed facts when they are closer to assumptions or planning-model outputs
 - [ ] （非阻塞）Source Register 中类型为 PRIMARY_COMPANY/PRIMARY_PARTNER/简化类型的 vendor-claim，或 Notes 标注"厂商自述"的来源，在正文引用时附加了内联说明 `(来源：厂商自述，非独立验证)`（见 `references/source-traceability-and-claim-citation.md` §来源标注一致性）
 - [ ] （非阻塞）SECONDARY_MEDIA / SECONDARY_ANALYST 类型来源（媒体估计、券商研报）未在正文中标注为 [已确认事实]（使用 [推断] 或具体来源角色替代）
+- [ ] （非阻塞）所有比较表、评分表、估算表包含数字角色列（或等效的行标/表注），读者无需回正文即可从表格行判断数字性质（观察值/代理指标/假设/模型输出）。单角色表可以在表注声明；多角色表必须有独立列或表头角色行。见 `references/quantitative-role-labeling.md` §表格中的角色标签
 
 ## Metric-scope audit
 

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -162,7 +162,7 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] heuristic timing, cost, payback, or ROI-style claims are not written as if they were directly observed facts when they are closer to assumptions or planning-model outputs
 - [ ] （非阻塞）Source Register 中类型为 PRIMARY_COMPANY/PRIMARY_PARTNER/简化类型的 vendor-claim，或 Notes 标注"厂商自述"的来源，在正文引用时附加了内联说明 `(来源：厂商自述，非独立验证)`（见 `references/source-traceability-and-claim-citation.md` §来源标注一致性）
 - [ ] （非阻塞）SECONDARY_MEDIA / SECONDARY_ANALYST 类型来源（媒体估计、券商研报）未在正文中标注为 [已确认事实]（使用 [推断] 或具体来源角色替代）
-- [ ] （非阻塞）所有比较表、评分表、估算表包含数字角色列（或等效的行标/表注），读者无需回正文即可从表格行判断数字性质（观察值/代理指标/假设/模型输出）。单角色表可以在表注声明；多角色表必须有独立列或表头角色行。见 `references/quantitative-role-labeling.md` §表格中的角色标签
+- [ ] （非阻塞）所有比较表、评分表、估算表包含数字角色列（或等效的表头角色行/表注），读者无需回正文即可从表格行判断数字性质（观察值/代理指标/假设/模型输出）。单角色表可以在表注声明；多角色表必须有独立列或表头角色行。见 `references/quantitative-role-labeling.md` §表格中的角色标签
 
 ## Metric-scope audit
 

--- a/references/quantitative-role-labeling.md
+++ b/references/quantitative-role-labeling.md
@@ -247,6 +247,51 @@ Quantitative role may be shown through:
 The format may vary.
 Role visibility may not.
 
+## 表格中的角色标签
+
+When numbers appear in comparison tables, scoring tables, or estimation tables, the role label must be visible **at the table level** — not only in the surrounding prose.
+
+### Correct: role column as part of table structure
+
+Include a dedicated column that labels each row's number role. This is the recommended pattern:
+
+```
+| 维度 | 方案A | 方案B | 方案C | 数字角色 |
+|------|-------|-------|-------|---------|
+| 年营收 | $50M | $30M | $20M | 观察值（年报披露） |
+| 市场增长率 | 15% | 12% | 10% | 代理指标（基于第三方行业预测推算） |
+| 实施成本 | $5M | $3M | $2M | 估算（基于项目规模和同类产品定价） |
+| ROI | 3.2x | 2.5x | 1.8x | 模型输出（基于前述成本和营收假设） |
+```
+
+### Acceptable alternative: role header row
+
+When the same role applies to all values in a column, a header row between column headers and data rows can be used:
+
+```
+| 维度 | 方案A | 方案B | 方案C |
+|------|-------|-------|-------|
+| 角色 | 观察值 | 代理指标 | 模型输出 |
+| 年营收 | $50M | $30M | $20M |
+| 市场份额 | 25% | 15% | 10% |
+```
+
+### Acceptable alternative: table-level note
+
+If all numbers in a table share the same epistemic role, a single table note suffices:
+
+```
+> 注：本表所有数字均为模型输出，基于行业公开数据和所述假设计算，不应视为已确认事实。
+```
+
+### What is not acceptable
+
+- A statement in the surrounding prose that "all numbers in this report are estimated" without a role indicator at the table level
+- A single inline disclaimer in the introduction applied to every table without per-table annotation
+- Mixing observed facts and model outputs in the same table without distinguishing them
+
+The rule is: **the reader should not need to leave the table to determine the epistemic role of the numbers inside it.**
+
 ## Hard fail signs
 
 - A load-bearing number has no visible role.

--- a/references/quantitative-role-labeling.md
+++ b/references/quantitative-role-labeling.md
@@ -260,9 +260,11 @@ Include a dedicated column that labels each row's number role. This is the recom
 |------|-------|-------|-------|---------|
 | 年营收 | $50M | $30M | $20M | 观察值（年报披露） |
 | 市场增长率 | 15% | 12% | 10% | 代理指标（基于第三方行业预测推算） |
-| 实施成本 | $5M | $3M | $2M | 估算（基于项目规模和同类产品定价） |
+| 实施成本 | $5M | $3M | $2M | 模型输出（基于项目规模和同类产品定价） |
 | ROI | 3.2x | 2.5x | 1.8x | 模型输出（基于前述成本和营收假设） |
 ```
+
+Placement note: put the role column as the last or second-to-last column in the table. Use the last position by default; reserve the second-to-last spot when a confidence indicator or source-reference column logically follows the role column.
 
 ### Acceptable alternative: role header row
 

--- a/references/report-template.md
+++ b/references/report-template.md
@@ -67,6 +67,29 @@ By default, a useful table should include:
 - consistent number formatting
 - a short interpretation below the table explaining what the table shows and why it matters
 
+### Number role column in comparison / scoring / estimation tables
+
+When a table carries numbers that affect ranking, recommendation, timing, or confidence — especially in comparison tables, scoring tables, or estimation tables — include a **数字角色 (number role) column** as the last or second-to-last column. This makes the epistemic status of each number visible to the reader without requiring them to cross-reference back to the body text.
+
+The role column identifies each number as one of: observed metric, proxy, assumption, model output, or illustrative calculation (see `references/quantitative-role-labeling.md` for definitions).
+
+Example template:
+
+```
+| 维度 | 国家A | 国家B | 国家C | 数字角色 |
+|------|-------|-------|-------|---------|
+| 成本 | $100M | $80M | $60M | 代理指标（基于行业报告推算） |
+| 市场增速 | 40% | 30% | 20% | 模型输出（基于假设增长率） |
+| 补贴比例 | 15%  | 10%  | 5%   | 假设（政策方向已知，具体比例未定） |
+```
+
+If a per-row role column makes the table too wide or repetitive, acceptable alternatives include:
+
+- a role **header row** (a row between the column headers and the data that labels each column's epistemic role)
+- a **table-level note** stating the role of all numbers in the table (e.g., "本表所有成本数字均为估算，基于公开财务数据的推算")
+
+What is **not** acceptable: a statement in the surrounding prose that "all numbers in this paper are estimates" while the table itself carries no role indicator. The role must be visible at the table level — either per row, per column in a header role row, or in an explicit table note.
+
 ## Default structure
 
 ### 1. Executive summary

--- a/references/report-template.md
+++ b/references/report-template.md
@@ -71,7 +71,9 @@ By default, a useful table should include:
 
 When a table carries numbers that affect ranking, recommendation, timing, or confidence — especially in comparison tables, scoring tables, or estimation tables — include a **数字角色 (number role) column** as the last or second-to-last column. This makes the epistemic status of each number visible to the reader without requiring them to cross-reference back to the body text.
 
-The role column identifies each number as one of: observed metric, proxy, assumption, model output, or illustrative calculation (see `references/quantitative-role-labeling.md` for definitions).
+Use the last column for the role label by default. Reserve the second-to-last position when the table also has a confidence or source-reference column that should appear after the role column (e.g., [数字角色 → 置信度] or [数字角色 → 来源]).
+
+The role column identifies each number as one of: observed metric, proxy, assumption, model output, or illustrative calculation (see `references/quantitative-role-labeling.md` §Core roles for definitions).
 
 Example template:
 
@@ -81,14 +83,21 @@ Example template:
 | 成本 | $100M | $80M | $60M | 代理指标（基于行业报告推算） |
 | 市场增速 | 40% | 30% | 20% | 模型输出（基于假设增长率） |
 | 补贴比例 | 15%  | 10%  | 5%   | 假设（政策方向已知，具体比例未定） |
+| 潜在市场规模 | 500亿 | 300亿 | 200亿 | 说明性计算（基于Top-Down市场拆分） |
 ```
 
 If a per-row role column makes the table too wide or repetitive, acceptable alternatives include:
 
 - a role **header row** (a row between the column headers and the data that labels each column's epistemic role)
-- a **table-level note** stating the role of all numbers in the table (e.g., "本表所有成本数字均为估算，基于公开财务数据的推算")
+- a **table-level note** stating the role of all numbers in the table (e.g., "本表所有数字均为模型输出，基于公开财务数据的推算，不应视为已确认事实")
 
-What is **not** acceptable: a statement in the surrounding prose that "all numbers in this paper are estimates" while the table itself carries no role indicator. The role must be visible at the table level — either per row, per column in a header role row, or in an explicit table note.
+What is **not** acceptable:
+
+- A statement in the surrounding prose that "all numbers in this report are estimates" while the table itself carries no role indicator
+- A single inline disclaimer in the introduction applied to every table without per-table annotation
+- Mixing observed facts and model outputs in the same table without distinguishing them
+
+For the full description of each pattern with examples, see `references/quantitative-role-labeling.md` §表格中的角色标签. The role must be visible at the table level — either per row, per column in a header role row, or in an explicit table note.
 
 ## Default structure
 


### PR DESCRIPTION
## 改动

根据 issue #183 的分析和评审，对三个文件进行修改，使数字角色标注从可选的正文行为升级为表格的默认结构要求。

### references/report-template.md

在 §Table discipline 下新增子节 **Number role column in comparison / scoring / estimation tables**：
- 比较表/评分表/估算表默认包含数字角色列
- 示例模板展示 4 种角色（代理指标、模型输出、假设、说明性计算）
- 接受等效替代方案（表头角色行、表注），明确不可接受模式
- 角色列位置说明（末列/倒数第二列）

### references/quantitative-role-labeling.md

在 §Minimal display patterns 与 §Hard fail signs 之间新增 **表格中的角色标签** 章节：
- **正确做法**：独立角色列，逐行标注（推荐）
- **可接受替代**：表头角色行、表注（单角色表）
- **不可接受**：3 种失败模式（正文声明无表注、统一入口声明、同表混用不区分）
- 角色列位置说明

### checklists/final-audit.md

在 §Precision and estimate sourcing 新增一个非阻塞检查项：
- 所有比较/评分/估算表包含数字角色列（或等效的表头角色行/表注）
- 单角色表可在表注声明；多角色表必须有独立列或表头角色行

## 验证

- 改动基于 issue #183 分析 + 4 个 Round 4 eval 案例（indie-game、RAG API、AI coding tools、NEV Europe）的失败模式
- 仅修改 3 个文件，不引入新文件，不改变 route 逻辑
- 新增内容与现有 `checklists/quantitative-role-audit.md` 正交（通用检查 vs 表格结构检查）
- 经双 agent 独立交叉审核后修复了 1 个 Major 问题（示例使用了未定义角色标签估算→ 统一为模型输出）+ 多个小问题（交叉引用锚点、术语一致化、不可接受模式补全、角色列位置说明、添加说明性计算示例）

Closes #183