### PR TITLE
feat: 审计状态区块增加证据列 — 从 Notes 改为具体引用要求 (#198)

### DIFF
--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -980,7 +980,7 @@ Before delivery:
 - run `checklists/route-activation-audit.md` when a specialized route was selected
 - run `checklists/workflow-spine-audit.md`
 - run `checklists/final-audit.md`
-- verify that all required audits for the task have been executed, with each audit's run status recorded in the standardized route-and-audit-status block (see `references/report-template.md` §Route and audit status):
+- verify that all required audits for the task have been executed, with each audit's run status recorded in the standardized route-and-audit-status block (see `references/report-template.md` §Route and audit status), and each audit's 「证据」column populated with specific section references or register entries per the template's evidence column rules:
   - if a specialized route was selected: for each audit listed in that route's `### Audit` section, confirm its run status: **已通过** (passed), **已跳过（附理由）** (skipped, with documented reason), or **未运行（附理由）** (not run, with documented reason)
   - if no specialized route applies (shared-workflow path): confirm at least `workflow-spine-audit.md` and `final-audit.md` were run, with run status recorded
 

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -55,6 +55,13 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] required audits are named and statused rather than merely assumed
 - [ ] the artifact includes a standardized route-and-audit-status block (via `references/report-template.md` §Route and audit status), with audit run status visible in the artifact itself (not only in a process log)
 - [ ] the audit status block matches the actual report body: each self-assessment claiming passage (✅ Passed or equivalent phrasing or emoji) in the block has corresponding visible execution evidence in the artifact body or structure; if the body shows missing citations, incomplete source register entries, missing route-required sections, or other hard-fail conditions, the block must reflect that status rather than claiming full passage
+
+  > Tier-2 说明：深度验证检查，不通过需记录理由但不必然阻断交付。区别于 Tier-1（阻断级，不通过不可交付）和 (非阻塞)（质量信号，不通过属于改进项）。
+
+- [ ] （Tier-2）每项审计的「证据」列附有与状态对应的具体引用，不可为空：
+  - ✅ Passed → 执行证据位置（章节号、检查项编号或 register 条目）
+  - ⚠️ Skipped / ❌ Not run → 决定理由在正文中的位置
+- [ ] （Tier-2）自称通过项的证据列引用的章节/条目确实存在且满足对应审计要求：引用的章节号/标题在正文中真实存在（非虚构引用）；引用内容与审计要求实质匹配——如 source-traceability ✅ 引用"正文使用 [S01]-[SN] 引用，附录为 7 列 Source Register"，则需验证正文确有 `[SN]` 引用且 register 满足 7 列模板格式
 - [ ] (非阻塞) cross-chapter label consistency: the same data point uses the same evidence label across all chapters; if the uncertainty register lists an item, bull/bear sections that reference it should cross-reference or maintain a consistent confidence level
 - [ ] if the task used a specialized route, there is visible evidence that the route was turned into an execution contract before full drafting
 

--- a/checklists/route-activation-audit.md
+++ b/checklists/route-activation-audit.md
@@ -14,7 +14,7 @@ It audits whether route activation was explicit and whether the route actually s
 - [ ] the total route count (primary + secondary) was reviewed: if it exceeds 3, scope focus was re-examined and the decision to keep the current route set is documented
 - [ ] secondary body-text share is reasonable (secondary-route content does not exceed roughly 25% of body text when the primary route requires minimizing those sections; if it does, consider shared-workflow declaration or route simplification)
 - [ ] a compact execution contract exists before synthesis: opening mandate, mandatory sections, hard-fail conditions, minimize / move later
-- [ ] all required audits for this route (from `ROUTING-MATRIX.md` `### Audit` section) are identified and each has an explicit run status: **已通过** (passed, with evidence visible in the artifact or process log), **已跳过（附理由）** (skipped, with documented reason), or **未运行（附理由）** (not run, with documented reason); if any required audit is missing, it is run before the report is considered ready
+- [ ] all required audits for this route (from `ROUTING-MATRIX.md` `### Audit` section) are identified and each has an explicit run status: **已通过** (passed, with evidence visible in the artifact via the standardized 「证据」column — see `references/report-template.md` §Route and audit status), **已跳过（附理由）** (skipped, with documented reason), or **未运行（附理由）** (not run, with documented reason); if any required audit is missing, it is run before the report is considered ready
 
 ## Route selection visibility
 

--- a/references/report-template.md
+++ b/references/report-template.md
@@ -226,13 +226,13 @@ This symmetry matters because asymmetric structure signals to the reader that on
 **Primary route**: Provider / Vendor Selection
 **Secondary route**: Regulatory / Policy Impact Analysis
 
