### PR TITLE
定量角色标注检查强化与跨路线扩展（Round 6 P1）

### DIFF
--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -180,7 +180,7 @@ Use when the task is mainly about:
 - current-state verification
 - source traceability
 - decision utility
-- quantitative role labeling when market size, payback, cost assumptions, sequencing thresholds, or scenario-style numbers materially affect the recommendation
+- quantitative role labeling when market size, payback, cost assumptions, sequencing thresholds, or scenario-style numbers materially affect the recommendation — see `checklists/quantitative-role-audit.md` §Route-specific checks (Market Entry)
 - sensitivity analysis when the recommendation depends on load-bearing numerical assumptions (growth rates, market size, payback periods)
 
 ### Audit
@@ -246,7 +246,7 @@ Concrete boundary examples:
 - forward-looking claims discipline
 - source traceability
 - scope completeness when the report claims global or broad market scope
-- quantitative role labeling when forecasts or scenario math appear
+- quantitative role labeling when forecasts or scenario math appear — see `checklists/quantitative-role-audit.md` §Route-specific checks (Market Outlook)
 - sensitivity analysis when forecasts, market size estimates, or adoption projections materially affect the conclusion
 
 ### Audit
@@ -361,7 +361,7 @@ Use when the task is mainly about:
 
 ### Attach
 - decision utility
-- quantitative role labeling when scoring, weighting, burden proxies, cost comparisons, or scenario comparisons materially affect ranking or recommendation
+- quantitative role labeling when scoring, weighting, burden proxies, cost comparisons, or scenario comparisons materially affect ranking or recommendation — see `checklists/quantitative-role-audit.md` §Route-specific checks (Constrained Choice)
 
 ### Audit
 - `checklists/option-selection-final-audit.md`
@@ -646,6 +646,7 @@ Use when the task is mainly about:
 - scope completeness when the report makes global market-position or global competitive claims
 - decision utility
 - sensitivity analysis when valuation, growth assumptions, or financial projections materially affect the investment thesis
+- quantitative role labeling when valuation ranges, industry forecasts, or scenario estimates materially affect the investment thesis — see `checklists/quantitative-role-audit.md` §Route-specific checks (Listed Company)
 
 For this route, current-state verification must explicitly lock:
 
@@ -744,6 +745,7 @@ Use when the task is mainly about:
 - current-state verification (funding status, product stage, team composition)
 - source traceability (especially for unverified founder claims)
 - forward-looking claims discipline (PMF signals, growth projections, runway estimates)
+- quantitative role labeling when ARR/MRR estimates, valuation multiples, or growth projections materially affect the assessment — see `checklists/quantitative-role-audit.md` §Route-specific checks (Startup)
 - decision utility when the task carries investment or partnership judgment
 
 ### Audit
@@ -898,6 +900,7 @@ Fail if:
 
 ### Quantitative role labeling
 Attach when the task uses proxies, scorecards, market sizing, scenario math, or composite scoring.
+See `checklists/quantitative-role-audit.md` §Route-specific checks for route-specific BLOCKER/NON-BLOCKER checks.
 
 Visible sign:
 - important numbers are labeled as observed fact / proxy / assumption / model output / illustrative calculation

--- a/checklists/option-selection-final-audit.md
+++ b/checklists/option-selection-final-audit.md
@@ -69,7 +69,8 @@ Run this checklist before delivery.
 - [ ] model synthesis / recommendation is distinguishable from raw source claims
 - [ ] strong negative or positive reputation claims are scoped and not treated as hard facts by default
 - [ ] source register must use the 7-column template (ID / Source Name / Source Type / Date / DOI or URL / Reliability / Claims Supported) defined in `references/source-traceability-and-claim-citation.md` (§Structured Source Register Template). 来源注册表必须使用该 7 列模板。
