### PR TITLE
[codex] Add declared-not-executed gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       - run: python3 scripts/validate_research_pack.py examples/research-pack-example.md --strict
       - run: python3 scripts/test_validator_regression.py
       - run: python3 scripts/test_forward_looking_label_lint.py
+      - run: python3 scripts/test_declared_execution.py
       - run: python3 scripts/test_md_to_pdf_preflight.py
 
   smoke:

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -61,6 +61,12 @@ This is the last gate before the report goes to the user. If any item fails, rev
   - 即使报告内容质量高，虚假的质量信号本身就是不可交付的状态——触发此 hard-fail gate 时报告视为未通过 final-audit，无论其他所有检查项通过与否
   - 此 gate 独立于其他所有检查项，是 final-audit 的最后防线
 
+- [ ] （阻断级）Declared-not-executed gate: if the report declares a discipline in methodology, metadata, a legend, or an audit block, verify that the discipline is visibly executed in the body where it applies. Methodology declarations do not count as execution.
+  - 数字角色标签体系（O/P/A/M or equivalent）→ key tables and load-bearing numbers must apply role labels at row, column, or table-note level. Declared but 0% applied to applicable body numbers → hard-fail. Declared but <50% applied → may not be marked ✅ Passed; conditional-pass ceiling.
+  - 证据层级/评估框架（dual-dimension, multi-level, study design × venue prestige, etc.）→ body must include a source-level evidence mapping table covering at least the major or load-bearing sources. Declared but no source-level mapping → hard-fail when systematic; conditional-pass ceiling when partial.
+  - Source Register → body must contain matching inline `[Sxx]` references or functionally equivalent claim-level citations. A register appendix with zero body citations → hard-fail. A register with substantial uncited inflation should be marked and cannot be used as proof of source-traceability pass.
+  - 判断标准：部分执行 = declared framework with >50% of applicable body locations visibly applying it; 声明未执行 = <50%; 声明零执行 = 0% or no body-level mapping/citations.
+
 - [ ] （Tier-2）每项审计的「证据」列附有与状态对应的具体引用，不可为空：
   - ✅ Passed → 执行证据位置（章节号、检查项编号或 register 条目）
   - ⚠️ Skipped / ❌ Not run → 决定理由在正文中的位置

--- a/checklists/market-outlook-audit.md
+++ b/checklists/market-outlook-audit.md
@@ -61,6 +61,8 @@ Run this checklist before delivery.
 
 - [ ] important numbers are labeled as observed current metric / inferred estimate / scenario assumption / illustrative calculation
 - [ ] readers can tell which kind of number they are reading without guessing
+- [ ] （阻断级）Declared-not-executed check: if the report defines an O/P/A/M or equivalent role system for market-outlook numbers, the body must apply that system to scenario tables, market-size numbers, growth rates, adoption projections, probabilities, and other load-bearing numeric claims. A label legend without body/table application does not satisfy quantitative role labeling.
+- [ ] Declared role system but 0% body/table application → hard-fail. Declared role system but <50% application to applicable market-outlook numbers → conditional-pass ceiling and quantitative-role labeling may not be marked ✅ Passed.
 
 ## Forward-looking claims
 

--- a/references/quantitative-role-labeling.md
+++ b/references/quantitative-role-labeling.md
@@ -20,6 +20,23 @@ Never present proxy, assumption, or model output as if it were an observed or di
 
 If a number materially affects ranking, recommendation, timing, sequencing, confidence, or valuation, its role should be visible.
 
+## Declared framework execution discipline
+
+If a report declares a quantitative role labeling system such as O/P/A/M, observed / proxy / assumption / model output, or an equivalent framework, the declaration must be executed in the body. A methodology note, legend, or front-page label definition does not substitute for applying the labels to the report's key tables and load-bearing numbers.
+
+Minimum execution requirements:
+
+- state where the declared system is used, such as "the scenario tables and key forecast numbers below use this role system"
+- apply the role labels at row, column, or table-note level for applicable numeric tables
+- apply the role labels inline for load-bearing numeric claims that are not in tables
+- do not use a single introductory disclaimer as a substitute for table-level or claim-level labels
+
+Audit interpretation:
+
+- declared and applied to >50% of applicable body locations → at most conditional pass unless remaining gaps are non-load-bearing
+- declared but applied to <50% of applicable body locations → mark declared-not-executed; do not mark quantitative role labeling as passed
+- declared but applied to 0% of applicable body locations → hard-fail under `checklists/final-audit.md` declared-not-executed gate
+
 ## Core roles
 
 ### Observed metric

