### PR TITLE
[codex] Sync docs and evals with traceability rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       - run: python3 scripts/test_forward_looking_label_lint.py
       - run: python3 scripts/test_market_outlook_monitoring_contract.py
       - run: python3 scripts/test_declared_execution.py
+      - run: python3 scripts/test_doc_eval_sync.py
       - run: python3 scripts/test_md_to_pdf_preflight.py
 
   smoke:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -87,7 +87,7 @@ The current first-class routes are:
 - constrained choice / shortlist
 - listed-company / investment-style research
 - private company / startup evaluation
-- academic / literature review (⚠️ experimental)
+- academic / literature review (hardened; still needs more real-case validation)
 
 As a rule:
 
@@ -268,10 +268,10 @@ Evals should continue to drive changes, rather than abstract architecture change
 
 ## What is intentionally not done yet
 
-This architecture is still early-stage. It does **not** yet do all of the following:
+This architecture is still evolving. It does **not** yet do all of the following:
 
 - formal family grouping across all `references/`, `checklists/`, and `evals`
-- a dedicated system-map file for failure families and intervention points
+- full eval indexing and route-family coverage metadata beyond the lightweight `SYSTEM-MAP.md`
 - a fully independent delivery subsystem with separate top-level docs
 - subfolder formalization for eval types such as `case`, `rubric`, `distillation`, and `meta-eval`
 
@@ -293,4 +293,3 @@ When making future changes, prefer this order of questions:
 Place the change in the narrowest layer that fully explains the problem.
 
 Do not default to expanding `SKILL.md` unless the change truly belongs to the workflow spine.
-to the workflow spine.

--- a/evals/README.md
+++ b/evals/README.md
@@ -69,6 +69,12 @@ Keep evals organized by function rather than by recency alone.
 
 If a new eval does not clearly fit an existing subtype, choose the smallest reasonable category instead of creating unnecessary taxonomy.
 
+When rules evolve, historical evals may keep their original case background, but they must clearly separate historical observations from current acceptance rules. Use short fields when a prior verdict no longer matches the current contract:
+
+- **Historical verdict**: how the case was judged when the eval was created
+- **Current rule verdict**: how the same pattern should be judged under the current rule set
+- **Current eval target**: what the eval now primarily guards against
+
 ## Periodic audits
 
 Run `evals/meta/rule-trigger-audit.md` every 10 new eval cases or quarterly to track whether core disciplines are being triggered. When adding a new case eval, note which disciplines were applicable and whether they were triggered — this data feeds the audit.

--- a/evals/cases/academic-route-activation-crispr-progress-case.md
+++ b/evals/cases/academic-route-activation-crispr-progress-case.md
@@ -3,7 +3,9 @@
 ## Case metadata
 
 - **Case type**: Route activation validation
-- **Route**: Academic / Literature Review (experimental)
+- **Route**: Academic / Literature Review
+- **Historical route status**: experimental at case creation
+- **Current route status: hardened** (see `ROUTING-MATRIX.md`)
 - **Task type**: Academic field progress analysis
 - **Date**: 2026-05-29
 - **Status**: Validation case
@@ -227,7 +229,7 @@ The route activation failed if:
 
 ## Recommendation
 
-**Route definition**: Adequate for experimental stage. The route correctly activates for field progress analysis and produces artifacts with clear evidence hierarchy.
+**Route definition**: This historical activation case helped validate the route during its experimental stage. The route now correctly activates for field progress analysis and produces artifacts with clear evidence hierarchy.
 
 **Next steps**:
 1. Validate with 1 more case (paper comparison)

--- a/evals/cases/academic-route-activation-llm-hallucination-comparison-case.md
+++ b/evals/cases/academic-route-activation-llm-hallucination-comparison-case.md
@@ -3,7 +3,9 @@
 ## Case metadata
 
 - **Case type**: Route activation validation
-- **Route**: Academic / Literature Review (experimental)
+- **Route**: Academic / Literature Review
+- **Historical route status**: experimental at case creation
+- **Current route status: hardened** (see `ROUTING-MATRIX.md`)
 - **Task type**: Paper comparison and methodological evaluation
 - **Date**: 2026-05-29
 - **Status**: Validation case
