### PR TITLE
[P1] 证据标签校准规则 — 来源类型到标签强度的强制映射 (#191)

### DIFF
--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -17,6 +17,9 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] key numbers are sourced and dated
 - [ ] load-bearing claims are traceable in the body text, not only recoverable from a source appendix or bibliography
 - [ ] strong-sounding comparative or forecast claims have explicit scope and source role, or were visibly downgraded
+- [ ] PRIMARY_COMPANY / PRIMARY_PARTNER / 简化类型的 vendor-claim 来源在正文引用时附加了内联说明 `(来源：厂商自述，非独立验证)`，未将厂商自述作为独立确认事实（见 `references/source-traceability-and-claim-citation.md` §来源标注一致性）
+- [ ] SECONDARY_MEDIA / SECONDARY_ANALYST 类型来源（媒体估计、券商研报）未在正文中标注为 [已确认事实]（已使用 [推断] 或具体来源角色替代）
+- [ ] 每条正文证据标签不超过 `references/quantitative-role-labeling.md` §来源类型到证据标签的校准规则 中对应来源类型允许的最大标签强度；例外已记录理由
 
 ## Counter-evidence
 
@@ -160,8 +163,6 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] for constrained-choice / shortlist reports that use composite scoring, important quantitative inputs are labeled as observed fact / proxy / assumption / model output when the distinction affects trust in the recommendation
 - [ ] when evidence buckets are used, the report does not stop at `confirmed / inference / unknown` if important numbers still function as proxy / assumption / planning-model output
 - [ ] heuristic timing, cost, payback, or ROI-style claims are not written as if they were directly observed facts when they are closer to assumptions or planning-model outputs
-- [ ] （非阻塞）Source Register 中类型为 PRIMARY_COMPANY/PRIMARY_PARTNER/简化类型的 vendor-claim，或 Notes 标注"厂商自述"的来源，在正文引用时附加了内联说明 `(来源：厂商自述，非独立验证)`（见 `references/source-traceability-and-claim-citation.md` §来源标注一致性）
-- [ ] （非阻塞）SECONDARY_MEDIA / SECONDARY_ANALYST 类型来源（媒体估计、券商研报）未在正文中标注为 [已确认事实]（使用 [推断] 或具体来源角色替代）
 - [ ] （非阻塞）所有比较表、评分表、估算表包含数字角色列（或等效的表头角色行/表注），读者无需回正文即可从表格行判断数字性质（观察值/代理指标/假设/模型输出）。单角色表可以在表注声明；多角色表必须有独立列或表头角色行。见 `references/quantitative-role-labeling.md` §表格中的角色标签
 
 ## Metric-scope audit

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -17,8 +17,8 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] key numbers are sourced and dated
 - [ ] load-bearing claims are traceable in the body text, not only recoverable from a source appendix or bibliography
 - [ ] strong-sounding comparative or forecast claims have explicit scope and source role, or were visibly downgraded
-- [ ] PRIMARY_COMPANY / PRIMARY_PARTNER / 简化类型的 vendor-claim 来源在正文引用时附加了内联说明 `(来源：厂商自述，非独立验证)`，未将厂商自述作为独立确认事实（见 `references/source-traceability-and-claim-citation.md` §来源标注一致性）
-- [ ] SECONDARY_MEDIA / SECONDARY_ANALYST 类型来源（媒体估计、券商研报）未在正文中标注为 [已确认事实]（已使用 [推断] 或具体来源角色替代）
+- [ ] PRIMARY_COMPANY / PRIMARY_PARTNER / 简化类型的 vendor-claim 来源（或 register Notes 列标注"厂商自述"的来源），在正文引用时附加了内联说明 `(来源：厂商自述，非独立验证)`，不得在缺少该限定的情况下标注为 [已确认事实]（见 `references/source-traceability-and-claim-citation.md` §来源标注一致性）
+- [ ] SECONDARY_MEDIA / SECONDARY_ANALYST 类型来源（媒体估计、券商研报）未在正文中标注为 [已确认事实]（已使用 [推断] 或具体来源角色替代）；例外（指 register 标为 high reliability 且经审计确认）已在 process log 或审计状态区块中记录理由（见 `references/quantitative-role-labeling.md` §映射表使用规则）
 - [ ] 每条正文证据标签不超过 `references/quantitative-role-labeling.md` §来源类型到证据标签的校准规则 中对应来源类型允许的最大标签强度；例外已记录理由
 
 ## Counter-evidence

