### PR TITLE
Harden forward-looking label checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - 'scripts/**'
       - 'schemas/**'
       - 'examples/**'
+      - 'checklists/**'
+      - 'references/**'
+      - 'evals/**'
       - 'requirements.txt'
       - '.github/workflows/ci.yml'
   push:
@@ -14,6 +17,9 @@ on:
       - 'scripts/**'
       - 'schemas/**'
       - 'examples/**'
+      - 'checklists/**'
+      - 'references/**'
+      - 'evals/**'
       - 'requirements.txt'
       - '.github/workflows/ci.yml'
   workflow_dispatch:
@@ -32,6 +38,7 @@ jobs:
       - run: python3 scripts/validate_research_pack.py examples/research-pack-example.md
       - run: python3 scripts/validate_research_pack.py examples/research-pack-example.md --strict
       - run: python3 scripts/test_validator_regression.py
+      - run: python3 scripts/test_forward_looking_label_lint.py
       - run: python3 scripts/test_md_to_pdf_preflight.py
 
   smoke:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ This file is intentionally lightweight. Use concise entries that explain:
 ## Unreleased
 
 ### Added
+- `checklists/market-outlook-audit.md`: added forward-looking label hard-fail gate — market-outlook numeric claims containing `预计` / `预测` / `expected` / `forecast` / `will reach` / `by 20xx` must not be labeled `[确认]` / `[CONF]`; separates confirmed source-event facts from future outcome claims (#222).
+- `checklists/forward-looking-claims.md` and `checklists/final-audit.md`: added confirmed-label prohibition and recall wording for forward-looking numeric claims, including official/analyst forecast boundary and already-realized observed-data exemption (#222).
+- `scripts/validate_forward_looking_labels.py` and `scripts/test_forward_looking_label_lint.py`: added lightweight fixture-scoped lint and regression tests for forward-looking numeric claims mislabeled as confirmed facts (#222).
+- `.github/workflows/ci.yml`: runs the new forward-looking label lint regression test and triggers CI for checklist/reference/eval changes (#222).
+- `evals/cases/dc-power-market-outlook-forward-looking-label-gap-case.md`, `evals/cases/ai-video-market-outlook-label-and-probability-gap-case.md`, and `evals/cases/embodied-ai-market-outlook-register-and-label-gap-case.md`: added Round 7 market-outlook eval cases covering forward-looking `[确认]` / `[CONF]` misuse, source-role gaps, and bare probability patterns (#222).
 - `ROUTING-MATRIX.md`: added Route boundary resolution requirement — when a report identifies a close alternative route but stays in the current route, must document which specific hard-fail conditions were checked and why they don't apply, plus route-switch conditions (#209).
 - `checklists/route-activation-audit.md`: added （阻断级）check for secondary route hard-fail verification skip — "covered elsewhere without independent run" constitutes a hard-fail (#209).
 - `checklists/academic-analysis-audit.md`: added Tier-1 hard-fail for secondary route verification — when a secondary route is declared, its hard-fail verification must be itemized; "covered elsewhere without independent run" is a hard-fail (#209).

--- a/SYSTEM-MAP.md
+++ b/SYSTEM-MAP.md
@@ -294,10 +294,14 @@ Controls forecasts, roadmap statements, target dates, and estimate-heavy claims 
 - `evals/cases/consensus-and-forward-pe-misuse-case.md`
 - `evals/cases/humanoid-robot-market-outlook-dual-route-case.md`
 - `evals/cases/ai-cost-control-market-outlook-full-pass-benchmark.md`
+- `evals/cases/dc-power-market-outlook-forward-looking-label-gap-case.md`
+- `evals/cases/ai-video-market-outlook-label-and-probability-gap-case.md`
+- `evals/cases/embodied-ai-market-outlook-register-and-label-gap-case.md`
 - `evals/comparative-distillation/byd-gpt-vs-minimax-comparative-distillation.md`
 
 ### Typical failure signs
 - `预计` / `expected` / `likely` without source role
+- forward-looking numeric claims labeled `[确认]`, `[已确认事实]`, or `[CONF]`
 - roadmap claims without announced vs rumored separation
 - consensus numbers without source or date
 - estimate language without assumption chain

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -150,6 +150,7 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] for market-outlook / industry-evolution tasks, a current market snapshot was verified before forward-looking sections
 - [ ] for market-outlook / industry-evolution tasks, drivers, blockers, scenarios, and stakeholder implications are explicit rather than implied
 - [ ] for market-outlook / industry-evolution tasks, all forward-looking claims have visible source role and time basis; derived, modeled, or load-bearing forecasts also show key assumptions and failure / reversal conditions
+- [ ] for market-outlook / industry-evolution tasks, forward-looking numeric claims containing `预计` / `预测` / `预期` / `将达` / `有望` / `expected` / `forecast` / `projected` / `estimated to` / `will reach` / `by 20xx` are not labeled `[确认]`, `[已确认事实]`, `[CONF]`, or `[Confirmed]`; >3 violations or any load-bearing scenario assumption labeled confirmed facts triggers hard-fail
 - [ ] for market-outlook / industry-evolution tasks, structured multi-scenario analysis exists (at minimum base case + one alternative) with quantitative ranges on the same load-bearing metric and trigger conditions
 - [ ] for market-outlook / industry-evolution tasks, stakeholder implications cover at least 3 distinct stakeholder types, not only investors
 - [ ] for market-outlook / industry-evolution tasks, the task's core output is direction/evolution/trajectory — not ranking, prediction, or selection among defined options
@@ -173,6 +174,7 @@ This is the last gate before the report goes to the user. If any item fails, rev
 
 - [ ] every "预计 / 估计 / 预期 / 有望" in the report has a named source attribution (who expects this?)
 - [ ] bare "预计" or bare "有望" without source = fail; go back and add "[据公司指引/据分析师/据媒体]预计" or "[据行业趋势/据管理层/据第三方]有望"
+- [ ] forward-looking numbers are not upgraded to confirmed facts merely because the source is official or reputable; confirm the source event separately from the future outcome
 - [ ] exact figures are used when source provides them; "约" only when source itself rounds
 - [ ] quantitative outlook numbers are labeled as observed / inferred / scenario assumption / illustrative calculation when the distinction matters
 - [ ] for constrained-choice / shortlist reports that use composite scoring, important quantitative inputs are labeled as observed fact / proxy / assumption / model output when the distinction affects trust in the recommendation

--- a/checklists/forward-looking-claims.md
+++ b/checklists/forward-looking-claims.md
@@ -34,6 +34,13 @@ Run through every item before delivering the final report.
 - [ ] predictions from media synthesis or speculation are labeled as such
 - [ ] consensus estimates used for forward-looking claims are checked against latest earnings releases; stale consensus is noted with timing gap
 - [ ] every instance of "预计" / "expected" / "likely" in the report has a named source attribution (who expects this?); bare "预计" without "据XX" = fail — go back and add source role before delivery
+- [ ] every forward-looking number has the first two fields of the forward-looking minimum set: source role (estimate / scenario assumption / analyst estimate / inference / model output) and attribution (named institution / analyst / company guidance + publication date or time basis). If these cannot be supplied, rewrite the claim as directional prose rather than a precise number.
+
+## Confirmed-label prohibition
+
+- [ ] Hard-fail: a forward-looking numeric claim containing `预计` / `预测` / `预期` / `将达` / `有望` / `expected` / `forecast` / `projected` / `estimated to` / `will reach` / `by 20xx` is labeled `[确认]`, `[已确认事实]`, `[CONF]`, or `[Confirmed]`.
+- [ ] Official or analyst forecasts may confirm that the source made the forecast, but the forecast value itself must still carry a forward-looking role label such as analyst estimate, company guidance, scenario assumption, inference, or model output.
+- [ ] Already-realized observed data is exempt: e.g. audited FY2025 revenue may be `[确认]`; FY2028 revenue forecast may not.
 
 ## Completeness
 

--- a/checklists/market-outlook-audit.md
+++ b/checklists/market-outlook-audit.md
@@ -68,6 +68,14 @@ Run this checklist before delivery.
 - [ ] `预计` / `expected` / `likely` has named source attribution (who expects this?)
 - [ ] forecasts show key assumptions and failure / reversal conditions
 
+### Forward-looking label hard-fail gate
+
+- [ ] （阻断级）扫描所有包含前瞻触发词的数字陈述：`预计`、`预测`、`预期`、`将达`、`有望`、`expected`、`forecast`、`projected`、`estimated to`、`will reach`、`by 20xx`。
+- [ ] 前瞻数字不得标为 `[确认]`、`[已确认事实]`、`[CONF]`、`[Confirmed]`，即使来源是权威机构、公司指引或分析师报告；可确认的是“某来源发布了该预测”，不是“未来数值会发生”。
+- [ ] 前瞻数字必须使用 estimate / scenario-assumption / analyst estimate / inference / model-output 等来源角色或数字角色标签，并给出归因来源和时间 basis。
+- [ ] 例外：已经发生并已被审计、披露或直接观测的 historical / current metric（如“2025 年实际营收”）可标为确认事实；仅描述“Gartner 于 2026-01 发布预测”且不把预测数值当事实时，也不触发。
+- [ ] 同一报告中出现 >3 处“前瞻数字标为确认事实”或任一 load-bearing scenario assumption 被标为确认事实 → hard-fail。
+
 ## Monitoring and change conditions
 
 - [ ] the report identifies what would change the conclusion

--- a/evals/cases/ai-video-market-outlook-label-and-probability-gap-case.md
+++ b/evals/cases/ai-video-market-outlook-label-and-probability-gap-case.md
@@ -1,0 +1,58 @@
+# Eval: AI 视频生成 Market Outlook — Label Overuse + Probability Precision Gap Case (Round 7)
+
+## Goal
+
+Test whether a market-outlook / industry-evolution report with strong route-contract execution (drivers/blockers, three scenarios, stakeholder coverage, monitoring signals) can still receive a **Fail** rating when:
+
+- **`[CONF]` label overuse** — secondary media/analyst/market-report sources labeled as confirmed facts; vendor claims lack "厂商自述" caveat
+- **forward-looking claims lack source role** — probability weights (`~60%`, `20-25%`, `15-20%`) and market size estimates (`$17-20B by 2028`) without calibration method or named source
+- **process-integrity hard-fail** — audit status claims `Forward-looking ✅`, `Source Traceability ✅`, `Final Audit ✅` but body evidence contradicts
+- **internal inconsistency** — Sora cost `$1500万/day` (exec summary) vs `$100万/day` (body) without reconciliation
+- **external verification failure** — Sora discontinuation date wrong (report says March 2026, actual web/app April 2026, API September 2026)
+- **vendor claims without caveat labels** — Runway revenue "超 $3 亿" without independent verification note
+
+This is the **seventh Round 7 case**, adding the **market-outlook route** with **label overuse** as the primary failure pattern.
+
+## Real case pattern
+
+A user-provided report "AI 视频生成市场未来 24 个月演化展望" dated **2026-06-10** demonstrates this pattern. Inferred route: `market-outlook / industry-evolution`.
+
+**What was done well:**
+- ✅ Opening carries core judgment — base case scenario, probability, market size, core variables within first 10 lines
+- ✅ Current market snapshot: product matrix, pricing, adoption landscape
+- ✅ Drivers and blockers separated with clear structure
+- ✅ Three scenarios (optimistic/base/pessimistic) sharing market size as quantitative axis
+- ✅ Stakeholder implications ≥3 types: creators, enterprise buyers, investors/policymakers
+- ✅ Monitoring signals specific: inference cost, copyright rulings, user growth, capital markets, tech rankings
+- ✅ Counter-evidence present: pessimistic scenario, copyright crisis, cost bottleneck
+- ✅ Body has `[Sxx]` traceable citations (incomplete but present)
+- ✅ Uncertainty register with U01-U05 items
+
+**Core issues (Fail — hard-fail triggered):**
+- ❌ **`[CONF]` label overuse** — secondary media/analyst/market-report sources (marketing team adoption rates, enterprise adoption rates, North America market share) labeled as `[CONF]` without source-role downgrade. Vendor claims (Runway revenue "$3亿+") lack `(厂商自述，非独立验证)` caveat. Triggers Round 5 #191 calibration rule.
+- ❌ **Forward-looking claims lack source role** — probability weights `~60%`, `20-25%`, `15-20%` assigned without calibration method, comparable basis, or named source. Market size "$17-20B by 2028" stated without attribution to specific forecast model or institution. Internal inconsistency: Sora cost `$1500万/day` (exec summary) vs `$100万/day` (body) unreconciled.
+- ❌ **Process-integrity hard-fail** — audit status claims `Forward-looking ✅`, `Source Traceability ✅`, `Final Audit ✅`, but label overuse, forward-looking attribution gaps, and internal inconsistency all present.
+- ❌ **External verification failure** — Sora discontinuation date: report states "2026 年 3 月关停", but OpenAI Help Center shows web/app discontinued April 2026 and API September 2026. Report error not caught by current-state verification.
+- ❌ **Probability precision false** — `~60%`, `20-25%`, `15-20%` imply precision without documented derivation. Per forward-looking discipline, probabilities without calibration basis should use directional ranges.
+
+## Why this case exists
+
+Seventh Round 7 case. First market-outlook case in this round. The failure triad is confirmed again — the pattern is route-independent. New dimensions added: external verification failure (Sora date) and internal inconsistency (cost figures), both of which are delivery-cleanliness issues.
+
+## Round 7 accumulation
+
+| # | Case | Route | Core failure |
+|---|------|-------|-------------|
+| 1 | Code review agent selection | provider-selection | Triad |
+| 2 | Chinese LLM writing | provider-selection | Triad + aggregation |
+| 3 | AI image generation | provider-selection | Triad + metadata drift |
+| 4 | Tea brand overseas entry | market-entry | Triad |
+| 5 | Short drama overseas entry | market-entry | Triad + hub-role + sensitivity |
+| 6 | Industrial robot overseas entry | market-entry | Triad + compound criterion |
+| 7 | AI video market outlook | market-outlook | Triad + label overuse + ext verification |
+
+## Related evals
+
+- `evals/cases/ai-agent-market-outlook-stakeholder-and-route-boundary-case.md` — Round 6: market-outlook stakeholder + route boundary
+- `evals/cases/cross-border-ecommerce-market-outlook-self-assessment-case.md` — Round 5: market-outlook self-assessment overconfidence
+- `evals/cases/us-chip-export-regulatory-evidence-label-case.md` — Round 5: `[CONF]` label overuse

--- a/evals/cases/dc-power-market-outlook-forward-looking-label-gap-case.md
+++ b/evals/cases/dc-power-market-outlook-forward-looking-label-gap-case.md
@@ -1,0 +1,57 @@
+# Eval: 数据中心电力瓶颈 Market Outlook — Forward-Looking Label + Traceability Gap Case (Round 7)
+
+## Goal
+
+Test whether a market-outlook / industry-evolution report with strong scenario analysis, stakeholder coverage, and clear bottom line can still receive a **Fail** rating when:
+
+- **forward-looking claims labeled as `[确认]`** — GPT-5 power estimate, 76% adoption forecast, 16GW capacity prediction all labeled as confirmed facts instead of estimate/assumption
+- **body-level source traceability absent** — no `[Sxx]` inline citations; Source Register only 5 columns, missing DOI/URL and Claims Supported
+- **process-integrity hard-fail** — audit status claims all `✅ 已通过` but source traceability, forward-looking label, and quantitative role are all noncompliant
+- **probability weights without method** — "20%→30%""20%→15%" assigned without estimation basis or named source
+- **monitoring signals not actionable** —更像 reversal condition list 而非 measurable dashboard with thresholds, frequency, sources
+
+This is the **ninth Round 7 case**.
+
+## Real case pattern
+
+A user-provided report "全球数据中心电力瓶颈对 AI 基础设施产业链影响深度研究报告" dated **2026-06-10** demonstrates this pattern. Inferred route: `market-outlook / industry-evolution`.
+
+**What was done well:**
+- ✅ Opening carries core judgment — "电力瓶颈取代芯片供应" as binding constraint at line 9
+- ✅ Current market snapshot: global power consumption, regional bottlenecks, policy constraints
+- ✅ Drivers and blockers clearly separated
+- ✅ Three scenarios (base/optimistic/pessimistic) sharing DC power consumption as quantitative axis
+- ✅ Stakeholder implications ≥6 types: cloud, chip, DC operators, power equipment, liquid cooling, policymakers
+- ✅ Counter-evidence present with 3 structured counter-arguments
+- ✅ Uncertainty register explicit
+- ✅ Decision usefulness: actionable for AI companies, DC operators, investors
+
+**Core issues (Fail — hard-fail triggered):**
+- ❌ **Forward-looking claims labeled as `[确认]`** — §73 "GPT-5 预计需 500+ GWh", §99 "预测到 2026 年底 76%", §111 "2026 年预计新增 16GW" all labeled as `[确认]` when evidence role is analyst estimate or scenario assumption. Triggers Round 5 #191 calibration rule: forecasts must carry estimate/assumption labels.
+- ❌ **Body-level source traceability absent** — no `[Sxx]` or equivalent inline citations for load-bearing claims. Source Register (§356-379) has only 5 columns, missing DOI/URL and Claims Supported per Round 4 #182 template.
+- ❌ **Process-integrity hard-fail** — §343-352 claims all `✅ 已通过`, but source traceability noncompliant, forward-looking labels misapplied, probability weights lack method.
+- ❌ **Probability weights without method** — §270 "20%→30%", §281 "20%→15%" assigned without calibration basis, named source, or scenario context. Bare percentages without derivation.
+- ❌ **Monitoring signals not actionable** — §334-339 lists "what would change the conclusion" items but lacks: measurable thresholds, observation frequency, data source, and trigger→action mapping. More of a reversal condition list than a monitoring dashboard.
+
+## Why this case exists
+
+Ninth Round 7 case. The failure triad continues across 9 cases × 4 routes. This case adds a clear pattern: **forward-looking claims written as confirmed facts** — the most direct violation of the Round 5 #191 label calibration rule seen so far in this round.
+
+## Round 7 accumulation
+
+| # | Case | Route | Core failure |
+|---|------|-------|-------------|
+| 1 | Code review agent selection | provider-selection | Triad |
+| 2 | Chinese LLM writing | provider-selection | Triad + aggregation |
+| 3 | AI image generation | provider-selection | Triad + metadata drift |
+| 4 | Tea brand overseas entry | market-entry | Triad |
+| 5 | Short drama overseas entry | market-entry | Triad + hub-role + sensitivity |
+| 6 | Industrial robot overseas entry | market-entry | Triad + compound criterion |
+| 7 | AI video market outlook | market-outlook | Triad + label overuse + ext verification |
+| 8 | Embodied AI market outlook | market-outlook | Triad + register inflation |
+| 9 | DC power market outlook | market-outlook | Triad + forward-looking as `[确认]` |
+
+## Related evals
+
+- `evals/cases/ai-video-market-outlook-label-and-probability-gap-case.md` — Round 7: `[CONF]` overuse in market-outlook
+- `evals/cases/us-chip-export-regulatory-evidence-label-case.md` — Round 5: Round 5 #191 calibration rule

--- a/evals/cases/embodied-ai-market-outlook-register-and-label-gap-case.md
+++ b/evals/cases/embodied-ai-market-outlook-register-and-label-gap-case.md
@@ -1,0 +1,59 @@
+# Eval: 具身智能商业化路径 Market Outlook — Source Register + Label Overuse Case (Round 7)
+
+## Goal
+
+Test whether a market-outlook / industry-evolution report with strong scenario structure, stakeholder coverage, and monitoring signals can still receive a **Fail** rating when:
+
+- **Source Register noncompliant** — 5 columns only (claims 6, actual is 5), missing DOI/URL and Claims Supported; S01-S60 listed but only 16 actually cited in body — register inflation without body mapping
+- **process-integrity hard-fail** — audit status claims `Source Traceability ✅`, `Forward-looking ✅`, `Final Audit ✅` but Register noncompliant, forward-looking claims bare, labels overused
+- **`[CONF]` label overuse** — secondary/media/analyst sources supporting deployment numbers, competitive position estimates labeled as confirmed facts
+- **forward-looking claims without source role** — "预计淘汰率 50%+""预计 >100 台" without named source or method; audit claims all forward-looking tagged but body contradicts
+- **quantitative role labels defined but not executed** — §18-25 defines O/P/A/M labels but body tables lack per-number role annotations
+- **metadata-first drift** — evidence grading and numeric role instructions occupy front page (§3-25) before judgment
+
+This is the **eighth Round 7 case**.
+
+## Real case pattern
+
+A user-provided report "具身智能创业公司商业化路径分化研究报告" dated **2026-06-10** demonstrates this pattern. Inferred route: `market-outlook / industry-evolution`.
+
+**What was done well:**
+- ✅ Opening carries core judgment — "三轨分化" at line 31
+- ✅ Current market snapshot: shipments, sales, competitor tiers
+- ✅ Drivers and blockers separated
+- ✅ Three scenarios (base/optimistic/pessimistic)
+- ✅ Stakeholder implications ≥4 types: founders, investors, enterprise buyers, policymakers
+- ✅ Monitoring signals specific and actionable
+- ✅ Counter-evidence strong (§312-329)
+- ✅ Uncertainty register explicit
+- ✅ Decision usefulness: actionable for founders, investors, enterprise buyers
+
+**Core issues (Fail — hard-fail triggered):**
+- ❌ **Source Register noncompliant** — has 5 columns (ID / Source Name / Type / Date / Reliability), missing DOI/URL and Claims Supported per Round 4 #182 template. Lists S01-S60 but only 16 are actually cited in body — register inflation without claim-level mapping. Audit claims "6列" but actual is 5 columns.
+- ❌ **Process-integrity hard-fail** — §389-394 claims `Source Traceability ✅`, `Forward-looking ✅`, `Final Audit ✅`, but Register is noncompliant (5 columns), forward-looking claims are bare ("预计淘汰率 50%+" without source), and `[CONF]` labels overused.
+- ❌ **`[CONF]` label overuse** — secondary/media/analyst sources supporting deployment numbers (生产部署不足 500 台), competitive position ("压倒性优势"), market share estimates labeled as `[CONF]` without source-role downgrade per Round 5 #191.
+- ❌ **Forward-looking claims without source role** — "预计淘汰率 50%+""预计工业/物流行业看到 >100 台" stated without named source, method, or confidence interval. Audit claims all forward-looking tagged but body evidence contradicts.
+- ❌ **Quantitative role labels defined not executed** — §18-25 defines O/P/A/M label system but body tables and key numbers lack per-number role annotations. Framework declared, labels not applied.
+- ❌ **Metadata-first drift** — §3-25 front page occupied by research method, evidence grading, numeric role instructions before core judgment at line 31.
+
+## Why this case exists
+
+Eighth Round 7 case. The same failure triad confirmed across 8 cases and 4 routes. Adds two notable patterns: (1) register inflation (60 entries, 44 uncited), and (2) labels defined but not executed — a variant of the "declared not executed" pattern seen in Round 6 academic cases.
+
+## Round 7 accumulation
+
+| # | Case | Route | Core failure |
+|---|------|-------|-------------|
+| 1 | Code review agent selection | provider-selection | Triad |
+| 2 | Chinese LLM writing | provider-selection | Triad + aggregation |
+| 3 | AI image generation | provider-selection | Triad + metadata drift |
+| 4 | Tea brand overseas entry | market-entry | Triad |
+| 5 | Short drama overseas entry | market-entry | Triad + hub-role + sensitivity |
+| 6 | Industrial robot overseas entry | market-entry | Triad + compound criterion |
+| 7 | AI video market outlook | market-outlook | Triad + label overuse + ext verification |
+| 8 | Embodied AI market outlook | market-outlook | Triad + register inflation + labels declared not executed |
+
+## Related evals
+
+- `evals/cases/ai-video-market-outlook-label-and-probability-gap-case.md` — Round 7: market-outlook label overuse
+- `evals/cases/llm-hallucination-academic-review-source-register-gap-case.md` — Round 6: evidence framework declared not executed

--- a/scripts/test_forward_looking_label_lint.py
+++ b/scripts/test_forward_looking_label_lint.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Regression tests for validate_forward_looking_labels.py."""
+
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+SCRIPT = str(Path(__file__).resolve().parent / "validate_forward_looking_labels.py")
+
+
+def run_lint(text: str) -> subprocess.CompletedProcess:
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "fixture.md"
+        path.write_text(text, encoding="utf-8")
+        return subprocess.run(
+            [sys.executable, SCRIPT, str(path)],
+            capture_output=True,
+            text=True,
+        )
+
+
+def expect_pass(name: str, text: str) -> None:
+    result = run_lint(text)
+    assert result.returncode == 0, (
+        f"{name}: expected pass, got {result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    print(f"  PASS  {name}")
+
+
+def expect_fail(name: str, text: str) -> None:
+    result = run_lint(text)
+    assert result.returncode == 2, (
+        f"{name}: expected lint failure, got {result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    print(f"  PASS  {name}")
+
+
+def test_forward_chinese_confirmed_fails() -> None:
+    expect_fail(
+        "Chinese forward-looking confirmed label",
+        "[确认] GPT-5 预计需 500+ GWh 电力。",
+    )
+
+
+def test_forward_english_confirmed_fails() -> None:
+    expect_fail(
+        "English forecast confirmed label",
+        "[CONF] The market is forecast to reach $50B by 2028.",
+    )
+
+
+def test_future_by_year_confirmed_fails() -> None:
+    expect_fail(
+        "by-year future confirmed label",
+        "[Confirmed] AI video revenue by 2028 will reach $17-20B.",
+    )
+
+
+def test_analyst_estimate_passes() -> None:
+    expect_pass(
+        "analyst estimate role passes",
+        "[ANALYST_EST] 据 Gartner 2026-01 预计，2028 年市场规模达 $50B [S01]。",
+    )
+
+
+def test_mixed_confirmed_and_estimate_fails() -> None:
+    expect_fail(
+        "mixed confirmed and estimate labels fails",
+        "[CONF][ANALYST_EST] 据 Gartner 2026-01 预计，2028 年市场规模达 $50B。",
+    )
+
+
+def test_scenario_assumption_passes() -> None:
+    expect_pass(
+        "scenario assumption role passes",
+        "[SCENARIO] 假设推理成本继续下降，2028 年市场规模将达 $17-20B。",
+    )
+
+
+def test_observed_historical_confirmed_passes() -> None:
+    expect_pass(
+        "observed historical confirmed fact passes",
+        "[确认] 2025 年实际营收为 $10B，来自已审计年报。",
+    )
+
+
+def test_source_event_without_forecast_number_passes() -> None:
+    expect_pass(
+        "forecast publication event passes",
+        "[确认] Gartner 于 2026-01 发布了 AI 市场预测报告。",
+    )
+
+
+def main() -> int:
+    tests = [
+        test_forward_chinese_confirmed_fails,
+        test_forward_english_confirmed_fails,
+        test_future_by_year_confirmed_fails,
+        test_analyst_estimate_passes,
+        test_mixed_confirmed_and_estimate_fails,
+        test_scenario_assumption_passes,
+        test_observed_historical_confirmed_passes,
+        test_source_event_without_forecast_number_passes,
+    ]
+    failures = []
+    for test in tests:
+        try:
+            test()
+        except AssertionError as exc:
+            failures.append(test.__name__)
+            print(f"  FAIL  {test.__name__}: {exc}")
+
+    if failures:
+        print(f"\n{len(failures)} test(s) failed: {', '.join(failures)}")
+        return 1
+
+    print(f"\nAll {len(tests)} tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_forward_looking_labels.py
+++ b/scripts/validate_forward_looking_labels.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Detect forward-looking numeric claims mislabeled as confirmed facts.
+
+This lightweight lint is intentionally report/fixture scoped. It should be run
+on final report text or purpose-built fixtures, not on eval case descriptions
+that quote known-bad examples for documentation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+CONFIRMED_LABEL_RE = re.compile(
+    r"\[(?:确认|已确认事实|CONF|Confirmed|confirmed)\]"
+)
+
+FORWARD_RE = re.compile(
+    r"(?:"
+    r"预计|预测|预期|将达|将达到|有望|"
+    r"expected|forecast(?:s|ed|ing)?|projected|projection|"
+    r"estimated\s+to|will\s+reach|by\s+20\d{2}"
+    r")",
+    re.IGNORECASE,
+)
+
+NUMBER_RE = re.compile(
+    r"(?:"
+    r"[$¥€£]?\s*\d[\d,]*(?:\.\d+)?\s*(?:%|bp|bps|x|X|倍|万|亿|兆|台|GW|GWh|TWh|MW|B|M|bn|mn)?\+?"
+    r"|20\d{2}\s*(?:年|H[12]|Q[1-4])?"
+    r")",
+    re.IGNORECASE,
+)
+
+SOURCE_EVENT_RE = re.compile(
+    r"(?:发布|published|released).{0,30}(?:预测报告|forecast report|projection report)",
+    re.IGNORECASE,
+)
+
+OUTCOME_RE = re.compile(
+    r"(?:"
+    r"预计|预期|将达|将达到|有望|"
+    r"预测.{0,30}(?:到|至|为|达|达到|超过|\d|%)|"
+    r"expected|forecast(?:s|ed|ing)?.{0,40}(?:to|reach|grow|increase|decline|\d|[$¥€£])|"
+    r"projected|estimated\s+to|will\s+reach|by\s+20\d{2}"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def strip_fenced_code_blocks(text: str) -> str:
+    lines = text.splitlines()
+    out: list[str] = []
+    in_fence = False
+    fence_char = ""
+    fence_len = 0
+
+    for line in lines:
+        stripped = line.rstrip()
+        if not in_fence:
+            m = re.match(r"^[ ]{0,3}(`{3,}|~{3,})", stripped)
+            if m:
+                fence_char = m.group(1)[0]
+                fence_len = len(m.group(1))
+                in_fence = True
+                continue
+            out.append(line)
+            continue
+
+        closing = re.compile(
+            r"^[ ]{0,3}" + re.escape(fence_char) + "{" + str(fence_len) + r",}\s*$"
+        )
+        if closing.match(stripped):
+            in_fence = False
+
+    return "\n".join(out)
+
+
+def split_sentences(text: str) -> list[tuple[int, str]]:
+    results: list[tuple[int, str]] = []
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        line = line.strip()
+        if not line:
+            continue
+        chunks = re.split(r"(?<=[。！？!?；;])\s+|\s+[•·]\s+", line)
+        for chunk in chunks:
+            chunk = chunk.strip()
+            if chunk:
+                results.append((line_no, chunk))
+    return results
+
+
+def find_confirmed_forward_looking_numbers(text: str) -> list[tuple[int, str]]:
+    cleaned = strip_fenced_code_blocks(text)
+    hits: list[tuple[int, str]] = []
+    for line_no, sentence in split_sentences(cleaned):
+        if not CONFIRMED_LABEL_RE.search(sentence):
+            continue
+        if not FORWARD_RE.search(sentence):
+            continue
+        if not NUMBER_RE.search(sentence):
+            continue
+        if SOURCE_EVENT_RE.search(sentence) and not OUTCOME_RE.search(sentence):
+            continue
+        hits.append((line_no, sentence))
+    return hits
+
+
+def validate_file(path: Path) -> list[str]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    hits = find_confirmed_forward_looking_numbers(text)
+    return [
+        f"{path}:{line_no}: forward-looking numeric claim uses confirmed label: {sentence}"
+        for line_no, sentence in hits
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Lint forward-looking numeric claims mislabeled as confirmed facts."
+    )
+    parser.add_argument("paths", nargs="+", help="Markdown/text files to validate")
+    args = parser.parse_args(argv)
+
+    errors: list[str] = []
+    for raw_path in args.paths:
+        path = Path(raw_path)
+        if not path.exists():
+            errors.append(f"{path}: file not found")
+            continue
+        errors.extend(validate_file(path))
+
+    if errors:
+        print("Forward-looking label lint failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 2
+
+    print(f"Forward-looking label lint passed for {len(args.paths)} file(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes #222.

- adds a Market Outlook hard-fail gate for forward-looking numeric claims mislabeled as `[确认]` / `[已确认事实]` / `[CONF]` / `[Confirmed]`
- syncs the prohibition into `forward-looking-claims` and `final-audit` recall, including the source-event vs future-outcome boundary
- adds the three Round 7 market-outlook eval cases from the issue
- adds a fixture-scoped lint plus regression tests for the forward-looking confirmed-label pattern
- runs the new lint in CI and expands CI path triggers for checklist/reference/eval changes

## Validation

- `python3 scripts/test_forward_looking_label_lint.py`
- `python3 -m py_compile scripts/*.py`
- `python3 scripts/validate_research_pack.py examples/research-pack-example.md`
- `python3 scripts/validate_research_pack.py examples/research-pack-example.md --strict`
- `python3 scripts/test_validator_regression.py`
- `python3 scripts/test_md_to_pdf_preflight.py`
- `git diff --cached --check`

Note: full `git diff --check` over the dirty worktree still reports pre-existing trailing whitespace in unstaged `research-output.md`; that file is not part of this PR.