-- [ ] （非阻塞）所有比较表、评分表、估算表包含数字角色列（或等效的表头角色行/表注），见 `references/quantitative-role-labeling.md` §表格中的角色标签
+- [ ] [BLOCKER] 所有比较表、评分表、估算表包含数字角色列（或等效的表头角色行/表注），见 `references/quantitative-role-labeling.md` §表格中的角色标签
+- [ ] [BLOCKER] 如果评分/排名系统中的 >3 个关键数字缺少角色标签（observed/proxy/assumption/model-output），触发 hard-fail（参见 ROUTING-MATRIX.md Constrained Choice hard-fail：`uses numbers without labeling observed fact / proxy / assumption / model output`）
 
 ## Scenario logic and change conditions
 

--- a/checklists/option-selection-final-audit.md
+++ b/checklists/option-selection-final-audit.md
@@ -69,8 +69,8 @@ Run this checklist before delivery.
 - [ ] model synthesis / recommendation is distinguishable from raw source claims
 - [ ] strong negative or positive reputation claims are scoped and not treated as hard facts by default
 - [ ] source register must use the 7-column template (ID / Source Name / Source Type / Date / DOI or URL / Reliability / Claims Supported) defined in `references/source-traceability-and-claim-citation.md` (§Structured Source Register Template). 来源注册表必须使用该 7 列模板。
-- [ ] [BLOCKER] 所有比较表、评分表、估算表包含数字角色列（或等效的表头角色行/表注），见 `references/quantitative-role-labeling.md` §表格中的角色标签
-- [ ] [BLOCKER] 如果评分/排名系统中的 >3 个关键数字缺少角色标签（observed/proxy/assumption/model-output），触发 hard-fail（参见 ROUTING-MATRIX.md Constrained Choice hard-fail：`uses numbers without labeling observed fact / proxy / assumption / model output`）
+- [ ] [BLOCKER] All comparison, scoring, and estimation tables must include a numeric role column (or equivalent header row / table note), per `references/quantitative-role-labeling.md` §表格中的角色标签。所有比较表、评分表、估算表必须包含数字角色列（或等效的表头角色行/表注）。
+- [ ] [BLOCKER] If >3 critical numbers in a scoring/ranking system lack role labels (observed / proxy / assumption / model-output) → hard-fail (see ROUTING-MATRIX.md §Constrained Choice hard-fail: `uses numbers without labeling observed fact / proxy / assumption / model output`). "关键数字"定义见 `references/quantitative-role-labeling.md` §What should be labeled（materially affect ranking / recommendation / sequencing / timing / valuation / confidence）。注意：辅助性描述数字（如"约 5 年"、"数万用户"）不受此规则限制。
 
 ## Scenario logic and change conditions
 

--- a/checklists/quantitative-role-audit.md
+++ b/checklists/quantitative-role-audit.md
@@ -20,6 +20,40 @@ If load-bearing numbers materially affect the conclusion, their roles should be 
 - The dependency conditions in each assumption chain are reasonable for the context.
 - The failure signals in each assumption chain are observable and actionable (not generic disclaimers).
 