--- a/references/quantitative-role-labeling.md
+++ b/references/quantitative-role-labeling.md
@@ -233,13 +233,13 @@ The assumption is named ("assume 15% growth"), but the conditions that must hold
 | 来源类型（granular） | 可标注的最高标签 | 必须附加的说明 |
 |---|---|---|
 | `PRIMARY_FILING`（监管/年报/交易所公告） | `[已确认事实]` | 无需额外说明，但需标注期间 |
-| `PRIMARY_COMPANY`（官网/新闻稿/股东信） | `[已确认事实]` + 来源角色 | 必须标注"（据公司[文件类型]）"如 `[已确认事实]（据公司官网）` |
-| `PRIMARY_PARTNER`（合作伙伴公告） | `[已确认事实]` + 来源角色 | 必须标注"（据[合作伙伴]声明）"如 `[已确认事实]（据客户公告）` |
-| `PRIMARY_DEV`（GitHub 仓库/API 文档/changelog） | `[已确认事实]` | 需标注版本号或 commit ref |
+| `PRIMARY_COMPANY`（官网/新闻稿/股东信） | `[已确认事实]` + 来源角色 | 必须附加内联说明 `(来源：厂商自述，非独立验证)`（见 `references/source-traceability-and-claim-citation.md` §来源标注一致性）；可补充来源角色如"（据公司官网）" |
+| `PRIMARY_PARTNER`（合作伙伴公告） | `[已确认事实]` + 来源角色 | 必须附加内联说明 `(来源：厂商自述，非独立验证)`（见 `references/source-traceability-and-claim-citation.md` §来源标注一致性）；可补充来源角色如"（据[合作伙伴]声明）" |
+| `PRIMARY_DEV`（GitHub 仓库/API 文档/changelog） | `[已确认事实]` | 需标注版本号或 commit ref。Pre-merge PR 默认使用 `[推断]`，除非审计员确认可升级 |
 | `SECONDARY_MEDIA`（媒体/行业报告） | `[推断]` | 必须标注"（据XX报道）"如 `[推断]（据路透社报道）` |
 | `SECONDARY_ANALYST`（券商研报） | `[推断]` | 必须标注"（据XX分析师）"如 `[推断]（据高盛分析师）` |
 | `SECONDARY_FEED`（RSS 摘要/聚合内容流） | `[推断]` | 必须标注来源名称 |
-| `TRANSCRIPT`（转录/访谈/电话会） | `[已确认事实]` 或 `[推断]` | 视 transcript 是否 verbatim 而定；必须标注来源场景（"据公司年报电话会"） |
+| `TRANSCRIPT`（转录/访谈/电话会） | `[已确认事实]` 或 `[推断]` | verbatim（逐字记录，经录音核对）→ `[已确认事实]`；summary/paraphrase → `[推断]`。无论哪种情况，必须标注来源场景（"据公司年报电话会"） |
 | `INFERRED`（报告自身推断） | `[推断]` | 必须附推理链（见 `references/source-traceability-and-claim-citation.md` §Inference documentation） |
 | `UNCONFIRMED`（无法独立验证） | `[未知]` | 必须标注"未经独立验证" |
 | `WEAK_SIGNAL`（社交/论坛/匿名来源） | `[未知]` | 仅用于补充上下文，不得承载 load-bearing claim |
@@ -247,13 +247,15 @@ The assumption is named ("assume 15% growth"), but the conditions that must hold
 ### 映射表使用规则
 
 1. **register 优先**：上述映射适用于 register 中已正确分类的来源。如果 register 本身的类型标注错误，先修正 register 再应用映射规则。
