### PR TITLE
feat: listed-company 市场快照表 + 估值方法模板化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This file is intentionally lightweight. Use concise entries that explain:
 ## Unreleased
 
 ### Added
+- `references/report-template.md`: added mandatory Market snapshot table (9-column template with share price, snapshot date, market cap, PE TTM/Forward, PB, PS, 52-week range, dividend yield, each with source column) and Valuation method + scenario analysis template (primary/secondary metrics, comparable company logic, multiple range, 3-scenario table with EPS/PE/target price/trigger) — closes market snapshot gaps and non-recomputable valuation failures from issue #190 eval cases.
+- `checklists/listed-company-report.md`: migrated market snapshot section from 6 English field-level items to 3 Chinese items referencing the new template; added 2 non-blocking valuation checklist items (multiple range + comparable logic, scenario parameters).
+
+### Added
 - `checklists/listed-company-report.md`: added evidence-label inflation check (inferred/third-party claims not labeled as confirmed facts; highest label tier must match source strength) and inline citation format consistency check (unified `[SN]`/`[IN]`/`[UN]` bracket style) — closes remaining gaps from issue #151 after #144/#153, #148, #149.
 
 ### Added

--- a/checklists/listed-company-report.md
+++ b/checklists/listed-company-report.md
@@ -4,14 +4,11 @@ Use this checklist when the research is about a publicly listed company.
 
 Run through every item before delivering the final report.
 
-## Market snapshot
+## Market snapshot (对照 references/report-template.md §Market snapshot table)
 
-- [ ] current stock price with date and source
-- [ ] approximate market capitalization
-- [ ] PE (TTM or forward) with basis and date
-- [ ] PB with basis and date
-- [ ] PS with basis and date
-- [ ] 52-week high/low range with source
+- [ ] 市场快照表已填入完整数据（对照模板必填列：当前股价/快照日期/市值/PE (TTM)/PE (Forward)/PB/PS/52周区间/股息率）
+- [ ] 每项指标都标注了具体数据来源和快照日期
+- [ ] 数据来源优先使用实时金融数据平台或交易所披露，而非过时或间接来源
 
 ## Reporting discipline
 
@@ -35,6 +32,8 @@ Run through every item before delivering the final report.
 - [ ] high-growth companies have forward metrics clearly labeled as estimate-based
 - [ ] consensus target prices are presented with source, date, and analyst count when available (never inferred); target prices are not treated as fair value
 - [ ] consensus data timing is checked against latest earnings releases; stale consensus is noted
+- [ ] （非阻塞）估值方法包含倍数区间范围，以及可比公司选择逻辑或估值指标选择理由说明（对照 `references/report-template.md` §Valuation method and scenario analysis）
+- [ ] （非阻塞）情景分析包含乐观/基准/悲观三档，每档有明确的 EPS 假设、PE 倍数和触发条件
 
 ## Reporting-period discipline
 

--- a/references/report-template.md
+++ b/references/report-template.md
@@ -44,6 +44,24 @@ Do not default to using the front page as the main location for:
 
 Method transparency should remain visible, but detailed label explanations and process notes should usually move to a later methods note, page-2 opening block, or appendix.
 
+## Market snapshot table (mandatory for listed-company work)
+
+For listed-company reports, a completed market snapshot table is mandatory. It must appear on the front page, immediately after the research-anchor block, before the thesis and executive bullets.
+
+| 指标 | 值 | 来源 |
+|------|-----|------|
+| 当前股价 | $__ | [数据源](URL) |
+| 快照日期 | YYYY-MM-DD | — |
+| 市值 | $__ | [数据源](URL) |
+| PE (TTM) | __x | [数据源](URL) |
+| PE (Forward) | __x | [数据源](URL) |
+| PB | __x | [数据源](URL) |
+| PS | __x | [数据源](URL) |
+| 52周区间 | $__ - $__ | [数据源](URL) |
+| 股息率 | __% | [数据源](URL) |
+
+> 注：PB 须注明净资产所属报告期，PS 须注明营收口径（TTM / FY2025 等）。
+
 ## Scanability and paragraph discipline
 
 Final reports should support scan reading, not only sequential reading.
@@ -138,6 +156,24 @@ Organize by task type. Examples:
 - market: size, growth, structure, competition, bottlenecks
 - technical: feasibility, constraints, trade-offs, implementation needs
 - policy: rules, scope, timing, compliance impact, edge cases
+
+### Valuation method and scenario analysis (mandatory for listed-company work)
+
+For listed-company reports, a **valuation method and scenario analysis** section is mandatory. It must appear in or immediately after the financial analysis portion of the report, with enough detail for a reviewer to recompute the target prices from the disclosed assumptions.
+
+**估值方法**
+- 主要估值指标：__（理由：__）
+- 补充指标：PB（说明：__）, PS（说明：__）, EV/EBITDA（说明：__）
+- 其他指标：__（说明：__）
+- 可比公司：__（选择逻辑：__）
+- 倍数区间历史范围：__x - __x
+
+**情景分析**
+| 情景 | EPS假设 | PE倍数 | 目标价 | 触发条件 |
+|------|---------|--------|--------|---------|
+| 乐观 | $__ | __x | $__ | __ |
+| 基准 | $__ | __x | $__ | __ |
+| 悲观 | $__ | __x | $__ | __ |
 
 ### 5. Risks and counter-evidence
 


### PR DESCRIPTION
## 背景

Round 5 累计 12 个 listed-company 案例中 6 个存在市场快照不完整（缺 PB/PS/52周范围），5 个估值缺可复算方法。Round 4 #182 通过 Source Register 结构化模板验证了"提供填空模板比抽象 checklist 更有效"的模式。

## 改动

### `references/report-template.md`
新增两个 **mandatory** 模板区块：

1. **Market snapshot table**（位于 research-anchor block 之后，首页可见位置）：10 列必填指标（股价/快照日期/市值/PE TTM/PE Forward/PB/PS/52周区间/股息率），每项要求标注来源

2. **Valuation method and scenario analysis**（位于 Detailed analysis 中，财务分析之后）：包含估值方法（主要指标及理由/补充指标/可比公司选择逻辑/倍数区间历史范围）和情景分析表（乐观/基准/悲观三档，每档含 EPS 假设、PE 倍数、目标价、触发条件）

### `checklists/listed-company-report.md`
- Market snapshot 检查项改为模板对照引用，聚合为 3 项有操作性的中文 check（填入完整、标注来源、首选实时数据）
- Valuation methodology 新增 2 项非阻塞检查（倍数区间 + 可比选择逻辑、情景三档参数）

## 验证标准
- 新报告包含完整市场快照表（股价/PE/PB/PS/52周/来源日期）
- 估值章节包含倍数区间、可比逻辑或选择理由、情景参数
- 评审者可从估值假设重新算出目标价

## 相关 issue
Closes #190