### PR TITLE
feat: 审计状态区块标准化 — 路由验证状态写入交付物正文 (#184)

### DIFF
--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -980,7 +980,7 @@ Before delivery:
 - run `checklists/route-activation-audit.md` when a specialized route was selected
 - run `checklists/workflow-spine-audit.md`
 - run `checklists/final-audit.md`
-- verify that all required audits for the task have been executed, with each audit's run status recorded:
+- verify that all required audits for the task have been executed, with each audit's run status recorded in the standardized route-and-audit-status block (see `references/report-template.md` §Route and audit status):
   - if a specialized route was selected: for each audit listed in that route's `### Audit` section, confirm its run status: **已通过** (passed), **已跳过（附理由）** (skipped, with documented reason), or **未运行（附理由）** (not run, with documented reason)
   - if no specialized route applies (shared-workflow path): confirm at least `workflow-spine-audit.md` and `final-audit.md` were run, with run status recorded
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -383,7 +383,7 @@ Before delivery:
 6. verify that all required audits for the task have been executed, with each audit's run status recorded:
    - if a specialized route was selected, list all audits listed in its `### Audit` section in `ROUTING-MATRIX.md`
    - if no specialized route applies (shared-workflow path), list at least `workflow-spine-audit.md` and `final-audit.md`
-   - for each listed audit, confirm one of these statuses: **已通过** (passed, with evidence visible in the artifact or process log), **已跳过（附理由）** (skipped, with documented reason), or **未运行（附理由）** (not run, with documented reason)
+   - for each listed audit, confirm one of these statuses: **已通过** (passed, with evidence visible in the standardized route-and-audit-status block in the artifact — see `references/report-template.md` §Route and audit status — or in the process log), **已跳过（附理由）** (skipped, with documented reason), or **未运行（附理由）** (not run, with documented reason)
    - if any required audit is missing or not run, run it before proceeding, or document the reason (skipped / not run / not applicable)
 
 A report that sounds informed but does not visibly satisfy its required artifact contract (route-specific or shared-workflow) is not ready.

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -50,7 +50,7 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] meaningful uncertainties are recorded rather than only implied
 - [ ] where the task warrants it, counter-evidence handling is recoverable from the process artifact
 - [ ] required audits are named and statused rather than merely assumed
-- [ ] (非阻塞) each declared route's required audits have a visible run status — **已通过** (passed), **已跳过（附理由）** (skipped, with documented reason), or **未运行（附理由）** (not run, with documented reason) — in the artifact or process log
+- [ ] (非阻塞) each declared route's required audits have a visible run status — **已通过** (passed), **已跳过（附理由）** (skipped, with documented reason), or **未运行（附理由）** (not run, with documented reason) — in the artifact (via the standardized route-and-audit-status block in `references/report-template.md` §Route and audit status) or process log
 - [ ] (非阻塞) cross-chapter label consistency: the same data point uses the same evidence label across all chapters; if the uncertainty register lists an item, bull/bear sections that reference it should cross-reference or maintain a consistent confidence level
 - [ ] if the task used a specialized route, there is visible evidence that the route was turned into an execution contract before full drafting
 

--- a/references/report-template.md
+++ b/references/report-template.md
@@ -176,7 +176,38 @@ This symmetry matters because asymmetric structure signals to the reader that on
 - include what to do next when useful
 - include what could change the conclusion
 
