### PR TITLE
[P1] 跨路由 Source Register 模板引用注入 — 5 个 checklist 添加模板引用

### DIFF
--- a/checklists/academic-analysis-audit.md
+++ b/checklists/academic-analysis-audit.md
@@ -56,7 +56,7 @@ This checklist verifies that the academic route was executed correctly and the f
 - [ ] （Tier-1）预印本/工作论文标注 "未同行评审"：preprints are explicitly labeled as "not peer-reviewed"
 - [ ] the report does not conflate study design quality with publication venue prestige
 - [ ] the report distinguishes between original research and secondary sources
-- [ ] Source Register uses the 7-column template (ID / Source Name / Source Type / Date / DOI or URL / Reliability / Claims Supported) defined in `references/source-traceability-and-claim-citation.md` (§Structured Source Register Template). 来源注册表必须使用该 7 列模板。
+- [ ] source register must use the 7-column template (ID / Source Name / Source Type / Date / DOI or URL / Reliability / Claims Supported) defined in `references/source-traceability-and-claim-citation.md` (§Structured Source Register Template). 来源注册表必须使用该 7 列模板。
 
 ## Artifact contract verification
 

--- a/checklists/academic-analysis-audit.md
+++ b/checklists/academic-analysis-audit.md
@@ -56,6 +56,7 @@ This checklist verifies that the academic route was executed correctly and the f
 - [ ] （Tier-1）预印本/工作论文标注 "未同行评审"：preprints are explicitly labeled as "not peer-reviewed"
 - [ ] the report does not conflate study design quality with publication venue prestige
 - [ ] the report distinguishes between original research and secondary sources
+- [ ] Source Register uses the 7-column template (ID / Source Name / Source Type / Date / DOI or URL / Reliability / Claims Supported) defined in `references/source-traceability-and-claim-citation.md` (§Structured Source Register Template). 来源注册表必须使用该 7 列模板。
 
 ## Artifact contract verification
 

--- a/checklists/option-selection-final-audit.md
+++ b/checklists/option-selection-final-audit.md
@@ -68,7 +68,7 @@ Run this checklist before delivery.
 - [ ] medium-stability attributes are not presented with the same certainty as official hard constraints
 - [ ] model synthesis / recommendation is distinguishable from raw source claims
 - [ ] strong negative or positive reputation claims are scoped and not treated as hard facts by default
-- [ ] Source Register uses the 7-column template (ID / Source Name / Source Type / Date / DOI or URL / Reliability / Claims Supported) defined in `references/source-traceability-and-claim-citation.md` (§Structured Source Register Template). 来源注册表必须使用该 7 列模板。
+- [ ] source register must use the 7-column template (ID / Source Name / Source Type / Date / DOI or URL / Reliability / Claims Supported) defined in `references/source-traceability-and-claim-citation.md` (§Structured Source Register Template). 来源注册表必须使用该 7 列模板。
 
 ## Scenario logic and change conditions
 

--- a/checklists/option-selection-final-audit.md
+++ b/checklists/option-selection-final-audit.md
@@ -68,6 +68,7 @@ Run this checklist before delivery.
 - [ ] medium-stability attributes are not presented with the same certainty as official hard constraints
 - [ ] model synthesis / recommendation is distinguishable from raw source claims
 - [ ] strong negative or positive reputation claims are scoped and not treated as hard facts by default
+- [ ] Source Register uses the 7-column template (ID / Source Name / Source Type / Date / DOI or URL / Reliability / Claims Supported) defined in `references/source-traceability-and-claim-citation.md` (§Structured Source Register Template). 来源注册表必须使用该 7 列模板。
 
 ## Scenario logic and change conditions
 

--- a/checklists/regulatory-analysis-audit.md
+++ b/checklists/regulatory-analysis-audit.md
@@ -25,6 +25,7 @@ This checklist verifies that the regulatory analysis route was executed correctl
 - [ ] media interpretation is distinguished from regulatory text
 - [ ] analyst speculation is labeled as such, not presented as regulatory fact
 - [ ] conflicting regulatory interpretations are handled explicitly
+- [ ] Source Register uses the 7-column template (ID / Source Name / Source Type / Date / DOI or URL / Reliability / Claims Supported) defined in `references/source-traceability-and-claim-citation.md` (§Structured Source Register Template). 来源注册表必须使用该 7 列模板。
 
 ## Business impact analysis
 

--- a/checklists/regulatory-analysis-audit.md
+++ b/checklists/regulatory-analysis-audit.md
@@ -25,7 +25,7 @@ This checklist verifies that the regulatory analysis route was executed correctl
 - [ ] media interpretation is distinguished from regulatory text
 - [ ] analyst speculation is labeled as such, not presented as regulatory fact
 - [ ] conflicting regulatory interpretations are handled explicitly
-- [ ] Source Register uses the 7-column template (ID / Source Name / Source Type / Date / DOI or URL / Reliability / Claims Supported) defined in `references/source-traceability-and-claim-citation.md` (§Structured Source Register Template). 来源注册表必须使用该 7 列模板。
+- [ ] source register must use the 7-column template (ID / Source Name / Source Type / Date / DOI or URL / Reliability / Claims Supported) defined in `references/source-traceability-and-claim-citation.md` (§Structured Source Register Template). 来源注册表必须使用该 7 列模板。
 
 ## Business impact analysis
 