+## Route-specific checks
+
+> **例外说明（所有路线）**：辅助性描述数字（如"约 5 年"、"数万用户"、"少量"、"~3-5 人"）不强制要求逐项标注角色标签。如果已标注角色标签（如 ASSUMPTION）则正常通过。此例外不适用于评分/排名表格中直接影响排序的 load-bearing 数字。"关键数字"定义参见 `references/quantitative-role-labeling.md` §What should be labeled（materially affect recommendation / ranking / shortlist / sequencing / timing / valuation / confidence）。
+
+### Constrained Choice / Shortlist / Option Selection
+
+- [BLOCKER] Key numbers in scoring/ranking systems (star ratings, weight scores, cost estimates, growth rates, plugin/ecosystem counts) must carry role labels (observed / proxy / assumption / model-output).
+- [BLOCKER] If >3 critical scoring/ranking numbers lack role labels ("critical" per `references/quantitative-role-labeling.md` §What should be labeled) → hard-fail (see ROUTING-MATRIX.md §Constrained Choice hard-fail).
+- [NON-BLOCKER] Composite score breakdown — which dimensions are observed vs. modeled — should be visible in the table or a note.
+
+### Market Outlook / Industry Evolution
+
+- [BLOCKER] Load-bearing numbers (market size, growth rates, scenario probabilities, adoption projections) must carry role labels (observed / estimate / scenario-assumption / model-output).
+- [NON-BLOCKER] Scenario probabilities (e.g., "20-25%") should include estimation method or source basis, not bare qualitative judgment.
+- [NON-BLOCKER] This route already has a "mixes observed facts with scenario assumptions" hard-fail (ROUTING-MATRIX.md §Market Outlook, enforced by `checklists/market-outlook-audit.md`). These role-label checks serve as defense-in-depth.
+
+### Listed Company / Investment-style Research
+
+- [NON-BLOCKER] Forward-looking numbers (industry forecasts, market-share probabilities, "提升 X%" claims) should carry source-role labels (analyst estimate / model-output / assumption / company-guidance).
+- [NON-BLOCKER] Valuation multiples, PE historical midpoints, industry-average PE — if no explicit source role, at least distinguish observed (annual-report / filing) vs. inferred (calculation / estimate).
+- [NON-BLOCKER] Input parameters in valuation sensitivity analysis should carry role labels.
+
+### Startup / Private Company Evaluation
+
+- [NON-BLOCKER] ARR/MRR source type must be explicit: company-reported / estimated / inferred (see `checklists/startup-company-report.md` §Funding and financials). This is complementary to the core role labels (observed / proxy / assumption / model-output) — use both.
+- [NON-BLOCKER] Valuation multiples (e.g., PS 100x) require boundary conditions: private-company premium context and comparable-transaction range source role.
+- [NON-BLOCKER] "预计 X" / "估测 Y" / "约 Z" claims must include method note or source role — bare hedge wording insufficient.
+
+### Market Entry / Regional Expansion
+
+- [NON-BLOCKER] Scoring/weighting matrices used for country or site ranking must label per-score role (observed / proxy / model-output).
+- [NON-BLOCKER] Load-bearing numbers (market size, payback period, localization cost, sequencing thresholds) must carry role labels (observed / estimate / assumption / model-output).
+- [NON-BLOCKER] When a secondary Constrained Choice route is declared, the CC route's quantitative role BLOCKER checks apply (see `ROUTING-MATRIX.md` §Secondary route hard-fail requirement).
+
 ## Sensitivity analysis checks
 
 - [BLOCKER] Has each load-bearing numerical assumption been classified by sensitivity level (low / medium / high) per `references/quantitative-role-labeling.md`?
@@ -27,32 +61,6 @@ If load-bearing numbers materially affect the conclusion, their roles should be 
 - [NON-BLOCKER] If the report includes scenario analysis (optimistic / base / pessimistic), verify that key assumptions also have independent sensitivity tables. Multi-variable scenario changes do not satisfy the sensitivity table requirement — scenario analysis and sensitivity analysis are complementary, not substitutes.
 - [NON-BLOCKER] Medium-sensitivity assumptions have at least the tipping point documented (the deviation at which the conclusion would change direction).
 - [NON-BLOCKER] The report states which assumptions are most load-bearing and what would change the conclusion.