-### 8. Sources
+### 8. 路由与审计状态（mandatory）
+
+在来源注册表之前，包含一个标准化的路由与审计状态区块，让评审者无需查看 process log 即可确认哪些审计已运行。
+
+**格式模板：**
+
+```
+## 路由与审计状态
+
+**主路由**：Provider / Vendor Selection
+**次级路由**：Regulatory / Policy Impact Analysis
+
+| Audit | Status | Notes |
+|-------|--------|-------|
+| route-activation-audit | ✅ 已通过 | 路由选择正确，无违反 Do-not-use 条件 |
+| option-selection-final-audit | ✅ 已通过 | 排名短名单、反转条件、runner-up 均执行 |
+| source-traceability | ✅ 已通过 | Source Register 结构化，正文有 [SN] 引用 |
+| final-audit | ✅ 已通过 | 核心关卡 7/7 |
+| regulatory secondary hard-fail | ⚠️ 已跳过 | 合规影响已在正文中覆盖，未作为独立次级路由执行 |
+```
+
+**规则：**
+
+- 列出该路由在 `ROUTING-MATRIX.md` `### Audit` 节中声明的所有 required audits
+- 每个 audit 一行，状态三选一：
+  - **已通过** — 审计已运行且通过
+  - **已跳过（附理由）** — 审计适用但决定跳过，理由需明确
+  - **未运行（附理由）** — 审计因故未运行，理由需明确
+- 该区块不追求详尽审计记录，只追求评审者可见——证明审计已运行
+- 如果路由未选择（shared-workflow 路径），说明"未选择专用路由，工作流脊柱审计已运行"并引用 `checklists/workflow-spine-audit.md` 的运行状态
+
+### 9. Sources
 
 - list the most important sources
 - **must** include a structured Source Register appendix using the 7-column template defined in `references/source-traceability-and-claim-citation.md` (§Structured Source Register Template) — a loose bibliography does not satisfy traceability

--- a/references/report-template.md
+++ b/references/report-template.md
@@ -176,36 +176,52 @@ This symmetry matters because asymmetric structure signals to the reader that on
 - include what to do next when useful
 - include what could change the conclusion
 
-### 8. 路由与审计状态（mandatory）
+### 8. Route and audit status (mandatory)
 
 在来源注册表之前，包含一个标准化的路由与审计状态区块，让评审者无需查看 process log 即可确认哪些审计已运行。
 
-**格式模板：**
+**格式模板（路由已选择时）：**
 
 ```
-## 路由与审计状态
+## Route and audit status
 
-**主路由**：Provider / Vendor Selection
-**次级路由**：Regulatory / Policy Impact Analysis
+**Primary route**: Provider / Vendor Selection
+**Secondary route**: Regulatory / Policy Impact Analysis
 
 | Audit | Status | Notes |
 |-------|--------|-------|
-| route-activation-audit | ✅ 已通过 | 路由选择正确，无违反 Do-not-use 条件 |
-| option-selection-final-audit | ✅ 已通过 | 排名短名单、反转条件、runner-up 均执行 |
-| source-traceability | ✅ 已通过 | Source Register 结构化，正文有 [SN] 引用 |
-| final-audit | ✅ 已通过 | 核心关卡 7/7 |
-| regulatory secondary hard-fail | ⚠️ 已跳过 | 合规影响已在正文中覆盖，未作为独立次级路由执行 |
+| route-activation-audit | ✅ Passed | Route selection correct, no Do-not-use violation |
+| option-selection-final-audit | ✅ Passed | Shortlist, reversal conditions, runner-up all executed |
+| source-traceability | ✅ Passed | Source Register structured, body has [SN] citations |
+| final-audit | ✅ Passed | Core gates 7/7 |
+| regulatory secondary hard-fail | ⚠️ Skipped | Compliance impact already covered in body, not executed as standalone secondary route |
+```
+
+**格式模板（shared-workflow 路径）：**
+
+```
+## Route and audit status
+
+**Route**: Shared-workflow (no specialized route selected)
+
+| Audit | Status | Notes |
+|-------|--------|-------|
+| workflow-spine-audit | ✅ Passed | Workflow spine audit complete, spine gates 5/5 |
+| final-audit | ✅ Passed | Final audit passed, core gates 7/7 |
 ```
 
 **规则：**
 
-- 列出该路由在 `ROUTING-MATRIX.md` `### Audit` 节中声明的所有 required audits
+- 列出该次任务运行或应运行的所有审计，包括：
+  - route-specific audits（来自 `ROUTING-MATRIX.md` 各路由的 `### Audit` 节）
+  - `route-activation-audit` 的运行状态
+  - 如果声明了次级路由（secondary route），次级路由的 hard-fail 验证状态
 - 每个 audit 一行，状态三选一：
   - **已通过** — 审计已运行且通过
   - **已跳过（附理由）** — 审计适用但决定跳过，理由需明确
   - **未运行（附理由）** — 审计因故未运行，理由需明确
 - 该区块不追求详尽审计记录，只追求评审者可见——证明审计已运行