@@ -242,7 +244,7 @@ The route activation failed if:
 
 ## Recommendation
 
-**Route definition**: Adequate for experimental stage. The route correctly activates for paper comparison tasks and produces artifacts with clear comparison dimensions.
+**Route definition**: This historical activation case helped validate the route during its experimental stage. The route now correctly activates for paper comparison tasks and produces artifacts with clear comparison dimensions.
 
 **Next steps**:
 1. Consider adding comparison table template

--- a/evals/cases/academic-route-activation-transformer-origin-case.md
+++ b/evals/cases/academic-route-activation-transformer-origin-case.md
@@ -3,7 +3,9 @@
 ## Case metadata
 
 - **Case type**: Route activation validation
-- **Route**: Academic / Literature Review (experimental)
+- **Route**: Academic / Literature Review
+- **Historical route status**: experimental at case creation
+- **Current route status: hardened** (see `ROUTING-MATRIX.md`)
 - **Task type**: Technology origin tracing through academic publications
 - **Date**: 2026-05-29
 - **Status**: Validation case
@@ -198,7 +200,7 @@ The route activation failed if:
 
 ## Recommendation
 
-**Route definition**: Adequate for experimental stage. The route correctly activates for technology origin tracing tasks and produces artifacts with visible evidence hierarchy.
+**Route definition**: This historical activation case helped validate the route during its experimental stage. The route now correctly activates for technology origin tracing tasks and produces artifacts with visible evidence hierarchy.
 
 **Next steps**:
 1. Validate with 2 more cases (field progress analysis, paper comparison)

--- a/evals/cases/ai-traffic-police-technical-deep-dive-traceability-case.md
+++ b/evals/cases/ai-traffic-police-technical-deep-dive-traceability-case.md
@@ -1,15 +1,16 @@
-# Eval: AI Traffic Police Technical Deep-Dive Source Traceability Hard-Fail Case
+# Eval: AI Traffic Police Technical Deep-Dive Source Traceability Format-Boundary Case
 
 ## Goal
 
-Test whether a Technical Deep-dive / Architecture Analysis report with complete appendix source list (S01-S27) can still trigger the source-traceability hard-fail gate by using non-standard inline citation formats (arXiv IDs, paper names) instead of structured `[SN]` inline references.
+Test whether a Technical Deep-dive / Architecture Analysis report with complete appendix source list (S01-S27) handles non-standard inline citation formats (arXiv IDs, paper names) under the current source-traceability format-equivalence rule.
 
 This eval targets a failure mode where:
 
 - the report has a **complete, well-structured source list** in the appendix
 - the body uses **partial inline references** (arXiv IDs, paper names) — which is better than nothing
-- but these references **do not follow the `[SN]` structured format** required by `checklists/source-traceability.md`
-- the hard-fail gate is triggered: "appendix source list exists but zero [SN] inline citations in body = undeliverable"
+- **Historical verdict**: this was originally treated as a source-traceability hard-fail because the body did not use the appendix `[SN]` IDs
+- **Current rule verdict**: arXiv IDs or DOI references can be a conditional pass if they uniquely map to structured Source Register entries; they fail only when the mapping is absent or ambiguous
+- **Current eval target**: distinguish format-boundary conditional pass from true zero-body-traceability failures
 
 This is distinct from previous source-traceability cases:
 
@@ -18,7 +19,7 @@ This is distinct from previous source-traceability cases:
 | Moore Threads | No sourcing at all |
 | 中际旭创 | Inconsistent inline citations |
 | 人形机器人 | Bibliography exists but zero body traceability |
-| **This case** | Body has partial citations (arXiv IDs) but not `[SN]` format — hard-fail triggered despite having better-than-nothing traceability |
+| **This case** | Body has partial citations (arXiv IDs) but not `[SN]` format — conditional pass if those citations map to structured register entries |
 
 ## Real case pattern
 
