### PR TITLE
[codex] Harden Source Register inflation checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is intentionally lightweight. Use concise entries that explain:
 ## Unreleased
 
 ### Added
+- `checklists/source-traceability.md`, `references/source-traceability-and-claim-citation.md`, and `scripts/validate_declared_execution.py`: added Source Register inflation gate so registers with `>25%` uncited entries cannot be marked source-traceability passed; added regression coverage for partial body citations with mostly unused register entries (#225).
 - `checklists/market-outlook-audit.md`, `checklists/final-audit.md`, and `references/decision-report-template.md`: strengthened market-outlook monitoring signals from qualitative reversal-condition lists into actionable dashboards with threshold, cadence, source, and trigger-to-action mapping requirements (#224).
 - `scripts/test_market_outlook_monitoring_contract.py` and `.github/workflows/ci.yml`: added a regression contract test so the market-outlook monitoring actionability rule stays wired into checklist, final-audit recall, and the decision template (#224).
 - `evals/cases/dc-power-market-outlook-forward-looking-label-gap-case.md` and `evals/cases/ai-video-market-outlook-label-and-probability-gap-case.md`: aligned Round 7 market-outlook eval descriptions with the new monitoring signal actionability failure mode (#224).

--- a/checklists/source-traceability.md
+++ b/checklists/source-traceability.md
@@ -30,6 +30,8 @@ Run through every item before delivering the final report.
 - [ ] Source Type is one of the simplified 5-class system (`primary` / `secondary` / `inferred` / `vendor-claim` / `unconfirmed`) or a compatible granular type (see `references/source-traceability-and-claim-citation.md`)
 - [ ] Reliability consistency: if Source Type is `vendor-claim`, `inferred`, or `unconfirmed`, Reliability must be `low`
 - [ ] no source id is listed but never cited in the body
+- [ ] **register inflation gate**: compare Source Register IDs against body `[Sxx]` references (or functionally equivalent claim-level citations). `<10%` uncited register entries can pass as normal auxiliary sourcing; `10-25%` uncited entries must be flagged for cleanup and may not be used as evidence of strong traceability; `>25%` uncited entries = register inflation and source-traceability may not be marked ✅ Passed.
+- [ ] **hard-fail escalation**: uncited register entries that also lack DOI/URL, clear Source Type, or a plausible `Claims Supported` mapping are not valid auxiliary sources; if they are material or numerous, the report is not deliverable until the register is cleaned up or moved to an explicit extra-reading appendix.
 
 ## Source type discipline
 

--- a/references/source-traceability-and-claim-citation.md
+++ b/references/source-traceability-and-claim-citation.md
@@ -181,6 +181,22 @@ Every source register entry must satisfy two additional rules beyond basic metad
 
 These rules prevent the "register theatre" problem where a source list looks comprehensive but contains dead or unreferenced entries.
 
+### Register discipline and inflation
+
+The Source Register is not a bibliography-size contest. Each register entry should serve at least one load-bearing body claim, and the body should make that link visible through `[Sxx]` or a functionally equivalent claim-level citation.
+
+Use this severity scale when auditing a register against body citations:
+
+| Uncited register entries | Severity | Action |
+|--------------------------|----------|--------|
+| `<10%` | Pass | Accept as normal auxiliary sourcing, but remove entries that do not help the report. |
+| `10-25%` | Flag | Mark for cleanup; source-traceability can be conditional but should not be described as strong. |
+| `>25%` | Register inflation | Source-traceability may not be marked ✅ Passed. Remove unused entries, add real body citations, or move them to a separate extra-reading appendix. |
+
+Uncited entries are especially problematic when they also lack DOI/URL, a clear Source Type, or a plausible `Claims Supported` mapping. In that case, treat them as non-auditable decoration rather than auxiliary evidence; if the pattern is material or numerous, it is a hard-fail for source traceability.
+
+If a report genuinely needs background or extra-reading sources that do not support specific body claims, put them under a separate `Extra Reading` / `Extended Bibliography` heading. Do not count those entries as proof that Source Register traceability passed. A good drafting workflow is: write the body claim with its citation first, then fill the register row that maps back to that claim.
+
 ## Source type classification
 
 Classify every source in the register by type. Use these types consistently:

--- a/scripts/test_declared_execution.py
+++ b/scripts/test_declared_execution.py
@@ -97,6 +97,47 @@ The market is growing quickly and adoption is likely to accelerate.
     )
 
 
+def test_source_register_uncited_inflation_fails() -> None:
+    expect_fail(
+        "Source Register inflation fails when most entries are uncited",
+        """
+## Findings
+
+The market is growing quickly and adoption is likely to accelerate [S01].
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Example market report | secondary | 2026-01-01 | https://example.com/1 | medium | § Findings |
+| S02 | Example filing | primary | 2026-02-01 | https://example.com/2 | high | § Findings |
+| S03 | Example benchmark | secondary | 2026-03-01 | https://example.com/3 | medium | § Findings |
+| S04 | Example interview | secondary | 2026-04-01 | https://example.com/4 | medium | § Findings |
+""",
+    )
+
+
+def test_source_register_fully_cited_passes() -> None:
+    expect_pass(
+        "Source Register entries cited in body pass",
+        """
+## Findings
+
+The market is growing quickly [S01][S02].
+Adoption is likely to accelerate [S03][S04].
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Example market report | secondary | 2026-01-01 | https://example.com/1 | medium | § Findings |
+| S02 | Example filing | primary | 2026-02-01 | https://example.com/2 | high | § Findings |
+| S03 | Example benchmark | secondary | 2026-03-01 | https://example.com/3 | medium | § Findings |
+| S04 | Example interview | secondary | 2026-04-01 | https://example.com/4 | medium | § Findings |
+""",
+    )
+
+
 def test_academic_framework_no_mapping_fails() -> None:
     expect_fail(
         "academic framework declared without mapping",
@@ -135,6 +176,8 @@ def main() -> int:
         test_opam_declared_zero_applied_fails,
         test_opam_declared_applied_passes,
         test_source_register_zero_body_refs_fails,
+        test_source_register_uncited_inflation_fails,
+        test_source_register_fully_cited_passes,
         test_academic_framework_no_mapping_fails,
         test_academic_framework_mapping_present_passes,
     ]

--- a/scripts/validate_declared_execution.py
+++ b/scripts/validate_declared_execution.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 
 EXIT_ISSUES = 2
+REGISTER_INFLATION_FAIL_RATIO = 0.25
 
 FENCE_RE = re.compile(r"^[ ]{0,3}(`{3,}|~{3,})")
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
@@ -169,6 +170,18 @@ def check_source_register_execution(text: str, path: Path) -> list[str]:
         return [
             f"{path}: Source Register declares {len(source_ids)} source ID(s), "
             "but the body contains no [Sxx] citations"
+        ]
+
+    uncited_source_ids = sorted(source_ids - body_refs)
+    uncited_ratio = len(uncited_source_ids) / len(source_ids)
+    if uncited_ratio > REGISTER_INFLATION_FAIL_RATIO:
+        uncited_preview = ", ".join(uncited_source_ids[:10])
+        if len(uncited_source_ids) > 10:
+            uncited_preview += ", ..."
+        return [
+            f"{path}: Source Register declares {len(source_ids)} source ID(s), "
+            f"but {len(uncited_source_ids)} are never cited in the body "
+            f"({uncited_ratio:.0%} uncited; register inflation): {uncited_preview}"
         ]
 
     return []


### PR DESCRIPTION
## Summary

- Adds a Source Register inflation gate: registers with `>25%` uncited entries may not be marked source-traceability passed.
- Extends the declared-execution lint to fail partial-citation cases where most register IDs are never cited in the body.
- Documents the `<10%` / `10-25%` / `>25%` severity scale and extra-reading boundary.

## Problem

Issue #225 identified a traceability gap: a report can include a large Source Register while citing only a small fraction of its entries in the body. Existing rules already said every register entry should be cited, but the executable lint only caught the zero-body-citation case, so register inflation could still pass.

Closes #225.

## Why this change

This keeps the fix narrow: it strengthens the existing Source Register discipline and declared-execution lint without redesigning traceability parsing or expanding into route-specific checklist rewrites.

## Files changed

- `scripts/validate_declared_execution.py`: compares Source Register IDs to body `[Sxx]` citations and fails when uncited entries exceed 25%.
- `scripts/test_declared_execution.py`: adds regression coverage for uncited register inflation and a fully cited pass case.
- `checklists/source-traceability.md`: adds register inflation and hard-fail escalation checks.
- `references/source-traceability-and-claim-citation.md`: adds register discipline guidance, severity scale, and extra-reading boundary.
- `CHANGELOG.md`: records the behavior change.

## Expected behavior change

A report with a Source Register that lists many unused `Sxx` entries can no longer use that register as proof that source traceability passed. Authors must remove unused entries, cite them in the body, or move them to an explicit extra-reading appendix.

## Eval impact

- Added eval: none; issue #225 already points to `evals/cases/embodied-ai-market-outlook-register-and-label-gap-case.md` as the motivating case.
- Updated eval: none.
- No eval change because this PR adds a focused executable regression test for the declared-execution lint behavior.

## Risks / possible regressions

- The automatic lint intentionally only checks structured `[Sxx]` body citations. Functionally equivalent formats remain governed by manual checklist/reference guidance to avoid false hard-fails.
- Reports with legitimate background sources should move them to an explicit Extra Reading / Extended Bibliography section instead of counting them as Source Register traceability evidence.

## Validation

- TDD red: `python3 scripts/test_declared_execution.py` failed on `test_source_register_uncited_inflation_fails` before implementation.
- `python3 -m py_compile scripts/*.py`
- `python3 scripts/validate_research_pack.py examples/research-pack-example.md`
- `python3 scripts/validate_research_pack.py examples/research-pack-example.md --strict`
- `python3 scripts/test_validator_regression.py` — 28/28 passed
- `python3 scripts/test_forward_looking_label_lint.py` — 8/8 passed
- `python3 scripts/test_market_outlook_monitoring_contract.py` — 3/3 passed
- `python3 scripts/test_declared_execution.py` — 7/7 passed
- `python3 scripts/test_md_to_pdf_preflight.py` — 2/2 passed

## Checklist

- [x] Focused change
- [x] Changelog updated if behavior changed
- [x] Eval added/updated if fixing a real failure mode
- [x] Commit message is specific