### PR TITLE
[P1] 跨路由量化角色列引用注入 — 4 个 checklist 添加模板引用

### DIFF
--- a/checklists/listed-company-report.md
+++ b/checklists/listed-company-report.md
@@ -67,6 +67,7 @@ Run through every item before delivering the final report.
 - [ ] operating cash flow direction noted
 - [ ] segment breakdown if multi-segment business
 - [ ] the report makes visible which numbers belong to the latest reported annual period, which belong to the latest reported quarter/interim period, and which belong only to older historical context
+- [ ] （非阻塞）所有比较表、评分表、估算表包含数字角色列（或等效的表头角色行/表注），见 `references/quantitative-role-labeling.md` §表格中的角色标签
 
 ## Judgment-shape micro-audit
 

--- a/checklists/option-selection-final-audit.md
+++ b/checklists/option-selection-final-audit.md
@@ -69,6 +69,7 @@ Run this checklist before delivery.
 - [ ] model synthesis / recommendation is distinguishable from raw source claims
 - [ ] strong negative or positive reputation claims are scoped and not treated as hard facts by default
 - [ ] source register must use the 7-column template (ID / Source Name / Source Type / Date / DOI or URL / Reliability / Claims Supported) defined in `references/source-traceability-and-claim-citation.md` (§Structured Source Register Template). 来源注册表必须使用该 7 列模板。
+- [ ] （非阻塞）所有比较表、评分表、估算表包含数字角色列（或等效的表头角色行/表注），见 `references/quantitative-role-labeling.md` §表格中的角色标签
 
 ## Scenario logic and change conditions
 

--- a/checklists/regulatory-analysis-audit.md
+++ b/checklists/regulatory-analysis-audit.md
@@ -33,6 +33,7 @@ This checklist verifies that the regulatory analysis route was executed correctl
 - [ ] impact is analyzed at business level (revenue, cost, operations, market access)
 - [ ] quantified impact is provided where possible, with explicit assumptions
 - [ ] impact timeline is stated (when will the regulation take effect?)
+- [ ] （非阻塞）所有比较表、评分表、估算表包含数字角色列（或等效的表头角色行/表注），见 `references/quantitative-role-labeling.md` §表格中的角色标签
 
 ## Uncertainty and scenarios
 

--- a/checklists/technical-analysis-audit.md
+++ b/checklists/technical-analysis-audit.md
@@ -36,6 +36,7 @@ This checklist verifies that the technical analysis route was executed correctly
 - [ ] trade-offs are stated, not just advantages
 - [ ] the comparison covers at least: performance, cost, maturity, ecosystem (or justified subset)
 - [ ] the recommendation explains which dimensions are load-bearing
+- [ ] （非阻塞）所有比较表、评分表、估算表包含数字角色列（或等效的表头角色行/表注），见 `references/quantitative-role-labeling.md` §表格中的角色标签
 
 ## Feasibility assessment (for technical feasibility)
 


### PR DESCRIPTION
## 改动

在以下 4 个 route-specific checklist 文件的相关章节中各添加一行引用，指向 `references/quantitative-role-labeling.md §表格中的角色标签`：

| 文件 | 章节 |
|------|------|
| `checklists/technical-analysis-audit.md` | Comparison structure |
| `checklists/option-selection-final-audit.md` | Evidence layers |
| `checklists/listed-company-report.md` | Key numbers |
| `checklists/regulatory-analysis-audit.md` | Business impact analysis |

## 背景

Round 6 中 9/12 case 的表格缺少数字角色列。#183 时已在 `report-template.md` 和 `quantitative-role-labeling.md` 中创建了规则，`final-audit.md` line 167 也有门控检查。但 route-specific checklist 作为第一道防线没有显式引用，导致作者到 final-audit 阶段才被拦截，产生返工。

本 issue 与 #196（Source Register 7 列模板引用注入）是同一模式。

## 验证

- 每个新增项使用 `（非阻塞）` 标签，与 final-audit.md 层级一致
- 最终审计门控检查不变（final-audit.md line 167）
- 引用路径与 reference 文件章节名保持精确匹配

Closes #197