### PR TITLE
[codex] Support equivalent Source Register refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is intentionally lightweight. Use concise entries that explain:
 ## Unreleased
 
 ### Added
+- `scripts/validate_declared_execution.py` and `scripts/test_declared_execution.py`: Source Register inflation lint now counts functionally equivalent body citations when they map uniquely to register entries, covering arXiv IDs, DOI references, Author-Year citations, and specific natural-language source attribution while keeping vague or ambiguous attribution failing (#230).
 - `checklists/source-traceability.md`, `references/source-traceability-and-claim-citation.md`, and `scripts/validate_declared_execution.py`: added Source Register inflation gate so registers with `>25%` uncited entries cannot be marked source-traceability passed; added regression coverage for partial body citations with mostly unused register entries (#225).
 - `checklists/market-outlook-audit.md`, `checklists/final-audit.md`, and `references/decision-report-template.md`: strengthened market-outlook monitoring signals from qualitative reversal-condition lists into actionable dashboards with threshold, cadence, source, and trigger-to-action mapping requirements (#224).
 - `scripts/test_market_outlook_monitoring_contract.py` and `.github/workflows/ci.yml`: added a regression contract test so the market-outlook monitoring actionability rule stays wired into checklist, final-audit recall, and the decision template (#224).

--- a/scripts/test_declared_execution.py
+++ b/scripts/test_declared_execution.py
@@ -138,6 +138,117 @@ Adoption is likely to accelerate [S03][S04].
     )
 
 
+def test_source_register_arxiv_equivalent_refs_pass() -> None:
+    expect_pass(
+        "Source Register entries cited by arXiv IDs pass",
+        """
+## Findings
+
+The base detector follows the YOLOv3 formulation (Redmon, 2018, arXiv:1804.02767).
+The transformer baseline follows the original attention paper (Vaswani et al. 2017, arXiv:1706.03762).
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | YOLOv3: An Incremental Improvement | primary | 2018-04-08 | https://arxiv.org/abs/1804.02767 | high | § Findings |
+| S02 | Attention Is All You Need | primary | 2017-06-12 | https://arxiv.org/abs/1706.03762 | high | § Findings |
+""",
+    )
+
+
+def test_source_register_doi_equivalent_refs_pass() -> None:
+    expect_pass(
+        "Source Register entries cited by DOI pass",
+        """
+## Findings
+
+The intervention effect is taken from the Nature study doi:10.1038/nature14539.
+The follow-up mechanism is described in https://doi.org/10.1145/3366423.3380295.
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Nature intervention study | primary | 2015-05-01 | https://doi.org/10.1038/nature14539 | high | § Findings |
+| S02 | Systems follow-up paper | primary | 2020-04-01 | 10.1145/3366423.3380295 | high | § Findings |
+""",
+    )
+
+
+def test_source_register_author_year_equivalent_refs_pass() -> None:
+    expect_pass(
+        "Source Register entries cited by Author-Year pass",
+        """
+## Findings
+
+The first cohort evidence comes from (Smith, 2025, Nature Medicine).
+The robustness check follows Lee et al. 2024.
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Smith 2025 Nature Medicine cohort study | primary | 2025-02-01 | https://doi.org/10.1000/smith2025 | high | § Findings |
+| S02 | Lee et al. 2024 robustness analysis | primary | 2024-08-01 | https://doi.org/10.1000/lee2024 | high | § Findings |
+""",
+    )
+
+
+def test_source_register_unique_natural_language_refs_pass() -> None:
+    expect_pass(
+        "Source Register entries cited by unique natural-language attribution pass",
+        """
+## Findings
+
+据 FY2025 年报，公司海外收入占比继续提升。
+2026Q1 业绩公告披露，同店销售恢复到正增长区间。
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | ExampleCo FY2025 Annual Report | primary | 2026-03-31 | https://example.com/fy2025-annual-report | high | § Findings |
+| S02 | ExampleCo 2026Q1 Earnings Announcement | primary | 2026-04-30 | https://example.com/2026q1-results | high | § Findings |
+""",
+    )
+
+
+def test_source_register_vague_natural_language_refs_fail() -> None:
+    expect_fail(
+        "vague natural-language attribution does not count as equivalent citation",
+        """
+## Findings
+
+据公开资料，公司海外收入占比继续提升。
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | ExampleCo FY2025 Annual Report | primary | 2026-03-31 | https://example.com/fy2025-annual-report | high | § Findings |
+""",
+    )
+
+
+def test_source_register_ambiguous_natural_language_refs_fail() -> None:
+    expect_fail(
+        "ambiguous natural-language attribution does not count as equivalent citation",
+        """
+## Findings
+
+据年报，公司海外收入占比继续提升。
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | ExampleCo FY2024 Annual Report | primary | 2025-03-31 | https://example.com/fy2024-annual-report | high | § Findings |
+| S02 | ExampleCo FY2025 Annual Report | primary | 2026-03-31 | https://example.com/fy2025-annual-report | high | § Findings |
+""",
+    )
+
+
 def test_academic_framework_no_mapping_fails() -> None:
     expect_fail(
         "academic framework declared without mapping",
@@ -178,6 +289,12 @@ def main() -> int:
         test_source_register_zero_body_refs_fails,
         test_source_register_uncited_inflation_fails,
         test_source_register_fully_cited_passes,
+        test_source_register_arxiv_equivalent_refs_pass,
+        test_source_register_doi_equivalent_refs_pass,
+        test_source_register_author_year_equivalent_refs_pass,
+        test_source_register_unique_natural_language_refs_pass,
+        test_source_register_vague_natural_language_refs_fail,
+        test_source_register_ambiguous_natural_language_refs_fail,
         test_academic_framework_no_mapping_fails,
         test_academic_framework_mapping_present_passes,
     ]

--- a/scripts/validate_declared_execution.py
+++ b/scripts/validate_declared_execution.py
@@ -40,6 +40,29 @@ ROLE_VALUE_RE = re.compile(
 SOURCE_REGISTER_HEADING_RE = re.compile(r"^#{1,6}\s+Source Register\s*$", re.IGNORECASE)
 SOURCE_ID_RE = re.compile(r"(?<!\w)\[?(S\d{2})\]?(?!\w)")
 BODY_SOURCE_REF_RE = re.compile(r"\[S\d{2}\]")
+ARXIV_REF_RE = re.compile(
+    r"(?:arxiv\s*:\s*|arxiv\.org/(?:abs|pdf)/)(\d{4}\.\d{4,5})(?:v\d+)?",
+    re.IGNORECASE,
+)
+DOI_REF_RE = re.compile(
+    r"(?:doi\s*:\s*|https?://(?:dx\.)?doi\.org/)?"
+    r"(10\.\d{4,9}/[^\s\]\)\|,;\"'<>]+)",
+    re.IGNORECASE,
+)
+AUTHOR_YEAR_RE = re.compile(
+    r"\(([A-Z][A-Za-z'’-]+)(?:\s+et\s+al\.)?,\s*((?:19|20)\d{2})(?:,\s*[^)]{2,80})?\)"
+    r"|\b([A-Z][A-Za-z'’-]+)(?:\s+et\s+al\.)?\s+((?:19|20)\d{2})\b"
+)
+NATURAL_ATTR_RE = re.compile(
+    r"(?:据|根据|来自|引用|援引)\s*([^。；;，,\n]{0,60}?"
+    r"(?:FY\s*20\d{2}|20\d{2}\s*Q[1-4]|招股书|年报|季报|业绩公告|annual report|prospectus|earnings announcement)"
+    r"[^。；;，,\n]{0,60})"
+    r"|((?:FY\s*20\d{2}|20\d{2}\s*Q[1-4])[^。；;，,\n]{0,40}?"
+    r"(?:年报|季报|业绩公告|annual report|earnings announcement))"
+    r"|((?:招股书|prospectus)\s*(?:披露)?)",
+    re.IGNORECASE,
+)
+VAGUE_ATTR_RE = re.compile(r"(?:公开资料|据悉|市场研究|行业研究|公开信息)", re.IGNORECASE)
 
 ACADEMIC_FRAMEWORK_RE = re.compile(
     r"(?:study\s+design\s+quality.{0,80}venue\s+prestige|venue\s+prestige.{0,80}study\s+design\s+quality|研究设计.{0,80}发表场所声誉|发表场所声誉.{0,80}研究设计|双维.{0,40}证据|多级.{0,40}证据)",
@@ -120,6 +143,158 @@ def table_lines(text: str) -> list[str]:
     return rows
 
 
+def split_markdown_table_row(row: str) -> list[str]:
+    stripped = row.strip()
+    if stripped.startswith("|"):
+        stripped = stripped[1:]
+    if stripped.endswith("|"):
+        stripped = stripped[:-1]
+    return [cell.strip() for cell in stripped.split("|")]
+
+
+def normalize_compact(text: str) -> str:
+    return re.sub(r"\s+", "", text.lower())
+
+
+def register_entries(register_text: str) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    for row in table_lines(register_text):
+        cells = split_markdown_table_row(row)
+        if not cells or cells[0].strip().lower() == "id":
+            continue
+        source_id = SOURCE_ID_RE.search(cells[0])
+        if not source_id:
+            continue
+        entries.append(
+            {
+                "id": source_id.group(1),
+                "text": " ".join(cells),
+                "source_name": cells[1] if len(cells) > 1 else "",
+                "doi_url": cells[4] if len(cells) > 4 else "",
+            }
+        )
+    return entries
+
+
+def normalize_doi(doi: str) -> str:
+    cleaned = doi.strip().lower()
+    cleaned = re.sub(r"^https?://(?:dx\.)?doi\.org/", "", cleaned)
+    cleaned = re.sub(r"^doi\s*:\s*", "", cleaned)
+    return cleaned.rstrip(".,;:)")
+
+
+def equivalent_id_matches(
+    body_values: set[str],
+    entries: list[dict[str, str]],
+    pattern: re.Pattern[str],
+    normalizer=lambda value: value.lower(),
+) -> set[str]:
+    cited: set[str] = set()
+    if not body_values:
+        return cited
+
+    for entry in entries:
+        entry_values = {normalizer(match) for match in pattern.findall(entry["text"])}
+        if body_values & entry_values:
+            cited.add(entry["id"])
+    return cited
+
+
+def author_year_refs(body_text: str, entries: list[dict[str, str]]) -> set[str]:
+    cited: set[str] = set()
+    for match in AUTHOR_YEAR_RE.finditer(body_text):
+        author = match.group(1) or match.group(3)
+        year = match.group(2) or match.group(4)
+        if not author or not year:
+            continue
+        hits = [
+            entry["id"]
+            for entry in entries
+            if author.lower() in entry["text"].lower() and year in entry["text"]
+        ]
+        if len(hits) == 1:
+            cited.add(hits[0])
+    return cited
+
+
+def natural_anchor_tokens(phrase: str) -> list[str]:
+    if VAGUE_ATTR_RE.search(phrase):
+        return []
+
+    compact = normalize_compact(phrase)
+    tokens: list[str] = []
+    tokens.extend(re.findall(r"fy20\d{2}", compact))
+    tokens.extend(re.findall(r"20\d{2}q[1-4]", compact))
+
+    if "annualreport" in compact or "年报" in compact:
+        tokens.append("annual_report")
+    if "earningsannouncement" in compact or "业绩公告" in compact:
+        tokens.append("earnings")
+    if "quarterly" in compact or "季报" in compact:
+        tokens.append("quarterly")
+    if "prospectus" in compact or "招股书" in compact:
+        tokens.append("prospectus")
+
+    return list(dict.fromkeys(tokens))
+
+
+def entry_matches_natural_tokens(entry: dict[str, str], tokens: list[str]) -> bool:
+    compact = normalize_compact(entry["text"])
+    for token in tokens:
+        if token == "annual_report":
+            if "annualreport" not in compact and "年报" not in compact:
+                return False
+            continue
+        if token == "earnings":
+            if (
+                "earnings" not in compact
+                and "results" not in compact
+                and "业绩公告" not in compact
+            ):
+                return False
+            continue
+        if token == "quarterly":
+            if "quarter" not in compact and "季报" not in compact:
+                return False
+            continue
+        if token == "prospectus":
+            if "prospectus" not in compact and "招股书" not in compact:
+                return False
+            continue
+        if token not in compact:
+            return False
+    return True
+
+
+def natural_language_refs(body_text: str, entries: list[dict[str, str]]) -> set[str]:
+    cited: set[str] = set()
+    for match in NATURAL_ATTR_RE.finditer(body_text):
+        phrase = next((group for group in match.groups() if group), "")
+        tokens = natural_anchor_tokens(phrase)
+        if not tokens:
+            continue
+        hits = [
+            entry["id"]
+            for entry in entries
+            if entry_matches_natural_tokens(entry, tokens)
+        ]
+        if len(hits) == 1:
+            cited.add(hits[0])
+    return cited
+
+
+def equivalent_body_source_refs(body_text: str, entries: list[dict[str, str]]) -> set[str]:
+    arxiv_values = {match.lower() for match in ARXIV_REF_RE.findall(body_text)}
+    doi_values = {normalize_doi(match) for match in DOI_REF_RE.findall(body_text)}
+
+    cited: set[str] = set()
+    cited.update(equivalent_id_matches(arxiv_values, entries, ARXIV_REF_RE))
+    cited.update(equivalent_id_matches(doi_values, entries, DOI_REF_RE, normalize_doi))
+    cited.update(author_year_refs(body_text, entries))
+    cited.update(natural_language_refs(body_text, entries))
+    return cited
+
+
 def check_opam_execution(text: str, path: Path) -> list[str]:
     if not OPAM_DECL_RE.search(text):
         return []
@@ -166,10 +341,11 @@ def check_source_register_execution(text: str, path: Path) -> list[str]:
 
     body_text = remove_section(text, SOURCE_REGISTER_HEADING_RE)
     body_refs = set(ref.strip("[]") for ref in BODY_SOURCE_REF_RE.findall(body_text))
+    body_refs.update(equivalent_body_source_refs(body_text, register_entries(register_text)))
     if not body_refs:
         return [
             f"{path}: Source Register declares {len(source_ids)} source ID(s), "
-            "but the body contains no [Sxx] citations"
+            "but the body contains no [Sxx] or equivalent citations"
         ]
 
     uncited_source_ids = sorted(source_ids - body_refs)


### PR DESCRIPTION
## Summary

Fixes #230.

This aligns `validate_declared_execution.py` with the existing source-traceability rules: Source Register inflation checks now count functionally equivalent body citations when they can be mapped uniquely to Source Register entries.

## What changed

- Added conservative equivalent-reference detection for:
  - arXiv IDs
  - DOI / doi.org references
  - Author-Year citations
  - specific natural-language attribution such as FY annual reports, quarterly/earnings announcements, and prospectus references
- Kept vague attribution such as `据公开资料` from counting as source traceability.
- Kept ambiguous natural-language attribution from counting when it matches multiple register entries.
- Updated declared-execution regression fixtures to cover the red/green cases.
- Added a changelog entry for #230.

## TDD notes

- Red: added equivalent-reference pass fixtures first; current `origin/main` failed them with `body contains no [Sxx] citations`.
- Green: implemented the minimal unique-mapping logic and kept existing register inflation behavior intact.

## Validation

- `python3 -m py_compile scripts/*.py`
- `python3 scripts/test_declared_execution.py`
- `python3 scripts/test_validator_regression.py`
- `python3 scripts/test_forward_looking_label_lint.py`
- `python3 scripts/test_market_outlook_monitoring_contract.py`
- `python3 scripts/test_md_to_pdf_preflight.py`
- `python3 scripts/validate_research_pack.py examples/research-pack-example.md`
- `python3 scripts/validate_research_pack.py examples/research-pack-example.md --strict`
- `git diff --check`