-
-## Route-specific checks
-
-### Constrained Choice / Shortlist / Option Selection
-
-- [ ] [BLOCKER] 评分/排名系统中的关键数字（星级评分、权重分数、成本估算、增长率）必须标注角色标签（observed/proxy/assumption/model-output）。
-- [ ] [BLOCKER] 若 >3 个关键评分/排名数缺少角色标签 → hard-fail（参见 ROUTING-MATRIX.md Constrained Choice hard-fail）。
-- [ ] [NON-BLOCKER] 聚合评分（composite score）的来源——哪些维度是观察值、哪些是模型输出——在表格或附注中可见。
-
-### Market Outlook / Industry Evolution
-
-- [ ] 市场规模、增长率、情景概率等 load-bearing 数字必须标注角色标签（observed / estimate / scenario-assumption / model-output）。
-- [ ] 情景概率（如"20-25%"）需说明估计方法或来源依据，不能仅靠定性判断。
-- [ ] 该路线已有 "mixes observed facts with scenario assumptions" hard-fail（ROUTING-MATRIX.md），本 check 作为 defense-in-depth。
-
-### Listed Company / Investment-style Research
-
-- [ ] 行业预测、市场份额概率、"提升 X%"等前瞻性数字需注明来源角色（分析师 estimate / 模型 output / 假设 assumption）。
-- [ ] 估值倍数、PE 历史中枢、行业平均 PE 等如无明确来源角色标注，至少要区分 observed（年报/披露）vs inferred（推算/估计）。
-- [ ] [NON-BLOCKER] 估值敏感性分析中的输入参数需标注角色。
-
-### Startup / Private Company Evaluation
-
-- [ ] ARR/MRR 来源类型必须明确：company-reported / estimated / inferred（参见 `checklists/startup-company-report.md` §Funding and financials）。
-- [ ] 估值倍数（如 PS 100x）需说明估值边界条件（private company premium / 可比交易区间来源角色）。
-- [ ] "预计 X"、"估测 Y"、"约 Z"等用语需附方法说明或来源角色，不得单独以模糊表述出现。
 
 ## Hard fail signs
 

--- a/checklists/quantitative-role-audit.md
+++ b/checklists/quantitative-role-audit.md
@@ -28,6 +28,32 @@ If load-bearing numbers materially affect the conclusion, their roles should be 
 - [NON-BLOCKER] Medium-sensitivity assumptions have at least the tipping point documented (the deviation at which the conclusion would change direction).
 - [NON-BLOCKER] The report states which assumptions are most load-bearing and what would change the conclusion.
 
+## Route-specific checks
+
+### Constrained Choice / Shortlist / Option Selection
+
+- [ ] [BLOCKER] 评分/排名系统中的关键数字（星级评分、权重分数、成本估算、增长率）必须标注角色标签（observed/proxy/assumption/model-output）。
+- [ ] [BLOCKER] 若 >3 个关键评分/排名数缺少角色标签 → hard-fail（参见 ROUTING-MATRIX.md Constrained Choice hard-fail）。
+- [ ] [NON-BLOCKER] 聚合评分（composite score）的来源——哪些维度是观察值、哪些是模型输出——在表格或附注中可见。
+
+### Market Outlook / Industry Evolution
+
+- [ ] 市场规模、增长率、情景概率等 load-bearing 数字必须标注角色标签（observed / estimate / scenario-assumption / model-output）。
+- [ ] 情景概率（如"20-25%"）需说明估计方法或来源依据，不能仅靠定性判断。
+- [ ] 该路线已有 "mixes observed facts with scenario assumptions" hard-fail（ROUTING-MATRIX.md），本 check 作为 defense-in-depth。
+
+### Listed Company / Investment-style Research
+
+- [ ] 行业预测、市场份额概率、"提升 X%"等前瞻性数字需注明来源角色（分析师 estimate / 模型 output / 假设 assumption）。
+- [ ] 估值倍数、PE 历史中枢、行业平均 PE 等如无明确来源角色标注，至少要区分 observed（年报/披露）vs inferred（推算/估计）。
+- [ ] [NON-BLOCKER] 估值敏感性分析中的输入参数需标注角色。
+
+### Startup / Private Company Evaluation
+
+- [ ] ARR/MRR 来源类型必须明确：company-reported / estimated / inferred（参见 `checklists/startup-company-report.md` §Funding and financials）。
+- [ ] 估值倍数（如 PS 100x）需说明估值边界条件（private company premium / 可比交易区间来源角色）。
+- [ ] "预计 X"、"估测 Y"、"约 Z"等用语需附方法说明或来源角色，不得单独以模糊表述出现。
+
 ## Hard fail signs
 
 - Numerical precision exceeds source certainty.

