### PR TITLE
feat: Source Register 7列模板强制阻断 + 学术11列扩展模板 + 百科来源分类指引 (#204)

### DIFF
--- a/checklists/academic-analysis-audit.md
+++ b/checklists/academic-analysis-audit.md
@@ -56,7 +56,8 @@ This checklist verifies that the academic route was executed correctly and the f
 - [ ] （Tier-1）预印本/工作论文标注 "未同行评审"：preprints are explicitly labeled as "not peer-reviewed"
 - [ ] the report does not conflate study design quality with publication venue prestige
 - [ ] the report distinguishes between original research and secondary sources
-- [ ] source register must use the 7-column template (ID / Source Name / Source Type / Date / DOI or URL / Reliability / Claims Supported) defined in `references/source-traceability-and-claim-citation.md` (§Structured Source Register Template). 来源注册表必须使用该 7 列模板。
+- [ ] source register must use the 7-column template (ID / Source Name / Source Type / Date / DOI/URL / Reliability / Claims Supported) defined in `references/source-traceability-and-claim-citation.md` (§Structured Source Register Template). 来源注册表必须使用该 7 列模板。
+- [ ] （Academic）Academic / Literature Review 路线的 Source Register 必须使用 11 列学术扩展模板（7 列基础 + Publication Type / Peer-review Status / Venue / Venue Prestige），定义见 `references/academic-evidence-hierarchy.md`（§Source Register 扩展模板（Academic 专用））——仅限 primary route 为 academic 或 literature review 的报告
 
 ## Artifact contract verification
 

--- a/checklists/source-traceability.md
+++ b/checklists/source-traceability.md
@@ -22,6 +22,7 @@ Run through every item before delivering the final report.
 
 ## Source register
 
+- [ ] **hard-fail gate（阻断级）**: Source Register 必须使用 7 列模板（ID / Source Name / Source Type / Date / DOI/URL / Reliability / Claims Supported），定义见 `references/source-traceability-and-claim-citation.md`（§Structured Source Register Template）。缺失 7 列中的任意 1 列 → **不可交付**
 - [ ] source register is present and structured (not a loose bibliography)
 - [ ] source register uses the 7-column template: ID / Source Name / Source Type / Date / DOI/URL / Reliability / Claims Supported
 - [ ] every register entry has a DOI/URL where available; for offline sources, the limitation is noted explicitly

--- a/references/academic-evidence-hierarchy.md
+++ b/references/academic-evidence-hierarchy.md
@@ -135,10 +135,10 @@ When citing academic sources, **always label**:
 
 1. **Title**: paper title (e.g., "Attention Is All You Need")
 2. **Publication type**: published / preprint / conference / working paper / unpublished
-3. **Peer-review status**: peer-reviewed / not peer-reviewed / unknown
+3. **Peer-review Status**: peer-reviewed / not peer-reviewed / unknown
 4. **Publication venue**: journal name, conference name, or repository
 5. **Publication date**: year (and month if available for fast-moving fields)
-6. **DOI or URL**: when available
+6. **DOI/URL**: when available
 
 Example labeling:
 ```

--- a/references/academic-evidence-hierarchy.md
+++ b/references/academic-evidence-hierarchy.md
@@ -154,12 +154,46 @@ Example labeling:
 |------|------|------|
 | **标题** | 论文/报告标题 | "Attention Is All You Need" |
 | **Publication type** | 原始研究/综述/预印本/工作论文/会议论文/书籍章节/报告 | original research / review / preprint |
-| **Peer-review status** | 同行评审状态 | peer-reviewed / preprint / unknown |
+| **Peer-review Status** | 同行评审状态 | peer-reviewed / preprint / unknown |
 | **Venue** | 期刊名/会议名/出版商 | NeurIPS 2017 / arXiv |
-| **DOI or URL** | 永久标识符或可访问链接 | 10.xxxx/xxxxx 或 https://... |
+| **DOI/URL** | 永久标识符或可访问链接 | 10.xxxx/xxxxx 或 https://... |
 | **Date** | 发表日期（至少年份） | 2017 |
 
 此要求与 `references/source-traceability-and-claim-citation.md` 中的结构化 source register 要求一致，是学术路由来源标注的具体扩展。
+
+### Source Register 扩展模板（Academic 专用）
+
+Academic / Literature Review 路线的 Source Register 必须在 7 列基础模板之上增加 4 列学术附加元数据，形成 11 列扩展模板：
+
+| # | 列名 | 说明 | 示例 |
+|---|------|------|------|
+| 1 | **ID** | 来源编号 | S01 |
+| 2 | **Source Name** | 论文/报告标题 | "Attention Is All You Need" |
+| 3 | **Source Type** | 来源类型（5 类简化或 8 类粒度） | primary |
+| 4 | **Date** | 发表日期（至少年份） | 2017 |
+| 5 | **DOI/URL** | 永久标识符或可访问链接 | 10.xxxx/xxxxx |
+| 6 | **Reliability** | 可靠性评级 | high / medium / low |
+| 7 | **Claims Supported** | 正文引用章节 | §3.1, §4.3 |
+| 8 | **Publication Type** | 研究类型 | original research / survey / benchmark / position paper / review / case report |
+| 9 | **Peer-review Status** | 同行评审状态 | peer-reviewed / preprint / working paper / unpublished / unknown |
+| 10 | **Venue** | 发表场所 | NeurIPS 2017 / arXiv / Nature |
+| 11 | **Venue Prestige** | 场所声誉等级（如适用） | Tier 1 — Tier 7（见上文「Dimension 2: Publication venue prestige」） |
+
+**Register 表格示例：**
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported | Publication Type | Peer-review Status | Venue | Venue Prestige |
+|----|-------------|-------------|------|---------|-------------|-----------------|-----------------|-------------------|-------|---------------|
+| S01 | Attention Is All You Need | primary | 2017 | 10.xxxx/xxxxx | high | §2.1, §4.3 | original research | peer-reviewed | NeurIPS 2017 | Tier 2 |
+| S02 | Scaling Laws for LLMs | primary | 2024 | arXiv:2401.xxxxx | medium | §2.2 | original research | preprint | arXiv | Tier 5 |
+| S03 | LLM Safety Survey | secondary | 2025 | 10.xxxx/yyyyy | medium | §3.1 | survey | peer-reviewed | ACM Computing Surveys | Tier 3 |
+
+**规则说明：**
+- 此 11 列模板是 7 列基础模板的学术扩展，仅适用于 Academic / Literature Review 路线。非学术路由仍使用 7 列基础模板。
+- **Publication Type**（第 8 列）：标注研究设计性质，帮助读者区分原始研究与综述等次级文献。
+- **Peer-review Status**（第 9 列）：区分已同行评审发表、预印本、工作论文；预印本必须标注 `preprint`，不得标为 `peer-reviewed`。
+- **Venue**（第 10 列）：标注具体期刊/会议/仓库名称，不得仅写 "journal" 或 "conference"。
+- **Venue Prestige**（第 11 列）：当报告使用了证据层级框架（双维评估）时必填；否则可填 `N/A`。
+- 如果某个来源不适合标注全部 11 列（如灰色文献、技术报告），缺少的列应注明原因（如 "venue prestige: N/A — technical report"），不可直接省略。
 
 ## Statistical assessment
 

--- a/references/source-quality.md
+++ b/references/source-quality.md
@@ -261,3 +261,21 @@ When consuming results from a local Research API (e.g. Agent-Reach), map the API
 > **Hard rule:** Search-level `DISCOVERY` results (unfetched search summaries) are not a valid source type for the Source Register. They live in the source intake log (see `references/external-channel-preflight.md`) and only enter the Source Register after content fetch and reclassification.
 
 **Weak-signal guard:** Social media, community discussion, and search discovery consensus must not be presented as evidence for headline conclusions. If a conclusion depends on weak signals, either downgrade the conclusion strength or supplement with a hard source (official, regulatory, primary documentation). See also `references/source-traceability-and-claim-citation.md` §Source type classification for `WEAK_SIGNAL` handling.
+
+## Tertiary encyclopedic sources (Wikipedia, Baidu Baike, etc.)
+
+Wikipedia, Baidu Baike, and similar crowd-sourced or collaboratively edited encyclopedias are **tertiary sources** — they aggregate, summarize, and interpret primary and secondary sources. They are **never** primary evidence.
+
+### Classification rules
+
+- **Not valid as `PRIMARY_COMPANY`, `PRIMARY_FILING`, or `PRIMARY_DEV`.** These types require official, direct-from-source documentation. Wikipedia is a tertiary aggregation with variable quality per article, editorial lag, and no institutional accountability.
+- **Recommended type:** `SECONDARY_MEDIA` for well-cited articles with stable consensus; `WEAK_SIGNAL` for controversial, poorly cited, or frequently edited topics.
+- **De facto fallback:** If a claim depends on a Wikipedia article as its best available source, the claim's evidence strength is inherently weak. Downgrade the conclusion strength rather than treating the citation as solid evidence.
+- **Load-bearing prohibition:** Wikipedia alone may not support any load-bearing claim (thesis-bearing, ranking, quantitative, or strong positioning). Use Wikipedia for background, discovery, and consensus summaries only. Every load-bearing claim must have a direct primary or secondary source as its evidentiary anchor.
+
+### Usage guidance
+
+- Wikipedia is useful for: discovery of primary sources (via the reference list at the bottom of each article), factual consensus on well-established topics (e.g., founding dates, historical events), and background context.
+- Wikipedia should not be used for: current financial data, current competitive positioning, product specifics, regulatory interpretation, or any claim where precision or timeliness matters.
+- When citing Wikipedia in the Source Register, include the URL of the specific page and the retrieval date. A generic "Wikipedia" entry without a page URL does not satisfy traceability.
+- If a more authoritative source is available (official document, regulatory filing, primary interview), prefer it over Wikipedia even if Wikipedia is more convenient.


### PR DESCRIPTION
## 改动

Issue #204 的三个修复点全部实现：

### A. 7 列模板强制阻断

`checklists/source-traceability.md` — Source Register 区块新增 hard-fail gate（阻断级），缺失 7 列中任意 1 列即不可交付。

- 将 7 列模板合规从普通 checklist 项升级为阻断级，与已有的 inline citation 硬阻断强度一致
- 解决 Round 6 中 10/12 个 case 的 register 列不全问题

### B2. 学术 11 列扩展模板

`references/academic-evidence-hierarchy.md` — 新增 `### Source Register 扩展模板（Academic 专用）` 节，定义 11 列扩展模板（7 列基础 + Publication Type / Peer-review Status / Venue / Venue Prestige），含列定义表格、Register 示例、规则说明。

`checklists/academic-analysis-audit.md` — Source labeling 区新增 academic 专用 checklist 项，要求 academic 路由使用 11 列扩展模板。

- 11 列模板仅适用于 academic 路由，非 academic 仍然使用 7 列基础模板
- 通过 `§Source Register 扩展模板（Academic 专用）` 双向引用，与现有规则体系一致

### C. 百科来源分类指引

`references/source-quality.md` — 新增 `## Tertiary encyclopedic sources (Wikipedia, Baidu Baike, etc.)` 节，包含分类规则和使用指引：

- 明确 Wikipedia 不可标为 PRIMARY_COMPANY / PRIMARY_FILING / PRIMARY_DEV
- 推荐分类：SECONDARY_MEDIA（稳定条目）或 WEAK_SIGNAL（争议条目）
- 禁止用于 load-bearing claim
- 引用时须附 URL 和 retrieval date

## 未覆盖（不在此 PR 范围内）

- Eval case 本身的修复（仅改规则文件，不改 eval case）
- ROUTING-MATRIX.md 不涉及
- 7 列模板定义本身不变（`source-traceability-and-claim-citation.md` 不动）

## 风险

- 7 列 blocker 可能将部分原本 conditional pass 的报告降为 fail。测试方法：使用现有 eval case 重新跑一遍，验证是否有误判
- 学术 11 列模板仅对 primary route = academic 生效，非 academic 报告不受影响
- 百科指引是新增规则，不影响已交付报告

Closes #204