-2. **例外机制**：当 register 将某个 SECONDARY 来源明确标为 `high` reliability（例如权威第三方基准测试报告），且来源质量经审计员确认，可酌情升级至 `[已确认事实]`。例外必须记录理由。
+2. **例外机制**：当 register 将某个 `SECONDARY_MEDIA` 或 `SECONDARY_ANALYST` 来源明确标为 `high` reliability（例如权威第三方基准测试报告），且来源质量经审计员确认，可酌情升级至 `[已确认事实]`。此例外不适用于 `SECONDARY_FEED`。例外必须记录理由。
 3. **简化类型兼容**：使用简化 5 类（primary / secondary / vendor-claim / inferred / unconfirmed）时，`vendor-claim` 的规则同 `PRIMARY_COMPANY`/`PRIMARY_PARTNER`；`secondary` 的规则同 `SECONDARY_MEDIA`/`SECONDARY_ANALYST`/`SECONDARY_FEED`。
 4. **标签强度一致性**：本映射表与 `references/source-traceability-and-claim-citation.md` §来源标注一致性 的关系——该章节定义 register 与正文间的标签强度约束（register ≥ body）；本映射表定义给定 register 类型时正文的**上限**。两者互补：register ≥ body 且 body ≤ 本表上限。
 
 ### 与现有规则的关系
 
 本映射表不替代 `references/source-traceability-and-claim-citation.md` §来源标注一致性 中的双边一致性规则（register 标签 ≥ 正文标签），而是在 register 到正文的映射方向提供更精确的上限约束。
+
+本映射表与 §厂商声明与媒体估计的特殊标注规则 的关系——该节（`quantitative-role-labeling.md` §厂商声明与媒体估计的特殊标注规则）定义了厂商自述和媒体估计这两类来源的特殊标注要求（不得单独标为 `[已确认事实]`）；本映射表将同一原则扩展为对所有 11 种 granular 来源类型的系统性覆盖，并提供统一的例外机制。两者在重叠区域语义一致：本映射表表中 `PRIMARY_COMPANY`/`PRIMARY_PARTNER` 的注释要求与 §厂商声明中的"不得单独标注为 `[已确认事实]`"一致，`SECONDARY_MEDIA`/`SECONDARY_ANALYST` 的注释要求与 §媒体估计中的"不得标注为 `[已确认事实]`"一致。
 
 ## Route-specific notes
 

--- a/references/quantitative-role-labeling.md
+++ b/references/quantitative-role-labeling.md
@@ -222,6 +222,39 @@ The assumption is named ("assume 15% growth"), but the conditions that must hold
 
 参见 `references/source-traceability-and-claim-citation.md` 的「来源标注一致性」章节，其中定义了 register 与正文标签强度的一致性原则。
 