--- a/references/quantitative-role-labeling.md
+++ b/references/quantitative-role-labeling.md
@@ -260,21 +260,21 @@ The assumption is named ("assume 15% growth"), but the conditions that must hold
 ## Route-specific notes
 
 ### Market entry / regional expansion
-Market size, payback, localization cost, and sequencing thresholds are often assumptions or model outputs rather than direct facts. Scoring/weighting matrices used for country ranking must label per-score role (observed / proxy / model-output).
+Market size, payback, localization cost, and sequencing thresholds are often assumptions or model outputs rather than direct facts. Scoring/weighting matrices used for country ranking must label per-score role (observed / proxy / model-output). Route-specific checks at `checklists/quantitative-role-audit.md` §Market Entry / Regional Expansion.
 
 ### Constrained choice / shortlist
 Weighted scores, burden proxies, and comparison totals often depend on proxies, assumptions, or model outputs. Star ratings, price comparisons, plugin/ecosystem counts, and growth rates must carry role labels. Composite scoring must disclose which dimensions are observed vs. modeled.
 
-This route has a hard-fail in ROUTING-MATRIX.md: `uses numbers without labeling observed fact / proxy / assumption / model output` — the option-selection final audit (`checklists/option-selection-final-audit.md`) enforces this with a BLOCKER check.
+This route has a hard-fail in ROUTING-MATRIX.md (§Constrained Choice / Shortlist / Option Selection): `uses numbers without labeling observed fact / proxy / assumption / model output` — the option-selection final audit (`checklists/option-selection-final-audit.md`) and route-specific checks (`checklists/quantitative-role-audit.md` §Constrained Choice / Shortlist / Option Selection) enforce this with BLOCKER checks.
 
 ### Market outlook / industry evolution
-Growth ranges, projected adoption, and scenario paths should not read like observed current-state facts. Scenario probabilities (e.g., "20-25%") must be accompanied by estimation method or source basis, not bare qualitative judgment. Scenario assumptions must be visibly separated from current-state observations.
+Growth ranges, projected adoption, and scenario paths should not read like observed current-state facts. Scenario probabilities (e.g., "20-25%") must be accompanied by estimation method or source basis, not bare qualitative judgment. Scenario assumptions must be visibly separated from current-state observations. Route-specific checks at `checklists/quantitative-role-audit.md` §Market Outlook / Industry Evolution.
 
 ### Listed-company / investment-style research
-Valuation ranges, scenario cases, and estimated financial outcomes often require explicit model-status visibility. Industry forecasts, market-share probabilities, and "提升 X%" claims should be labeled as estimate / analyst-inference / model-output / assumption rather than presented as established facts.
+Valuation ranges, scenario cases, and estimated financial outcomes often require explicit model-status visibility. Industry forecasts, market-share probabilities, and "提升 X%" claims should be labeled as estimate / analyst-inference / model-output / assumption rather than presented as established facts. Route-specific checks at `checklists/quantitative-role-audit.md` §Listed Company / Investment-style Research.
 
 ### Startup / private company evaluation
-ARR/MRR figures must be labeled by source type (company-reported / estimated / inferred). Valuation multiples (e.g., PS 100x) require explicit boundary conditions (private-company premium context, comparable transaction range). "预计" / "估测" / "约" claims must include method note or source role — bare hedge wording is insufficient.
+ARR/MRR figures must be labeled by source type (company-reported / estimated / inferred) — this is complementary to the core role labels (observed / proxy / assumption / model-output); both should be applied where relevant. Valuation multiples (e.g., PS 100x) require explicit boundary conditions (private-company premium context, comparable transaction range). "预计" / "估测" / "约" claims must include method note or source role — bare hedge wording is insufficient. Route-specific checks at `checklists/quantitative-role-audit.md` §Startup / Private Company Evaluation.
 
 ## Minimal display patterns
 