-- 如果路由未选择（shared-workflow 路径），说明"未选择专用路由，工作流脊柱审计已运行"并引用 `checklists/workflow-spine-audit.md` 的运行状态
+- 如果路由未选择（shared-workflow 路径），列出 `workflow-spine-audit.md` 和 `final-audit.md` 的运行状态
 
 ### 9. Sources
 

--- a/references/route-activation-and-preflight.md
+++ b/references/route-activation-and-preflight.md
@@ -91,6 +91,18 @@ The full contract format (including "visible proof the route fired") is defined 
 
 The contract belongs in the research plan, not only in the final audit. A route is not fully selected until this contract exists in operational form.
 
+### Step 5: Delivery output — route and audit status block
+
+Before deep collection concludes, add the following requirement to the execution contract: the final deliverable must include a standardized route-and-audit-status block (template defined in `references/report-template.md` §路由与审计状态).
+
+This block makes the route selection and audit run status visible to anyone reading the final report, without requiring access to the process log.
+
+- list all required audits for the declared route(s) from `ROUTING-MATRIX.md` `### Audit` sections
+- for each audit, record one of: **已通过** (passed), **已跳过（附理由）** (skipped, with documented reason), **未运行（附理由）** (not run, with documented reason)
+- if no specialized route applies (shared-workflow path), state that the workflow-spine audit was run instead
+
+Do not treat this block as optional or as a process-log-only concern. If the reader cannot see which audits ran, the audit framework has not been delivered.
+
 ## Common route confusions
 
 ### Market entry vs constrained choice

--- a/references/route-activation-and-preflight.md
+++ b/references/route-activation-and-preflight.md
@@ -93,13 +93,13 @@ The contract belongs in the research plan, not only in the final audit. A route 
 
 ### Step 5: Delivery output — route and audit status block
 
-Before deep collection concludes, add the following requirement to the execution contract: the final deliverable must include a standardized route-and-audit-status block (template defined in `references/report-template.md` §路由与审计状态).
+In the execution contract (Step 4), add the following requirement: the final deliverable must include a standardized route-and-audit-status block (template defined in `references/report-template.md` §Route and audit status).
 
 This block makes the route selection and audit run status visible to anyone reading the final report, without requiring access to the process log.
 
-- list all required audits for the declared route(s) from `ROUTING-MATRIX.md` `### Audit` sections
+- list all required audits for the declared route(s) from `ROUTING-MATRIX.md` `### Audit` sections, along with `route-activation-audit` status and (if a secondary route is declared) the secondary route's hard-fail verification status
 - for each audit, record one of: **已通过** (passed), **已跳过（附理由）** (skipped, with documented reason), **未运行（附理由）** (not run, with documented reason)
-- if no specialized route applies (shared-workflow path), state that the workflow-spine audit was run instead
+- if no specialized route applies (shared-workflow path), list at least `workflow-spine-audit.md` and `final-audit.md` with their run statuses
 
 Do not treat this block as optional or as a process-log-only concern. If the reader cannot see which audits ran, the audit framework has not been delivered.
 


### PR DESCRIPTION
## Summary

Closes #184. 在最终交付物正文中新增标准化的"路由与审计状态"区块，使评审者无需查看 process log 即可确认哪些审计已运行及其状态。

## Changes

### `references/report-template.md`
- 新增 §8「路由与审计状态（mandatory）」，包含标准表格模板和三态规则（已通过/已跳过+理由/未运行+理由）
- 原有 §8 Sources 顺延为 §9

### `references/route-activation-and-preflight.md`
- 在 Preflight steps 中新增 **Step 5: Delivery output — route and audit status block**
- 要求将审计状态写入交付物正文，并在 shared-workflow 路径下说明工作流脊柱审计运行状态

## Design decisions

- **放在 Bottom line 之后、Sources 之前**：不干扰首屏判断可见性（与 report-template.md 首屏纪律一致），作为交付前审计完成声明
- **SKILL.md Step 6 未改**：现措辞 "in the artifact or process log" 已兼容交付物写入，无需收紧
- **final-audit.md 未改**：L53 非阻塞检查已覆盖
- **未新增 checklist**：标准化区块的合规性由评审时人工检查覆盖

## Verification

- 改后文件通过 markdown 格式检查
- 不影响现有报告模板的其他章节和规则
- 无逻辑变更，纯模板+流程文档修改