### PR TITLE
feat: stale-anchor 阻断条件具体化 + startup→listed 路线切换指引（Round 6 P1 #208）

### DIFF
--- a/checklists/listed-company-report.md
+++ b/checklists/listed-company-report.md
@@ -46,6 +46,7 @@ Run through every item before delivering the final report.
 
 - [ ] stale-anchor hard gate: a missing, stale, or mis-timed research-anchor layer — latest full-year, quarterly / interim, or current market snapshot — invalidates the memo unless synthesis was stopped, the anchor was re-checked, and the anchor was corrected or visibly downgraded before continuing — per SKILL.md fail-fast rule
 - [ ] this gate applies regardless of whether listed-company is the primary route or a secondary/sub-route (per ROUTING-MATRIX.md "Secondary route hard-fail requirement")
+- [ ] （阻断级）追加触发条件（适用于 primary 和 secondary route）— 存在以下任一情况则触发 stale-anchor hard-fail，无论 anchor block 形式是否完整：a) 报告日期晚于交易所/公司官网的公告披露日期，且已发布的年度/半年度/季度报告未被纳入（即使报告声称"未获取"）；b) 报告将已公开的关键财务数据（营收、利润、现金流）当作未知值处理；c) 自上市之日起不足 2 年的公司，最近的已发布业绩公告未纳入
 
 ## Current product lineup
 

--- a/checklists/startup-company-report.md
+++ b/checklists/startup-company-report.md
@@ -10,6 +10,7 @@ Run through every item before delivering the final report.
 - [ ] current stage identified: pre-seed / seed / Series A/B/C... / growth / pre-IPO
 - [ ] source confirming status is primary and current (not stale filing language)
 - [ ] if IPO process is underway, current stage is precise (filed / accepted / under review / approved)
+- [ ] （阻断级）公司已上市（listed + trading）后，评估路线必须从 startup-company 切换为 listed-company；IPO 不等同于旧数据缺口仍在——已发布的年报/业绩公告必须纳入；未及时切换路线并使用已公开数据 → 标记为路线执行失败（触发 ROUTING-MATRIX.md "Do not use this route when: the company is publicly listed and trading" 门禁，按 wrong route 处理）
 
 ## Team and founders
 


### PR DESCRIPTION
## 对应 Issue

Close #208

## 改动内容（经交叉审核修复后）

### checklists/listed-company-report.md（+1 行，替代原 5 行）

Stale-anchor hard-fail gate 追加 3 条具体触发条件，合并为一行内联格式：
- a) 报告日期晚于交易所/公司官网公告披露日期，已发布报告未被纳入
- b) 将已公开关键财务数据当作未知值处理
- c) 上市不足 2 年的公司，最近已发布业绩公告未纳入

格式从 sub-list 改为 inline a/b/c（项目惯例），标签从（hard-fail）统一为（阻断级）。

### checklists/startup-company-report.md（+1 行）

Company status 增加路线切换阻断项：
- 公司已上市后必须从 startup-company 切换为 listed-company
- IPO 不等同于旧数据缺口仍在
- 标签从（硬性切换）统一为（阻断级）；交叉引用从 route-activation-audit 修正为 ROUTING-MATRIX.md "Do not use this route when" 门禁

## 不做

- ROUTING-MATRIX.md — 概念层已有 stale-anchor hard-fail 覆盖；新增条件是执行层细化，不重复到路由矩阵
- references/corporate-status-and-listing-state-discipline.md — 已有 IPO 过渡覆盖
- 其他文件 — scope 干净

## 交叉审核摘要

两路 subagent 独立评审，发现 6 项 non-blocker，已全部修复：

| 发现 | 严重度 | 修复 |
|------|--------|------|
|（hard-fail）与项目约定（阻断级）冲突 | non-blocker | 统一 |
|（硬性切换）未注册标签 | non-blocker | 统一为（阻断级）|
| 子列表格式无先例 | non-blocker | 改为 inline a/b/c |
| 交叉引用 route-activation-audit 中不存在所述术语 | non-blocker | 修正为 ROUTING-MATRIX.md "Do not use" |
| 新条件对 secondary route 适用范围不显式 | non-blocker | 追加（适用于 primary 和 secondary route）|
| 缺省 措辞歧义（default vs 缺位）| non-blocker | 改为 追加触发条件 |

## Eval 覆盖

- evals/cases/pop-mart-overseas-growth-stale-anchor-hard-fail-case.md — 模式 A
- evals/cases/minimax-valuation-stale-anchor-and-missing-financials-case.md — 模式 B

## 风险

低。只增加清单项，不改变现有逻辑结构。