--- a/references/quantitative-role-labeling.md
+++ b/references/quantitative-role-labeling.md
@@ -260,16 +260,21 @@ The assumption is named ("assume 15% growth"), but the conditions that must hold
 ## Route-specific notes
 
 ### Market entry / regional expansion
-Market size, payback, localization cost, and sequencing thresholds are often assumptions or model outputs rather than direct facts.
+Market size, payback, localization cost, and sequencing thresholds are often assumptions or model outputs rather than direct facts. Scoring/weighting matrices used for country ranking must label per-score role (observed / proxy / model-output).
 
 ### Constrained choice / shortlist
-Weighted scores, burden proxies, and comparison totals often depend on proxies, assumptions, or model outputs.
+Weighted scores, burden proxies, and comparison totals often depend on proxies, assumptions, or model outputs. Star ratings, price comparisons, plugin/ecosystem counts, and growth rates must carry role labels. Composite scoring must disclose which dimensions are observed vs. modeled.
+
+This route has a hard-fail in ROUTING-MATRIX.md: `uses numbers without labeling observed fact / proxy / assumption / model output` — the option-selection final audit (`checklists/option-selection-final-audit.md`) enforces this with a BLOCKER check.
 
 ### Market outlook / industry evolution
-Growth ranges, projected adoption, and scenario paths should not read like observed current-state facts.
+Growth ranges, projected adoption, and scenario paths should not read like observed current-state facts. Scenario probabilities (e.g., "20-25%") must be accompanied by estimation method or source basis, not bare qualitative judgment. Scenario assumptions must be visibly separated from current-state observations.
 
 ### Listed-company / investment-style research
-Valuation ranges, scenario cases, and estimated financial outcomes often require explicit model-status visibility.
+Valuation ranges, scenario cases, and estimated financial outcomes often require explicit model-status visibility. Industry forecasts, market-share probabilities, and "提升 X%" claims should be labeled as estimate / analyst-inference / model-output / assumption rather than presented as established facts.
+
+### Startup / private company evaluation
+ARR/MRR figures must be labeled by source type (company-reported / estimated / inferred). Valuation multiples (e.g., PS 100x) require explicit boundary conditions (private-company premium context, comparable transaction range). "预计" / "估测" / "约" claims must include method note or source role — bare hedge wording is insufficient.
 
 ## Minimal display patterns
 


### PR DESCRIPTION
## 对应 Issue

Closes #205

## 改动摘要

### `checklists/quantitative-role-audit.md`
- 新增 **Route-specific checks** 小节，覆盖 4 条路线：
  - **Constrained Choice / Shortlist** — 评分/排名数字角色标签 hard-fail（BLOCKER）
  - **Market Outlook** — 市场规模/情景概率角色标签 check
  - **Listed Company** — 前瞻性数字/估值数字来源角色 check
  - **Startup Evaluation** — ARR/估值倍数来源类型明确 check
- 保留原有 Hard fail signs 和 Sensitivity analysis 结构不变

### `checklists/option-selection-final-audit.md`
- 第 72 行：`（非阻塞）` → `[BLOCKER]`（表格数字角色列要求升级为阻断级）
- 新增第 73 行：评分/排名系统 >3 关键数字无角色标签 → hard-fail

### `references/quantitative-role-labeling.md`
- 扩展 Route-specific notes，为每条路线补充具体数字类型举例和 enforce 要求

## 验证

- 修改基于 Round 6 的 4 个 eval cases 的真实 fail 模式
- 与 ROUTING-MATRIX.md 中已定义的 hard-fail 规则语义一致
- 不修改 ROUTING-MATRIX.md、final-audit.md，不新增文件
- 不改核心定量角色定义（5 种角色、假设链模板、敏感性分析）