### PR TITLE
feat: add process-integrity hard-fail gate to final-audit (#202)

### DIFF
--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -54,14 +54,19 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] where the task warrants it, counter-evidence handling is recoverable from the process artifact
 - [ ] required audits are named and statused rather than merely assumed
 - [ ] the artifact includes a standardized route-and-audit-status block (via `references/report-template.md` §Route and audit status), with audit run status visible in the artifact itself (not only in a process log)
-- [ ] the audit status block matches the actual report body: each self-assessment claiming passage (✅ Passed or equivalent phrasing or emoji) in the block has corresponding visible execution evidence in the artifact body or structure; if the body shows missing citations, incomplete source register entries, missing route-required sections, or other hard-fail conditions, the block must reflect that status rather than claiming full passage
+- [ ] the audit status block matches the actual report body: each self-assessment claiming passage (✅ Passed or equivalent phrasing or emoji) in the block has corresponding visible execution evidence in the artifact body or structure; if the body shows missing citations, incomplete source register entries, missing route-required sections, or other hard-fail conditions, the block must reflect that status rather than claiming full passage （阻断级）
 
-  > Tier-2 说明：深度验证检查，不通过需记录理由但不必然阻断交付。区别于 Tier-1（阻断级，不通过不可交付）和 (非阻塞)（质量信号，不通过属于改进项）。
+- [ ] Process-integrity gate（阻断级）: self-assessment inconsistency triggers delivery block
+  - 触发条件：当第 57 行检查未通过时，此 gate 自动触发——审计状态块中任何 discipline 标为 ✅ 已通过，但正文检查显示该 discipline 未达标（正文缺少 `[SN]` 引用、Source Register 列不完整、缺少路由要求的章节）
+  - 即使报告内容质量高，虚假的质量信号本身就是不可交付的状态——触发此 hard-fail gate 时报告视为未通过 final-audit，无论其他所有检查项通过与否
+  - 此 gate 独立于其他所有检查项，是 final-audit 的最后防线
 
 - [ ] （Tier-2）每项审计的「证据」列附有与状态对应的具体引用，不可为空：
   - ✅ Passed → 执行证据位置（章节号、检查项编号或 register 条目）
   - ⚠️ Skipped / ❌ Not run → 决定理由在正文中的位置
 - [ ] （Tier-2）自称通过项的证据列引用的章节/条目确实存在且满足对应审计要求：引用的章节号/标题在正文中真实存在（非虚构引用）；引用内容与审计要求实质匹配——如 source-traceability ✅ 引用"正文使用 [S01]-[SN] 引用，附录为 7 列 Source Register"，则需验证正文确有 `[SN]` 引用且 register 满足 7 列模板格式
+
+  > Tier-2 说明：深度验证检查，不通过需记录理由但不必然阻断交付。区别于 Tier-1（阻断级，不通过不可交付）和 (非阻塞)（质量信号，不通过属于改进项）。
 - [ ] (非阻塞) cross-chapter label consistency: the same data point uses the same evidence label across all chapters; if the uncertainty register lists an item, bull/bear sections that reference it should cross-reference or maintain a consistent confidence level
 - [ ] if the task used a specialized route, there is visible evidence that the route was turned into an execution contract before full drafting
 


### PR DESCRIPTION
## 背景

Issue #202 指出：Round 6 的 12 个 eval case 中 **100%** 存在审计状态块声明全部 ✅ 已通过，但正文证据不支持该声明的问题。

## 变更内容

仅改 `checklists/final-audit.md` 一个文件：

1. **Line 57 增加（阻断级）标注**：现有的一致性检查项明确标记为阻断级
2. **新增 Process-integrity gate（阻断级）**：命名门控，与普通检查项分离
   - 触发条件明确引用第 57 行检查结果，不重复条件描述
   - 移除开放式的 catch-all 短语，仅保留三个客观可验证条件
   - 明确"即使内容质量高，虚假质量信号不可交付"原则
   - 声明独立于其他所有检查项
3. **Tier-2 blockquote 移到最后一项 Tier-2 检查之后**：消除原位置 (line 59) 容易被误判为影响 line 57 的歧义
4. **去除加粗格式**：与其他 checklist item 格式一致

## 交叉审核修复

在初始提交后，启动两个独立 subagent 做交叉审核，发现并修复了：

- **冗余问题**: 原有 check (line 57) 与新 gate (line 59) 检查同一条件，关系不明确 → 修复：gate 的触发条件直接引用"当第 57 行检查未通过时"
- **Catch-all 过度开放**: "或其他 hard-fail 条件"赋予评审者无限裁量权 → 移除
- **格式不一致**: gate 标题使用 `(HARD FAIL)` 与文档中 `（阻断级）` 不一致；且使用了加粗 → 统一为 `（阻断级）`，去除加粗

## 范围说明

Issue #202 提出的其他修改（证据列、tri-state 格式）已在 #184/#192/#198 完成，本 PR 不重复改动。

## 验收

- [x] 一致性检查项明确标注为阻断级
- [x] Process-integrity gate 作为命名门控存在，触发条件引用 line 57
- [x] Gate 独立于其他检查项，虚假质量信号不可交付
- [x] Tier-2 blockquote 明确仅覆盖 Tier-2 项
- [x] 通过两轮独立 subagent 交叉审核，所有 Important 级别以上问题已修复

Closes #202