@@ -37,8 +38,8 @@ A user-provided AI Traffic Police report (AI 在交警电子警察违章图片�
 - ✅ Clear multi-timescale judgment (short/medium/long term, §10)
 - ✅ Judgment-first opening (6 core conclusions in executive summary, no background-first drift)
 
-**What triggered the hard-fail:**
-- ❌ **Source traceability hard-fail triggered** — body uses arXiv IDs (e.g., `arXiv:1911.00927`) and paper names instead of `[S01]`-format structured inline references. The S01-S27 IDs from the appendix source list are never referenced in the body text. Per `checklists/source-traceability.md`, this is a hard-fail: "appendix source list exists but zero [SN] inline citations in body = undeliverable."
+**Historical source-traceability concern:**
+- ⚠️ **Format-boundary concern** — body uses arXiv IDs (e.g., `arXiv:1911.00927`) and paper names instead of `[S01]`-format structured inline references. Under the current rule, this is not automatically a hard-fail: it is conditional pass if the identifiers uniquely map to Source Register entries, and fail only if the mapping is missing or ambiguous.
 
 **What has minor gaps:**
 - ⚠️ **Route planning (announced vs shipped)** — LLM integration cited from FT report (§4.3) describes an announced product integration, but is not explicitly labeled as "announced / not yet deployed at scale"
@@ -46,13 +47,13 @@ A user-provided AI Traffic Police report (AI 在交警电子警察违章图片�
 
 ## What this eval is testing
 
-### Failure Mode 1: Non-standard inline citations triggering hard-fail
+### Failure Mode 1: Non-standard inline citations as a format boundary
 
-The report uses arXiv IDs and paper names as inline references — this is a legitimate form of citation in academic contexts. However, the project's `source-traceability.md` checklist requires `[SN]`-format structured inline references. The report has a complete S01-S27 list in the appendix, but these IDs are never used in the body.
+The report uses arXiv IDs and paper names as inline references — this is a legitimate form of citation in academic contexts. The current `source-traceability.md` checklist treats arXiv IDs / DOI references as functionally equivalent inline citations when they uniquely map to structured register entries.
 
-This is a **format compliance failure**: the content is there, the traceability exists in principle, but the format doesn't match the project's structural requirement.
+This is a **format-boundary case**: the content is there, the traceability exists in principle, but reviewers must verify that the non-`[SN]` citations map cleanly to the appendix source entries.
 
-The lesson: **having source information in the body (arXiv IDs, paper names) is better than nothing, but it does not satisfy the `[SN]` inline citation requirement if the appendix IDs are not referenced from the body.**
+The lesson: **having source information in the body (arXiv IDs, paper names) can satisfy the hard-fail gate conditionally, but full pass still requires structured `[SN]` citations or an equally unambiguous register mapping.**
 
 ### Failure Mode 2: Announced vs shipped separation in Technical Deep-dive
 
@@ -66,7 +67,7 @@ The report covers three route types (Technical Deep-dive primary + Provider Sele
 
 A good answer should:
 
-1. **Structured inline citations in `[SN]` format** — body text references appendix source IDs (S01-S27), not just arXiv IDs or paper names
+1. **Structured inline citations in `[SN]` format for full pass** — body text references appendix source IDs (S01-S27), or non-`[SN]` citations uniquely map to register entries for conditional pass
 2. **Announced vs shipped separated** — roadmap/route-planning claims explicitly labeled as "announced" vs "shipped/delivered" vs "rumored/speculative"
 3. **Data freshness annotations** — data older than 2 years from report date has a staleness notice
 4. **Multi-route content labeled** — if non-primary-route content is included (provider analysis, regulatory), it is explicitly labeled as belonging to a different route family
@@ -75,8 +76,8 @@ A good answer should:
 
 Mark this eval as failed if the answer:
 
-- has a complete appendix source list (S01-S27) but zero `[SN]` inline references in the body text
-- has arXiv IDs or paper names in the body but no structured `[SN]` citations pointing to the appendix
+- has a complete appendix source list (S01-S27) but no body-level source references of any kind
+- has arXiv IDs or paper names in the body that cannot be uniquely mapped to structured Source Register entries
 - fails to separate announced vs shipped in roadmap/route-planning sections
 - uses vendor or market data 2+ years old without a staleness annotation
 
@@ -90,16 +91,16 @@ This case adds coverage for a distinct source-traceability failure mode: **non-s
 | `innolight-listed-company-execution-case.md` | Inconsistent body citations | 🟡 |
 | `humanoid-robot-market-outlook-dual-route-case.md` | Bibliography but zero body traceability | 🔴 |
 | `storage-chip-listed-company-deep-dive-pass-case.md` | Pass-level: no inline citations but other quality high | ✅ |
-| **This case** | Body has arXiv citations but not `[SN]` format — hard-fail triggered despite having better traceability than some passing cases | ⚠️ |
+| **This case** | Body has arXiv citations but not `[SN]` format — conditional pass if mapped to structured register entries | ⚠️ |
 
-This case documents a **borderline**: the report's traceability is better than the 人形机器人 case (which had zero body citations), but worse than the 存储芯片 case (which at least had evidence labels in the body). Yet it triggers a hard-fail because the format doesn't match the project's structural requirement.
+This case documents a **borderline**: the report's traceability is better than the 人形机器人 case (which had zero body citations), but less structured than a clean `[SN]` implementation. It should now be judged by functional traceability rather than `[SN]` format alone.
 
-The case suggests that the `[SN]` format requirement may need to allow non-standard citations when they provide equivalent or better traceability (arXiv IDs are globally unique and permanently resolvable).
+The case records why the `[SN]` format requirement was refined to allow non-standard citations when they provide equivalent or better traceability (arXiv IDs are globally unique and permanently resolvable).
 
 ## Suggested intervention target
 
-- `references/source-traceability-and-claim-citation.md` — clarify whether non-standard inline citations (arXiv IDs, DOI, paper names with dates) satisfy the source-traceability requirement, or whether `[SN]` format is strictly required; if strict, provide explicit guidance for migrating from arXiv IDs to `[SN]` format
-- `checklists/source-traceability.md` — add clarifying note: "arXiv IDs in body text count as inline citations IF the appendix also lists them under a structured ID; otherwise they are partial compliance"
+- `references/source-traceability-and-claim-citation.md` — preserve the current format-equivalence rule for arXiv IDs / DOI / paper names with dates, while requiring unique mapping to structured register entries
+- `checklists/source-traceability.md` — keep the conditional-pass distinction between equivalent inline formats and true zero-body-traceability failures
 - `checklists/technical-analysis-audit.md` — add non-blocker: "announced vs shipped separation for roadmap claims"
 - `references/technical-analysis-discipline.md` — add guidance for multi-route labeling when non-primary content is included
 
@@ -114,8 +115,8 @@ The case suggests that the `[SN]` format requirement may need to allow non-stand
 ## Suggested scoring
 
 - **Full pass**: `[SN]` inline citations present, announced vs shipped separated, fresh data, multi-route labeled
-- **Conditional pass**: source list exists, body has partial citations (arXiv IDs) but not `[SN]` format; announced/shipped mostly separated (this case's level)
-- **Fail**: source traceability hard-fail triggered AND no mitigation annotation
+- **Conditional pass**: source list exists, body has equivalent citations (arXiv IDs) but not `[SN]` format; announced/shipped mostly separated (this case's level)
+- **Fail**: no body-level source references, or equivalent references cannot be mapped to the register
 
 ## Related evals
 

--- a/evals/cases/fertility-academic-literature-review-format-boundary-case.md
+++ b/evals/cases/fertility-academic-literature-review-format-boundary-case.md
@@ -8,8 +8,9 @@ This eval targets a format boundary failure:
 
 - the report uses **(Author, Year, Journal)** inline citations — the universal standard in academic publishing
 - this format is **more informative than `[SN]`** — a reader can immediately identify the source without cross-referencing an appendix
-- but it **does not use `[SN]`/`[IN]`/`[UN]`** numbering, triggering the checklist hard-fail for format noncompliance
-- the core question: **should the project's `[SN]` requirement override discipline-specific citation standards when the alternative format provides equivalent or better traceability?**
+- **Historical verdict**: this case was created when `[SN]` format compliance was still being tested as a possible hard-fail boundary
+- **Current rule verdict**: `(Author, Year, Journal)` satisfies the inline traceability requirement for conditional pass when the register cross-references those citations structurally
+- **Current eval target**: ensure academic reports keep discipline-appropriate citations while still providing search strategy, publication-bias, evidence-tiering, and register traceability
 
 This continues the Round 2 pattern of **source traceability format boundary** cases:
 
@@ -48,7 +49,7 @@ The academic standard `(Author, Year, Journal)` is:
 - Universally recognized across academic disciplines
 - Permanently resolvable (unlike arXiv IDs which may change)
 
-Yet it triggers the project's source-traceability hard-fail because it doesn't use `[SN]` numbering.
+Under the current source-traceability rule, this format no longer fails merely because it does not use `[SN]` numbering; it conditionally passes when cross-referenced to a structured register.
 
 This case raises the same question as the AI Traffic Police and 泡泡玛特 cases: **should functionally equivalent citation formats be accepted?**
 

--- a/evals/cases/pop-mart-listed-company-traceability-hard-fail-case.md
+++ b/evals/cases/pop-mart-listed-company-traceability-hard-fail-case.md
@@ -1,17 +1,19 @@
-# Eval: 泡泡玛特 Listed-Company Source Traceability Hard-Fail + Absolute Claim Case
+# Eval: 泡泡玛特 Listed-Company Source Traceability Format-Boundary + Absolute Claim Case
 
 ## Goal
 
-Test whether a listed-company / investment-style report with a complete 30-entry source register and natural-language source attribution can still trigger the source-traceability hard-fail gate by using prose-based attribution instead of structured `[SN]` inline citations.
+Test whether a listed-company / investment-style report with a complete 30-entry source register and natural-language source attribution handles prose-based attribution correctly under the current source-traceability format-equivalence rule.
 
 This eval targets a failure mode where:
 
 - the report has a **complete, well-structured source register** (30 `[S#]` entries)
 - the body uses **natural language attribution** ("据 FY2025 年报", "招股书披露") — which is human-readable and functionally traceable
-- but these do **not use `[SN]` inline citations**, triggering the hard-fail gate: "source register exists but zero [SN] inline citations in body = undeliverable"
+- **Historical verdict**: this was originally treated as a source-traceability hard-fail because the body did not use `[SN]` inline citations
+- **Current rule verdict**: natural language attribution can be a conditional pass if it uniquely identifies one structured Source Register entry; it fails when the attribution is vague or ambiguous
+- **Current eval target**: separate traceable natural-language attribution from true bibliography-only / zero-body-reference failures
 - additionally, an **absolute claim** ("中国唯一") is used without exclusivity verification
 
-This is a companion to the AI Traffic Police case (`ai-traffic-police-technical-deep-dive-traceability-case.md`), which had the same source-traceability pattern but with arXiv IDs instead of natural language. Together, these cases suggest the `[SN]` hard-fail gate may need to carve out exceptions for functionally equivalent attribution formats.
+This is a companion to the AI Traffic Police case (`ai-traffic-police-technical-deep-dive-traceability-case.md`), which had the same source-traceability pattern but with arXiv IDs instead of natural language. Together, these cases document why the `[SN]` hard-fail gate now has exceptions for functionally equivalent attribution formats.
 
 ## Real case pattern
 
@@ -27,8 +29,8 @@ A user-provided 泡泡玛特 (Pop Mart, 9992.HK) deep research report dated **20
 - ✅ Data freshness: all anchor points labeled [确认事实]
 - ✅ Report redundancy at "slightly compressible" not "severely off-track"
 
-**What triggered the hard-fail:**
-- ❌ **Source traceability hard-fail triggered** — 30 `[S#]` entries in the source register, but zero `[SN]` inline citations in the body text. Body uses natural language attribution ("来自 FY2025 年报", "招股书披露", "彭博信用卡数据") which is human-readable but does not follow the `[SN]` format. Per `checklists/source-traceability.md`, this is a hard-fail.
+**Historical source-traceability concern:**
+- ⚠️ **Format-boundary concern** — 30 `[S#]` entries exist in the source register, while the body uses natural language attribution ("来自 FY2025 年报", "招股书披露", "彭博信用卡数据") instead of `[SN]` inline citations. Under the current rule, this is conditional pass if each attribution maps unambiguously to one register entry.
 
 **What has minor gaps:**
 - ❌ **Absolute claim "中国唯一" without exclusivity verification** — Section 2 uses "中国唯一" (China's only) for a market positioning claim. This is the strongest absolute claim in the report, but no exclusivity verification is provided. It also violates the report's own §18.2 guidance against overclaimed language.
@@ -41,17 +43,17 @@ A user-provided 泡泡玛特 (Pop Mart, 9992.HK) deep research report dated **20
 
 The report uses natural language source attribution ("据 FY2025 年报") throughout the body — this is functionally traceable (a human reader can find the source), but does not follow the `[SN]` inline citation format required by the source-traceability checklist.
 
-This raises the same question as the AI Traffic Police case: **should the `[SN]` hard-fail gate be strictly format-enforced, or should functionally equivalent attribution (natural language, arXiv IDs, DOIs) be accepted?**
+This records the same boundary as the AI Traffic Police case: functionally equivalent attribution (natural language, arXiv IDs, DOIs) is accepted for conditional pass when it is uniquely traceable.
 
 The difference between the three cases:
 
-| Case | Body attribution | Traceability | Hard-fail |
+| Case | Body attribution | Traceability | Current verdict |
 |------|-----------------|-------------|-----------|
-| AI Traffic Police | arXiv IDs, paper names | Partial (tech readers can resolve) | ❌ Triggered |
-| 泡泡玛特 | Natural language prose ("据FY2025年报") | High (any reader can follow) | ❌ Triggered |
-| 人形机器人 | Zero body attribution | None | ❌ Triggered |
+| AI Traffic Police | arXiv IDs, paper names | Partial (tech readers can resolve) | Conditional pass if mapped |
+| 泡泡玛特 | Natural language prose ("据FY2025年报") | High (any reader can follow) | Conditional pass if unambiguous |
+| 人形机器人 | Zero body attribution | None | Fail |
 
-The 泡泡玛特 case has the **strongest functional traceability** of all three, yet still triggers the hard-fail because the format doesn't match. This suggests the hard-fail gate needs refinement.
+The 泡泡玛特 case has the **strongest functional traceability** of all three, so the current rule treats it as a format-boundary conditional pass unless the natural-language references cannot be mapped to the register.
 
 ### Failure Mode 2: Absolute claim "唯一" without exclusivity gate
 
@@ -75,7 +77,7 @@ Without the derivation formula, the inference label is accurate but not transpar
 
 A good answer should:
 
-1. **Structured inline citations (`[SN]`)** — even if natural language attribution is also present, every load-bearing claim must also have a `[SN]` inline reference pointing to the source register
+1. **Structured inline citations (`[SN]`) for full pass** — if natural language attribution is used instead, every load-bearing claim must still map unambiguously to one source register entry
 2. **Exclusivity verification for absolute claims** — "唯一", "only", "first" claims must include explicit scope definition + verification evidence or be downgraded to "leading" / "top"
 3. **Inference derivation transparency** — each [推断] that involves a calculation or proxy must include the formula, assumptions, and data sources; if proprietary, state the limitation explicitly
 4. **Fresh anchor block** (already present in this case — maintain)
@@ -84,10 +86,10 @@ A good answer should:
 
 Mark this eval as failed if the answer:
 
-- has a complete source register but zero `[SN]` inline citations in body text
+- has a complete source register but no body-level source references of any kind
 - uses "唯一"/"only"/"first"/"only" without scope definition and exclusivity verification
 - labels indicators as [推断] without showing the derivation formula in body or appendix
-- has functional traceability via natural language but not `[SN]` format (this case's pattern)
+- uses natural language attribution that cannot be uniquely mapped to source register entries
 
 ## Why this case exists
 
@@ -99,7 +101,7 @@ This case adds to the growing group of source-traceability borderline cases in R
 | 泡泡玛特 (this case) | Natural language prose | High (all readers) | ❌ Noncompliant |
 | TikTok AI | [SN] inline citations | Full | ✅ **Compliant** |
 
-Together, these three cases form a spectrum that should inform the `[SN]` hard-fail gate's refinement in the next fix cycle.
+Together, these three cases form a spectrum that informed the current `[SN]` hard-fail gate refinement.
 
 | Gap | Existing coverage | This case adds |
 |-----|-------------------|----------------|
@@ -109,12 +111,12 @@ Together, these three cases form a spectrum that should inform the `[SN]` hard-f
 
 ## Suggested intervention target
 
-- `references/source-traceability-and-claim-citation.md` — refine the `[SN]` hard-fail gate to allow functionally equivalent attribution formats (natural language that uniquely identifies the source) while still requiring structured register entries; distinguish between "format noncompliant but traceable" vs "format noncompliant and untraceable"
-- `checklists/source-traceability.md` — add a graduated severity scale: (1) no attribution at all = hard-fail, (2) natural language but traceable = conditional pass with format fix recommended, (3) structured `[SN]` = full pass
+- `references/source-traceability-and-claim-citation.md` — preserve the current `[SN]` format-equivalence rule: natural language that uniquely identifies the source can conditionally pass while still requiring structured register entries
+- `checklists/source-traceability.md` — keep the graduated severity scale: (1) no attribution at all = hard-fail, (2) natural language but traceable = conditional pass with format fix recommended, (3) structured `[SN]` = full pass
 - `checklists/listed-company-report.md` — add: "unique/only/first claims have explicit scope and exclusivity verification"
 - `checklists/final-audit.md` — add non-blocker: "each [推断] with a calculation or proxy includes the derivation formula or explicitly states the limitation"
 
-(**Note**: the source-traceability gate refinement question is shared across 3 Round 2 cases — AI Traffic Police, TikTok AI, and 泡泡玛特. A batch fix should address this pattern rather than individual fixes.)
+(**Note**: the source-traceability gate refinement question is shared across 3 Round 2 cases — AI Traffic Police, TikTok AI, and 泡泡玛特. Current rules address this pattern through format equivalence plus structured register mapping.)
 
 ## Reviewer checklist
 
@@ -127,8 +129,8 @@ Together, these three cases form a spectrum that should inform the `[SN]` hard-f
 ## Suggested scoring
 
 - **Full pass**: structured `[SN]` citations, no absolute claims without verification, inference formulas present
-- **Conditional pass**: natural language attribution (traceable but noncompliant), minor absolute claim, inference labeled but formula absent (this case's level)
-- **Fail**: source traceability hard-fail AND no functional traceability; or unverified absolute claims AND other quality issues
+- **Conditional pass**: natural language attribution (traceable but not full `[SN]` format), minor absolute claim, inference labeled but formula absent (this case's level)
+- **Fail**: no functional traceability; or unverified absolute claims AND other quality issues
 
 ## Related evals
 

--- a/scripts/test_doc_eval_sync.py
+++ b/scripts/test_doc_eval_sync.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Regression tests for doc/eval synchronization after rule evolution."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relpath: str) -> str:
+    return (ROOT / relpath).read_text(encoding="utf-8")
+
+
+def expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def test_architecture_reflects_current_route_map() -> None:
+    text = read("ARCHITECTURE.md")
+
+    expect(
+        "academic / literature review (⚠️ experimental)" not in text,
+        "ARCHITECTURE.md still marks academic route as experimental",
+    )
+    expect(
+        "academic / literature review" in text and "hardened" in text,
+        "ARCHITECTURE.md should describe academic route as hardened/current",
+    )
+    expect(
+        "a dedicated system-map file for failure families and intervention points" not in text,
+        "ARCHITECTURE.md still says the dedicated system-map file is missing",
+    )
+    expect(
+        "\nDo not default to expanding `SKILL.md` unless the change truly belongs to the workflow spine.\nto the workflow spine." not in text,
+        "ARCHITECTURE.md still contains the duplicate trailing fragment",
+    )
+
+
+def test_eval_readme_documents_historical_rule_sync() -> None:
+    text = read("evals/README.md")
+
+    for phrase in [
+        "Historical verdict",
+        "Current rule verdict",
+        "Current eval target",
+    ]:
+        expect(
+            phrase in text,
+            f"evals/README.md should document the {phrase} field for historical evals",
+        )
+
+
+def test_source_traceability_format_boundary_evals_are_current() -> None:
+    cases = [
+        "evals/cases/ai-traffic-police-technical-deep-dive-traceability-case.md",
+        "evals/cases/pop-mart-listed-company-traceability-hard-fail-case.md",
+        "evals/cases/fertility-academic-literature-review-format-boundary-case.md",
+    ]
+
+    stale_phrases = [
+        "appendix source list exists but zero [SN] inline citations in body = undeliverable",
+        "source register exists but zero [SN] inline citations in body = undeliverable",
+        "Per `checklists/source-traceability.md`, this is a hard-fail",
+        "Yet it triggers the project's source-traceability hard-fail because it doesn't use `[SN]` numbering",
+    ]
+
+    for case in cases:
+        text = read(case)
+        for phrase in ["Historical verdict", "Current rule verdict", "Current eval target"]:
+            expect(phrase in text, f"{case} should explicitly distinguish {phrase}")
+        for phrase in stale_phrases:
+            expect(phrase not in text, f"{case} still contains stale rule text: {phrase}")
+
+
+def test_academic_activation_cases_mark_historical_experimental_status() -> None:
+    cases = [
+        "evals/cases/academic-route-activation-transformer-origin-case.md",
+        "evals/cases/academic-route-activation-crispr-progress-case.md",
+        "evals/cases/academic-route-activation-llm-hallucination-comparison-case.md",
+    ]
+
+    for case in cases:
+        text = read(case)
+        expect(
+            "Current route status: hardened" in text,
+            f"{case} should state the current academic route status",
+        )
+        expect(
+            "Adequate for experimental stage" not in text,
+            f"{case} still describes the current route definition as experimental",
+        )
+
+
+def main() -> int:
+    tests = [
+        test_architecture_reflects_current_route_map,
+        test_eval_readme_documents_historical_rule_sync,
+        test_source_traceability_format_boundary_evals_are_current,
+        test_academic_activation_cases_mark_historical_experimental_status,
+    ]
+    failures = []
+    for test in tests:
+        try:
+            test()
+            print(f"  PASS  {test.__name__}")
+        except AssertionError as exc:
+            failures.append(test.__name__)
+            print(f"  FAIL  {test.__name__}: {exc}")
+
+    if failures:
+        print(f"\n{len(failures)} test(s) failed: {', '.join(failures)}")
+        return 1
+
+    print(f"\nAll {len(tests)} tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Fixes #231.

This PR syncs the architecture docs and historical eval assets with the current source-traceability and academic-route contracts.

Changes:
- updates `ARCHITECTURE.md` so academic / literature review is no longer described as experimental
- removes the stale claim that a dedicated system-map file is missing, and deletes the duplicate trailing fragment
- adds an `evals/README.md` maintenance note for historical evals whose original verdict no longer matches current rules
- updates the AI Traffic Police, Pop Mart, and fertility format-boundary evals to distinguish historical verdict, current rule verdict, and current eval target
- marks the three academic activation evals as historical experimental-stage cases while pointing to the current hardened route status
- adds `scripts/test_doc_eval_sync.py` and wires it into CI to guard against this drift recurring

## TDD

Started by adding `scripts/test_doc_eval_sync.py`; it failed on current `origin/main` with four failures covering:
- stale academic experimental status in `ARCHITECTURE.md`
- missing historical/current eval maintenance fields
- stale format-boundary hard-fail wording
- academic activation cases lacking current hardened status

Then updated only the docs/eval assets needed to make that regression test pass.

## Validation

- `python3 scripts/test_doc_eval_sync.py`
- `python3 -m py_compile scripts/*.py`
- `python3 scripts/validate_research_pack.py examples/research-pack-example.md`
- `python3 scripts/validate_research_pack.py examples/research-pack-example.md --strict`
- `python3 scripts/test_validator_regression.py`
- `python3 scripts/test_forward_looking_label_lint.py`
- `python3 scripts/test_market_outlook_monitoring_contract.py`
- `python3 scripts/test_declared_execution.py`
- `python3 scripts/test_md_to_pdf_preflight.py`
- `git diff --check`

## Scope notes

This PR does not change the source-traceability rules themselves. It only updates documentation and eval descriptions to match the current rules: functionally equivalent inline references can be conditional pass when they uniquely map to structured register entries; true zero-body-reference cases remain failures.