--- a/scripts/test_declared_execution.py
+++ b/scripts/test_declared_execution.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Regression tests for declared-not-executed report discipline."""
+
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+SCRIPT = str(Path(__file__).resolve().parent / "validate_declared_execution.py")
+
+
+def run_lint(text: str) -> subprocess.CompletedProcess:
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "fixture.md"
+        path.write_text(text, encoding="utf-8")
+        return subprocess.run(
+            [sys.executable, SCRIPT, str(path)],
+            capture_output=True,
+            text=True,
+        )
+
+
+def expect_pass(name: str, text: str) -> None:
+    result = run_lint(text)
+    assert result.returncode == 0, (
+        f"{name}: expected pass, got {result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    print(f"  PASS  {name}")
+
+
+def expect_fail(name: str, text: str) -> None:
+    result = run_lint(text)
+    assert result.returncode == 2, (
+        f"{name}: expected lint failure, got {result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    print(f"  PASS  {name}")
+
+
+def test_opam_declared_zero_applied_fails() -> None:
+    expect_fail(
+        "O/P/A/M declared but not applied",
+        """
+## Method
+
+This report uses O/P/A/M labels: O = observed metric, P = proxy,
+A = assumption, M = model output.
+
+## Scenario table
+
+| Metric | Base | Upside |
+|--------|------|--------|
+| Market size | $10B | $15B |
+| Adoption | 25% | 35% |
+| Payback | 18 months | 12 months |
+""",
+    )
+
+
+def test_opam_declared_applied_passes() -> None:
+    expect_pass(
+        "O/P/A/M declared and applied",
+        """
+## Method
+
+This report uses O/P/A/M labels: O = observed metric, P = proxy,
+A = assumption, M = model output.
+
+## Scenario table
+
+| Metric | Base | Upside | Role |
+|--------|------|--------|------|
+| Market size | $10B | $15B | A |
+| Adoption | 25% | 35% | M |
+| Payback | 18 months | 12 months | M |
+""",
+    )
+
+
+def test_source_register_zero_body_refs_fails() -> None:
+    expect_fail(
+        "Source Register declared but no body citations",
+        """
+## Findings
+
+The market is growing quickly and adoption is likely to accelerate.
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Example market report | secondary | 2026-01-01 | https://example.com | medium | § Findings |
+| S02 | Example filing | primary | 2026-02-01 | https://example.com/filing | high | § Findings |
+""",
+    )
+
+
+def test_academic_framework_no_mapping_fails() -> None:
+    expect_fail(
+        "academic framework declared without mapping",
+        """
+## Method
+
+Evidence is evaluated on two dimensions: study design quality × venue prestige.
+
+## Findings
+
+Smith 2025 provides the strongest evidence; Lee 2024 is weaker.
+""",
+    )
+
+
+def test_academic_framework_mapping_present_passes() -> None:
+    expect_pass(
+        "academic framework mapping present",
+        """
+## Method
+
+Evidence is evaluated on two dimensions: study design quality × venue prestige.
+
+## Evidence mapping table
+
+| Source | Study design quality | Venue prestige | Overall assessment |
+|--------|----------------------|----------------|--------------------|
+| S01 | RCT | Tier 1 journal | strong |
+| S02 | cohort study | Tier 3 journal | medium |
+""",
+    )
+
+
+def main() -> int:
+    tests = [
+        test_opam_declared_zero_applied_fails,
+        test_opam_declared_applied_passes,
+        test_source_register_zero_body_refs_fails,
+        test_academic_framework_no_mapping_fails,
+        test_academic_framework_mapping_present_passes,
+    ]
+    failures = []
+    for test in tests:
+        try:
+            test()
+        except AssertionError as exc:
+            failures.append(test.__name__)
+            print(f"  FAIL  {test.__name__}: {exc}")
+
+    if failures:
+        print(f"\n{len(failures)} test(s) failed: {', '.join(failures)}")
+        return 1
+
+    print(f"\nAll {len(tests)} tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_declared_execution.py
+++ b/scripts/validate_declared_execution.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Detect report frameworks that are declared but not executed.
+
+This lint is intentionally lightweight and fixture/report scoped. It catches
+the concrete Issue #223 patterns where a report declares a discipline such as
+O/P/A/M labels, Source Register traceability, or an academic evidence framework
+but the body does not visibly apply that discipline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+EXIT_ISSUES = 2
+
+FENCE_RE = re.compile(r"^[ ]{0,3}(`{3,}|~{3,})")
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+TABLE_ROW_RE = re.compile(r"^\s*\|.*\|\s*$")
+TABLE_DELIMITER_RE = re.compile(r"^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$")
+NUMBER_RE = re.compile(
+    r"(?:[$¥€£]?\s*\d[\d,]*(?:\.\d+)?\s*(?:%|bp|bps|x|X|倍|万|亿|兆|台|GW|GWh|TWh|MW|B|M|bn|mn|months?|月|年)?\+?)",
+    re.IGNORECASE,
+)
+
+OPAM_DECL_RE = re.compile(
+    r"(?:O/P/A/M|O\s*=\s*observed|P\s*=\s*proxy|A\s*=\s*assumption|M\s*=\s*model)",
+    re.IGNORECASE,
+)
+ROLE_HEADER_RE = re.compile(r"(?:数字角色|number role|role|epistemic role)", re.IGNORECASE)
+ROLE_VALUE_RE = re.compile(
+    r"(?:\b[OPAM]\b|observed|proxy|assumption|model\s*output|estimate|scenario|inferred|illustrative)",
+    re.IGNORECASE,
+)
+
+SOURCE_REGISTER_HEADING_RE = re.compile(r"^#{1,6}\s+Source Register\s*$", re.IGNORECASE)
+SOURCE_ID_RE = re.compile(r"(?<!\w)\[?(S\d{2})\]?(?!\w)")
+BODY_SOURCE_REF_RE = re.compile(r"\[S\d{2}\]")
+
+ACADEMIC_FRAMEWORK_RE = re.compile(
+    r"(?:study\s+design\s+quality.{0,80}venue\s+prestige|venue\s+prestige.{0,80}study\s+design\s+quality|研究设计.{0,80}发表场所声誉|发表场所声誉.{0,80}研究设计|双维.{0,40}证据|多级.{0,40}证据)",
+    re.IGNORECASE | re.DOTALL,
+)
+MAPPING_HEADER_RE = re.compile(
+    r"\|\s*(?:Source|来源)\s*\|.*(?:Study design|研究设计).*(?:Venue prestige|发表场所声誉|Venue)",
+    re.IGNORECASE,
+)
+
+
+def strip_fenced_code_blocks(text: str) -> str:
+    lines = text.splitlines()
+    out: list[str] = []
+    in_fence = False
+    fence_char = ""
+    fence_len = 0
+
+    for line in lines:
+        stripped = line.rstrip()
+        if not in_fence:
+            m = FENCE_RE.match(stripped)
+            if m:
+                fence_char = m.group(1)[0]
+                fence_len = len(m.group(1))
+                in_fence = True
+                continue
+            out.append(line)
+            continue
+
+        closing = re.compile(
+            r"^[ ]{0,3}" + re.escape(fence_char) + "{" + str(fence_len) + r",}\s*$"
+        )
+        if closing.match(stripped):
+            in_fence = False
+
+    return "\n".join(out)
+
+
+def section_bounds(lines: list[str], heading_re: re.Pattern[str]) -> tuple[int, int] | None:
+    start = None
+    start_level = None
+    for idx, line in enumerate(lines):
+        if heading_re.match(line):
+            m = HEADING_RE.match(line)
+            start = idx
+            start_level = len(m.group(1)) if m else 2
+            break
+    if start is None:
+        return None
+
+    end = len(lines)
+    for idx in range(start + 1, len(lines)):
+        m = HEADING_RE.match(lines[idx])
+        if m and len(m.group(1)) <= start_level:
+            end = idx
+            break
+    return start, end
+
+
+def remove_section(text: str, heading_re: re.Pattern[str]) -> str:
+    lines = text.splitlines()
+    bounds = section_bounds(lines, heading_re)
+    if not bounds:
+        return text
+    start, end = bounds
+    return "\n".join(lines[:start] + lines[end:])
+
+
+def table_lines(text: str) -> list[str]:
+    rows = []
+    for line in text.splitlines():
+        if not TABLE_ROW_RE.match(line):
+            continue
+        if TABLE_DELIMITER_RE.match(line):
+            continue
+        rows.append(line)
+    return rows
+
+
+def check_opam_execution(text: str, path: Path) -> list[str]:
+    if not OPAM_DECL_RE.search(text):
+        return []
+
+    rows = [row for row in table_lines(text) if NUMBER_RE.search(row)]
+    if not rows:
+        return []
+
+    role_headers = [row for row in table_lines(text) if ROLE_HEADER_RE.search(row)]
+    applied = 0
+    for row in rows:
+        if ROLE_VALUE_RE.search(row):
+            applied += 1
+            continue
+        if role_headers and ROLE_HEADER_RE.search(row):
+            applied += 1
+
+    if applied == 0:
+        return [
+            f"{path}: O/P/A/M or equivalent quantitative role system is declared, "
+            "but numeric table rows do not visibly apply role labels"
+        ]
+
+    if applied / len(rows) < 0.5:
+        return [
+            f"{path}: O/P/A/M or equivalent quantitative role system is declared, "
+            f"but only {applied}/{len(rows)} numeric table rows visibly apply role labels"
+        ]
+
+    return []
+
+
+def check_source_register_execution(text: str, path: Path) -> list[str]:
+    lines = text.splitlines()
+    bounds = section_bounds(lines, SOURCE_REGISTER_HEADING_RE)
+    if not bounds:
+        return []
+
+    start, end = bounds
+    register_text = "\n".join(lines[start:end])
+    source_ids = set(SOURCE_ID_RE.findall(register_text))
+    if not source_ids:
+        return []
+
+    body_text = remove_section(text, SOURCE_REGISTER_HEADING_RE)
+    body_refs = set(ref.strip("[]") for ref in BODY_SOURCE_REF_RE.findall(body_text))
+    if not body_refs:
+        return [
+            f"{path}: Source Register declares {len(source_ids)} source ID(s), "
+            "but the body contains no [Sxx] citations"
+        ]
+
+    return []
+
+
+def check_academic_framework_execution(text: str, path: Path) -> list[str]:
+    if not ACADEMIC_FRAMEWORK_RE.search(text):
+        return []
+    if MAPPING_HEADER_RE.search(text):
+        return []
+    return [
+        f"{path}: academic evidence framework is declared, "
+        "but no source-level evidence mapping table is visible"
+    ]
+
+
+def validate_file(path: Path) -> list[str]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    cleaned = strip_fenced_code_blocks(text)
+    errors: list[str] = []
+    errors.extend(check_opam_execution(cleaned, path))
+    errors.extend(check_source_register_execution(cleaned, path))
+    errors.extend(check_academic_framework_execution(cleaned, path))
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Lint declared report frameworks that are not executed."
+    )
+    parser.add_argument("paths", nargs="+", help="Markdown/text files to validate")
+    args = parser.parse_args(argv)
+
+    errors: list[str] = []
+    for raw_path in args.paths:
+        path = Path(raw_path)
+        if not path.exists():
+            errors.append(f"{path}: file not found")
+            continue
+        errors.extend(validate_file(path))
+
+    if errors:
+        print("Declared execution lint failed:")
+        for error in errors:
+            print(f"- {error}")
+        return EXIT_ISSUES
+
+    print(f"Declared execution lint passed for {len(args.paths)} file(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add a lightweight declared execution lint for Issue #223 patterns: O/P/A/M declared but not applied, Source Register with zero body citations, and academic evidence framework without source-level mapping.
- Add fixture-style TDD coverage for the declared-not-executed cases and wire it into CI.
- Harden final-audit, market-outlook, and quantitative-role guidance so methodology declarations do not substitute for body/table execution.

## Validation

- `python3 -m py_compile scripts/*.py`
- `python3 scripts/test_declared_execution.py`
- `python3 scripts/test_forward_looking_label_lint.py`
- `python3 scripts/test_validator_regression.py`
- `python3 scripts/validate_research_pack.py examples/research-pack-example.md`
- `python3 scripts/validate_research_pack.py examples/research-pack-example.md --strict`
- `python3 scripts/test_md_to_pdf_preflight.py`

## Notes

`git diff --check` across the whole working tree still reports a pre-existing trailing whitespace issue in `research-output.md`, which was not part of this PR and was not modified here.