+## 来源类型到证据标签的校准规则
+
+### 核心原则
+
+**标签强度 ≤ 来源类型允许的最大强度。** 二级/推断性来源承载的主张不可仅标注 `[已确认事实]` 而不附加来源角色说明。例外必须记录理由到 process log 或审计状态区块。
+
+### 来源类型 → 允许标签映射表
+
+| 来源类型（granular） | 可标注的最高标签 | 必须附加的说明 |
+|---|---|---|
+| `PRIMARY_FILING`（监管/年报/交易所公告） | `[已确认事实]` | 无需额外说明，但需标注期间 |
+| `PRIMARY_COMPANY`（官网/新闻稿/股东信） | `[已确认事实]` + 来源角色 | 必须标注"（据公司[文件类型]）"如 `[已确认事实]（据公司官网）` |
+| `PRIMARY_PARTNER`（合作伙伴公告） | `[已确认事实]` + 来源角色 | 必须标注"（据[合作伙伴]声明）"如 `[已确认事实]（据客户公告）` |
+| `PRIMARY_DEV`（GitHub 仓库/API 文档/changelog） | `[已确认事实]` | 需标注版本号或 commit ref |
+| `SECONDARY_MEDIA`（媒体/行业报告） | `[推断]` | 必须标注"（据XX报道）"如 `[推断]（据路透社报道）` |
+| `SECONDARY_ANALYST`（券商研报） | `[推断]` | 必须标注"（据XX分析师）"如 `[推断]（据高盛分析师）` |
+| `SECONDARY_FEED`（RSS 摘要/聚合内容流） | `[推断]` | 必须标注来源名称 |
+| `TRANSCRIPT`（转录/访谈/电话会） | `[已确认事实]` 或 `[推断]` | 视 transcript 是否 verbatim 而定；必须标注来源场景（"据公司年报电话会"） |
+| `INFERRED`（报告自身推断） | `[推断]` | 必须附推理链（见 `references/source-traceability-and-claim-citation.md` §Inference documentation） |
+| `UNCONFIRMED`（无法独立验证） | `[未知]` | 必须标注"未经独立验证" |
+| `WEAK_SIGNAL`（社交/论坛/匿名来源） | `[未知]` | 仅用于补充上下文，不得承载 load-bearing claim |
+
+### 映射表使用规则
+
+1. **register 优先**：上述映射适用于 register 中已正确分类的来源。如果 register 本身的类型标注错误，先修正 register 再应用映射规则。
+2. **例外机制**：当 register 将某个 SECONDARY 来源明确标为 `high` reliability（例如权威第三方基准测试报告），且来源质量经审计员确认，可酌情升级至 `[已确认事实]`。例外必须记录理由。
+3. **简化类型兼容**：使用简化 5 类（primary / secondary / vendor-claim / inferred / unconfirmed）时，`vendor-claim` 的规则同 `PRIMARY_COMPANY`/`PRIMARY_PARTNER`；`secondary` 的规则同 `SECONDARY_MEDIA`/`SECONDARY_ANALYST`/`SECONDARY_FEED`。
+4. **标签强度一致性**：本映射表与 `references/source-traceability-and-claim-citation.md` §来源标注一致性 的关系——该章节定义 register 与正文间的标签强度约束（register ≥ body）；本映射表定义给定 register 类型时正文的**上限**。两者互补：register ≥ body 且 body ≤ 本表上限。
+
+### 与现有规则的关系
+
+本映射表不替代 `references/source-traceability-and-claim-citation.md` §来源标注一致性 中的双边一致性规则（register 标签 ≥ 正文标签），而是在 register 到正文的映射方向提供更精确的上限约束。
+
 ## Route-specific notes
 
 ### Market entry / regional expansion


### PR DESCRIPTION
## 改动

### 问题
Round 5 中 5 个 case（emc、lotes、aaeon、advantech、unitree）将二级/媒体/聚合来源支撑的主张直接标为 `[确认事实]`，证据标签强度高于来源实际质量。这不是偶发，而是系统性规则缺失。

### 改动文件

**`references/quantitative-role-labeling.md`**
- 新增「来源类型到证据标签的校准规则」章节
- 11 种 granular 来源类型的映射表（PRIMARY_FILING → INFERRED → WEAK_SIGNAL）
- 核心原则：标签强度 ≤ 来源类型允许的最大强度
- 例外机制：high-reliability SECONDARY 可酌情升级（需记录理由）
- 简化 5 类兼容规则

**`checklists/final-audit.md`**
- PRIMARY_COMPANY/PRIMARY_PARTNER/vendor-claim 检查：non-blocker → blocker
- SECONDARY_MEDIA/SECONDARY_ANALYST 检查：non-blocker → blocker  
- 新增：映射一致性阻塞检查

### 不做的事
- 不改 SKILL.md / ROUTING-MATRIX.md / source-traceability-and-claim-citation.md
- 不改证据分级定义本身（`[确认事实]`/`[推断]`/`[未知]` 含义不变）
- 不改 source register 结构、模板、eval case

### 验证标准
- [x] 新表格覆盖所有 11 种 granular 来源类型
- [x] 与 existing source-traceability-and-claim-citation.md §来源标注一致性 互补不冲突
- [x] final-audit.md 中原有的 non-blocker 已升级为 blocker