--- a/checklists/startup-company-report.md
+++ b/checklists/startup-company-report.md
@@ -54,7 +54,7 @@ Run through every item before delivering the final report.
 - [ ] Crunchbase / PitchBook data is labeled as aggregator data, not primary source
 - [ ] social media (Twitter, LinkedIn, Reddit) is labeled as weak supplemental signal
 - [ ] load-bearing claims have identifiable sources in the body, not just bibliography
-- [ ] Source Register uses the 7-column template (ID / Source Name / Source Type / Date / DOI or URL / Reliability / Claims Supported) defined in `references/source-traceability-and-claim-citation.md` (§Structured Source Register Template). 来源注册表必须使用该 7 列模板。
+- [ ] source register must use the 7-column template (ID / Source Name / Source Type / Date / DOI or URL / Reliability / Claims Supported) defined in `references/source-traceability-and-claim-citation.md` (§Structured Source Register Template). 来源注册表必须使用该 7 列模板。
 
 ## Judgment-shape micro-audit
 

--- a/checklists/startup-company-report.md
+++ b/checklists/startup-company-report.md
@@ -54,6 +54,7 @@ Run through every item before delivering the final report.
 - [ ] Crunchbase / PitchBook data is labeled as aggregator data, not primary source
 - [ ] social media (Twitter, LinkedIn, Reddit) is labeled as weak supplemental signal
 - [ ] load-bearing claims have identifiable sources in the body, not just bibliography
+- [ ] Source Register uses the 7-column template (ID / Source Name / Source Type / Date / DOI or URL / Reliability / Claims Supported) defined in `references/source-traceability-and-claim-citation.md` (§Structured Source Register Template). 来源注册表必须使用该 7 列模板。
 
 ## Judgment-shape micro-audit
 

--- a/checklists/technical-analysis-audit.md
+++ b/checklists/technical-analysis-audit.md
@@ -27,7 +27,7 @@ This checklist verifies that the technical analysis route was executed correctly
 - [ ] patent claims cite patent numbers or specific filings, not just counts
 - [ ] （非阻塞）厂商自述在正文中明确标注了来源角色（如 `(厂商自述)` 或 `(来源：厂商自述，非独立验证)`），见 `references/source-traceability-and-claim-citation.md` §来源标注一致性
 - [ ] （非阻塞）涉及厂商自述的行内引用附加了标准格式 caveat `(来源：厂商自述，非独立验证)` 或等效说明
-- [ ] Source Register uses the 7-column template (ID / Source Name / Source Type / Date / DOI or URL / Reliability / Claims Supported) defined in `references/source-traceability-and-claim-citation.md` (§Structured Source Register Template). 来源注册表必须使用该 7 列模板。
+- [ ] source register must use the 7-column template (ID / Source Name / Source Type / Date / DOI or URL / Reliability / Claims Supported) defined in `references/source-traceability-and-claim-citation.md` (§Structured Source Register Template). 来源注册表必须使用该 7 列模板。
 
 ## Comparison structure (for architecture comparison)
 

--- a/checklists/technical-analysis-audit.md
+++ b/checklists/technical-analysis-audit.md
@@ -27,6 +27,7 @@ This checklist verifies that the technical analysis route was executed correctly
 - [ ] patent claims cite patent numbers or specific filings, not just counts
 - [ ] （非阻塞）厂商自述在正文中明确标注了来源角色（如 `(厂商自述)` 或 `(来源：厂商自述，非独立验证)`），见 `references/source-traceability-and-claim-citation.md` §来源标注一致性
 - [ ] （非阻塞）涉及厂商自述的行内引用附加了标准格式 caveat `(来源：厂商自述，非独立验证)` 或等效说明
+- [ ] Source Register uses the 7-column template (ID / Source Name / Source Type / Date / DOI or URL / Reliability / Claims Supported) defined in `references/source-traceability-and-claim-citation.md` (§Structured Source Register Template). 来源注册表必须使用该 7 列模板。
 
 ## Comparison structure (for architecture comparison)
 


### PR DESCRIPTION
## 改动

在 5 个 Route-specific checklist 文件的证据/来源相关章节中添加一行引用，指向 Source Register 7 列模板（定义在 `references/source-traceability-and-claim-citation.md` §Structured Source Register Template）。

### 改动文件

| 文件 | 章节 | 行数变更 |
|------|------|---------|
| `checklists/technical-analysis-audit.md` | Evidence quality | +1 |
| `checklists/option-selection-final-audit.md` | Evidence layers | +1 |
| `checklists/regulatory-analysis-audit.md` | Evidence quality | +1 |
| `checklists/startup-company-report.md` | Source quality and traceability | +1 |
| `checklists/academic-analysis-audit.md` | Source labeling | +1 |

### 评审建议中已采纳的修改

1. 引用目标改为 `references/source-traceability-and-claim-citation.md`（7 列模板的权威定义处），而非 issue 原述的 `references/report-template.md`（report-template.md 本身也引用该文件）
2. `option-selection-final-audit.md` 原计划插入 "Source traceability" 章节，但该章节不存在，改为插入同级的 "Evidence layers" 章节

### 说明

`checklists/source-traceability.md` 第 20 行已要求 7 列模板，每个路由的 audit 也包含该 checklist。本次改动增加 route-specific 层面的显式引用，使各路由 checklist 在证据/来源章节内即可看到该要求，无需交叉引用共享 checklist，属防御性增强。

Closes #196