-| Audit | Status | Notes |
-|-------|--------|-------|
-| route-activation-audit | ✅ Passed | Route selection correct, no Do-not-use violation |
-| option-selection-final-audit | ✅ Passed | Shortlist, reversal conditions, runner-up all executed |
-| source-traceability | ✅ Passed | Source Register structured, body has [SN] citations |
-| final-audit | ✅ Passed | Core gates 7/7 |
-| regulatory secondary hard-fail | ⚠️ Skipped | Compliance impact already covered in body, not executed as standalone secondary route |
+| Audit | Status | 证据 |
+|-------|--------|------|
+| route-activation-audit | ✅ Passed | §3-§5 路由选择正确，无 Do-not-use 违规 |
+| option-selection-final-audit | ✅ Passed | §4 短名单、反转条件、次优选项均已执行 |
+| source-traceability | ✅ Passed | 正文使用 [S01]-[S12] 引用，附录为 7 列 Source Register |
+| final-audit | ✅ Passed | 各核心关卡在正文可追溯（§2-§6, §8） |
+| regulatory secondary hard-fail | ⚠️ Skipped | §6 合规影响已在正文覆盖，未作为独立次级路由运行 |
 ```
 
 **格式模板（shared-workflow 路径）：**
@@ -242,10 +242,10 @@ This symmetry matters because asymmetric structure signals to the reader that on
 
 **Route**: Shared-workflow (no specialized route selected)
 
-| Audit | Status | Notes |
-|-------|--------|-------|
-| workflow-spine-audit | ✅ Passed | Workflow spine audit complete, spine gates 5/5 |
-| final-audit | ✅ Passed | Final audit passed, core gates 7/7 |
+| Audit | Status | 证据 |
+|-------|--------|------|
+| workflow-spine-audit | ✅ Passed | 各工作流关卡在正文可追溯（§2-§6） |
+| final-audit | ✅ Passed | 各核心关卡在正文有对应检查标记 |
 ```
 
 **规则：**
@@ -260,6 +260,11 @@ This symmetry matters because asymmetric structure signals to the reader that on
   - **未运行（附理由）** — 审计因故未运行，理由需明确
 - 该区块不追求详尽审计记录，只追求评审者可见——证明审计已运行
 - **一致性要求**：区块中每个声称已通过的审计（✅ Passed 或等效表达/emoji）必须在正文或交付物结构中有对应的执行证据（如 source-traceability ✅ 需要正文存在 `[SN]` 引用，workflow-spine-audit ✅ 需要交付物有清晰的工作流结构）；无对应执行证据的 ✅ Passed 视为自评不准确，由 final-audit 门控标记为未通过
+- **证据列要求**：每项审计的「证据」列必须填写具体的正文引用，不得为空或仅写"是"、"通过"等无明确引用内容：
+  - ✅ **已通过 (Passed)** — 引用执行证据的具体位置（章节号、检查项编号、或 Source Register 条目）
+  - ⚠️ **已跳过 (Skipped)** — 引用正文中说明跳过理由的章节位置，或说明"§X 已在正文覆盖，未独立运行"
+  - ❌ **未运行 (Not run)** — 引用正文中说明未运行原因的章节位置
+  「证据」列与 Status 列的自评状态共同构成可审计记录——评审者无需全文扫描即可定位每项审计的执行证据或决定理由
 - 如果路由未选择（shared-workflow 路径），列出 `workflow-spine-audit.md` 和 `final-audit.md` 的运行状态
 
 ### 9. Sources

--- a/references/route-activation-and-preflight.md
+++ b/references/route-activation-and-preflight.md
@@ -98,7 +98,7 @@ In the execution contract (Step 4), add the following requirement: the final del
 This block makes the route selection and audit run status visible to anyone reading the final report, without requiring access to the process log.
 
 - list all required audits for the declared route(s) from `ROUTING-MATRIX.md` `### Audit` sections, along with `route-activation-audit` status and (if a secondary route is declared) the secondary route's hard-fail verification status
-- for each audit, record one of: **已通过** (passed), **已跳过（附理由）** (skipped, with documented reason), **未运行（附理由）** (not run, with documented reason)
+- for each audit, record its status (**已通过** / **已跳过（附理由）** / **未运行（附理由）**) and a concrete evidence citation in the standardized 「证据」column (chapter reference, checklist item number, or Source Register entry — see `references/report-template.md` §证据列要求)
 - if no specialized route applies (shared-workflow path), list at least `workflow-spine-audit.md` and `final-audit.md` with their run statuses
 
 Do not treat this block as optional or as a process-log-only concern. If the reader cannot see which audits ran, the audit framework has not been delivered.


### PR DESCRIPTION
## 改动

审计状态区块增加「证据」列，将原来自由注释的 Notes 改为结构化引用的证据列，防止空口声明。

### 改动文件（5 个）

**references/report-template.md**
- Notes 列 → 证据 列（路由已选择 + shared-workflow 两个模板）
- 示例内容从模糊说明改为具体章节/register 引用
- 替换不可验证的"7 项核心关卡"/"5 道工作流关卡"为"各核心关卡"/"各工作流关卡"
- 增加「证据列要求」规则，覆盖三种状态：Passed 引用执行证据位置；Skipped/Not run 引用决定理由位置

**checklists/final-audit.md**
- 增加 Tier-2 定义（区别于 Tier-1 阻断级和 (非阻塞) 质量信号）
- 增加 2 条 Tier-2 检查项：证据列引用非空；引用真实存在且实质匹配

**ROUTING-MATRIX.md、route-activation-and-preflight.md、route-activation-audit.md**
- 同步引用「证据」列要求

### 审核过程
- 两个独立 subagent 交叉审核
- 修复所有 blocker：Tier-2 定义、Skipped 规则覆盖、假证据鲁棒性
- 同步 3 个下游引用文件

Closes #198