### PR TITLE
[P1] Technical Deep-dive 强化路线图状态分层：稳定能力 / 已宣布 / 实验扩展 / 推测不得混写 (#243)

### DIFF
--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -166,6 +166,7 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] for technical deep-dive / architecture analysis tasks, the report makes a technical judgment (not just a survey) and the judgment is supported by evidence
 - [ ] for technical deep-dive / architecture analysis tasks, comparison dimensions are explicit and the analysis is dimension-by-dimension (not just a feature list)
 - [ ] for technical deep-dive / architecture analysis tasks, technical state is current and vendor claims are distinguished from independently verified technical facts
+- [ ] for technical deep-dive / architecture analysis tasks, roadmap / feature-state claims separate stable shipped capability from announced roadmap, experimental extension, deprecated feature, and speculative direction
 - [ ] for regulatory / policy impact analysis tasks, current regulations are separated from pending/in-progress legislation
 - [ ] for regulatory / policy impact analysis tasks, business impact is analyzed (direct vs indirect) and uncertainty is explicitly bounded
 - [ ] for regulatory / policy impact analysis tasks, scenario analysis covers optimistic / base / pessimistic outcomes

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -166,7 +166,7 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] for technical deep-dive / architecture analysis tasks, the report makes a technical judgment (not just a survey) and the judgment is supported by evidence
 - [ ] for technical deep-dive / architecture analysis tasks, comparison dimensions are explicit and the analysis is dimension-by-dimension (not just a feature list)
 - [ ] for technical deep-dive / architecture analysis tasks, technical state is current and vendor claims are distinguished from independently verified technical facts
-- [ ] for technical deep-dive / architecture analysis tasks, roadmap / feature-state claims separate stable shipped capability from announced roadmap, experimental extension, deprecated feature, and speculative direction
+- [ ] for technical deep-dive / architecture analysis tasks, roadmap / feature-state claims separate stable/shipped from experimental, deprecated/superseded, announced roadmap, proposed/SEP draft, and rumored/community signal
 - [ ] for regulatory / policy impact analysis tasks, current regulations are separated from pending/in-progress legislation
 - [ ] for regulatory / policy impact analysis tasks, business impact is analyzed (direct vs indirect) and uncertainty is explicitly bounded
 - [ ] for regulatory / policy impact analysis tasks, scenario analysis covers optimistic / base / pessimistic outcomes

--- a/checklists/technical-analysis-audit.md
+++ b/checklists/technical-analysis-audit.md
@@ -17,8 +17,10 @@ This checklist verifies that the technical analysis route was executed correctly
 - [ ] current technical state is verified (versions, capabilities, benchmarks)
 - [ ] the report's stated coverage date or assessment window is consistent with the source timeline it cites; if sources span a date range, the coverage window is explicit
 - [ ] stale technical claims are flagged and either updated or explicitly marked as historical
-- [ ] roadmap claims are separated into: announced / rumored / speculative
-- [ ] deprecated or superseded features are not presented as current
+- [ ] roadmap / version / feature-state claims 分为 stable shipped / experimental / deprecated / announced roadmap / proposed / rumored
+- [ ] roadmap announcement 可标为 confirmed event，但未来能力结果不得标为 confirmed outcome
+- [ ] deprecated / superseded feature 没有被当作当前推荐能力
+- [ ] 如果报告引用官方 roadmap，必须说明是否 commitment，以及该说明对结论的影响
 
 ## Evidence quality
 

--- a/checklists/technical-analysis-audit.md
+++ b/checklists/technical-analysis-audit.md
@@ -17,7 +17,7 @@ This checklist verifies that the technical analysis route was executed correctly
 - [ ] current technical state is verified (versions, capabilities, benchmarks)
 - [ ] the report's stated coverage date or assessment window is consistent with the source timeline it cites; if sources span a date range, the coverage window is explicit
 - [ ] stale technical claims are flagged and either updated or explicitly marked as historical
-- [ ] roadmap / version / feature-state claims 分为 stable shipped / experimental / deprecated / announced roadmap / proposed / rumored
+- [ ] roadmap / version / feature-state claims 分为 stable / shipped / experimental / deprecated / superseded / announced roadmap / proposed / SEP draft / rumored / community signal
 - [ ] roadmap announcement 可标为 confirmed event，但未来能力结果不得标为 confirmed outcome
 - [ ] deprecated / superseded feature 没有被当作当前推荐能力
 - [ ] 如果报告引用官方 roadmap，必须说明是否 commitment，以及该说明对结论的影响

--- a/docs/superpowers/plans/2026-06-12-roadmap-state-stratification.md
+++ b/docs/superpowers/plans/2026-06-12-roadmap-state-stratification.md
@@ -1,0 +1,243 @@
+# Technical Roadmap State Stratification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Strengthen technical deep-dive roadmap state stratification — prevent reports from mixing stable/shipped, announced roadmap, experimental, deprecated, proposed, and rumored directions into one undifferentiated layer.
+
+**Architecture:** Pure documentation changes to 4 discipline/checklist files, plus a property-based test suite that verifies cross-document consistency invariants.
+
+**Tech Stack:** Python (property-based tests with hypothesis), Markdown
+
+---
+
+### Task 0: Write property-based test suite (TDD anchor)
+
+**Files:**
+- Create: `scripts/test_roadmap_state_stratification.py`
+
+This test suite verifies cross-document consistency invariants that must hold after ALL 4 tasks complete. It runs as a standalone script (project convention, no pytest needed).
+
+Invariants to test:
+
+- **P0 (Table completeness)**: `references/technical-analysis-discipline.md` must contain a markdown table with column headers: `状态`, `含义`, `允许标签`, `写作要求`. The table must have ≥ 6 data rows.
+
+- **P1 (Checklist coverage)**: For each status in the stratification table (extracted from technical-analysis-discipline.md), there is at least one corresponding checklist item in `checklists/technical-analysis-audit.md` that mentions that status (or its equivalent term).
+
+- **P2 (No orphan checklist items)**: Every roadmap-related checklist item in technical-analysis-audit.md maps to a status in the stratification table.
+
+- **P3 (Forward-looking technical section)**: `references/forward-looking-discipline.md` contains a section heading that mentions "technical roadmap" or "技术路线图".
+
+- **P4 (Final-audit recall)**: `checklists/final-audit.md` has a recall item for technical deep-dive that mentions "roadmap" and "state" or "状态" and "stable shipped".
+
+- **P5 (Hard-fail preservation)**: The existing hard-fail condition "roadmap evaluation treats announced features as shipped" in `technical-analysis-discipline.md` §Hard fail conditions is preserved.
+
+- [ ] **Step 0.1: Install hypothesis** if not available
+
+```bash
+pip install hypothesis
+```
+
+- [ ] **Step 0.2: Write failing test suite**
+
+Write the full test suite. The tests will fail now because the documents haven't been updated yet.
+
+- [ ] **Step 0.3: Verify tests fail**
+
+```bash
+python scripts/test_roadmap_state_stratification.py
+```
+Expected: multiple failures (since docs haven't been updated yet).
+
+- [ ] **Step 0.4: Commit**
+
+```bash
+git add scripts/test_roadmap_state_stratification.py
+git commit -m "test: add property-based consistency tests for roadmap state stratification"
+```
+
+---
+
+### Task 1: Update `references/technical-analysis-discipline.md`
+
+**Files:**
+- Modify: `references/technical-analysis-discipline.md` (§5 Technology roadmap evaluation)
+
+- [ ] **Step 1.1: Add status stratification table**
+
+After the 5 questions in §5 "Technology roadmap evaluation", append a new subsection with the status stratification table:
+
+````md
+### Roadmap/feature state stratification
+
+When evaluating a technology roadmap, classify each claim into exactly one of these states.
+Do not mix multiple states in the same claim.
+
+| 状态 | 含义 | 允许标签 | 写作要求 |
+|------|------|----------|----------|
+| Stable / shipped | 当前稳定规范或已发布实现支持 | [CONF] | 标明版本和验证日期 |
+| Experimental | 规范/扩展标明 experimental | [CONF] for status, [INFER] for maturity | 不得写成生产稳定能力 |
+| Deprecated / superseded | 已弃用或被替代 | [CONF] for status | 必须说明迁移或风险 |
+| Announced roadmap | 官方 roadmap / WG priority | [CONF] for announcement, not outcome | 必须写明不是已交付能力 |
+| Proposed / SEP draft | 提案、草案、PR | [INFER] or scoped [CONF] for proposal existence | 不得当成 adopted spec |
+| Rumored / community signal | 媒体、社区、issue、论坛 | [INFER]/[UNKN] | 必须标低置信或 discovery |
+````
+
+- [ ] **Step 1.2: Update Common failure modes**
+
+Update failure mode 5 "Roadmap optimism" to also mention state mixing:
+
+Old: `5. **Roadmap optimism**: treats announced features as shipped capabilities`
+
+New: `5. **Roadmap optimism**: treats announced features as shipped capabilities, or mixes stable/shipped, experimental, deprecated, announced, proposed, and rumored states into one undifferentiated layer`
+
+- [ ] **Step 1.3: Update Related references**
+
+Add a cross-reference to the new stratification section from the forward-looking discipline reference line.
+
+- [ ] **Step 1.4: Commit**
+
+```bash
+git add references/technical-analysis-discipline.md
+git commit -m "docs(technical-analysis): add roadmap/feature state stratification table"
+```
+
+---
+
+### Task 2: Update `checklists/technical-analysis-audit.md`
+
+**Files:**
+- Modify: `checklists/technical-analysis-audit.md`
+
+- [ ] **Step 2.1: Expand roadmap checks**
+
+Replace the existing single roadmap check (line 20) with granular checks:
+
+Old:
+```
+- [ ] roadmap claims are separated into: announced / rumored / speculative
+```
+
+New:
+```
+- [ ] roadmap / version / feature-state claims 分为 stable shipped / experimental / deprecated / announced roadmap / proposed / rumored
+- [ ] roadmap announcement 可标为 confirmed event，但未来能力结果不得标为 confirmed outcome
+- [ ] deprecated / superseded feature 没有被当作当前推荐能力
+- [ ] 如果报告引用官方 roadmap，必须说明是否 commitment，以及该说明对结论的影响
+```
+
+- [ ] **Step 2.2: Commit**
+
+```bash
+git add checklists/technical-analysis-audit.md
+git commit -m "docs(audit): expand roadmap state checks from 3 to 6 categories"
+```
+
+---
+
+### Task 3: Update `references/forward-looking-discipline.md`
+
+**Files:**
+- Modify: `references/forward-looking-discipline.md`
+
+- [ ] **Step 3.1: Add technical roadmap adaptation section**
+
+After the "Confidence framing" section (line 55), before "Assumption chains" (line 57), add:
+
+```md
+## Technical roadmap adaptation
+
+The categories above (announced / estimated / inferred) are designed for financial forecasts and corporate guidance. Technology roadmaps require additional dimensions:
+
+- **Feature lifecycle stage**: is the capability stable / experimental / deprecated / proposed?
+- **Specification status**: is the spec adopted / draft / SEP / archived?
+- **Implementation status**: is there a production implementation / reference implementation / proof-of-concept / none?
+
+Apply these rules when writing about technical roadmaps:
+
+1. **Confirmation scope is narrower for roadmap claims.** You can confirm that "the organization published a roadmap item," but you cannot confirm that "the roadmap outcome will be delivered." The former is an observed event; the latter is a forward-looking claim.
+2. **Do not mix lifecycle stages.** A deprecated feature is not "available but older" — it is explicitly superseded. An experimental extension is not "early production" — it is not yet stable.
+3. **Official roadmaps can confirm intent, not delivery.** Even when the source is the specification body itself, roadmap priority is not a commitment. Label accordingly.
+4. **When in doubt, use the stratification table in `references/technical-analysis-discipline.md` §Roadmap/feature state stratification.**
+```
+
+- [ ] **Step 3.2: Update Relationship section**
+
+In the "Relationship to other discipline files" section, add a reference:
+
+Old:
+```
+- `checklists/final-audit.md` includes forward-looking gates for precision and estimate sourcing.
+```
+
+New:
+```
+- `references/technical-analysis-discipline.md` §Roadmap/feature state stratification provides a state classification table specific to technical roadmap claims.
+- `checklists/final-audit.md` includes forward-looking gates for precision and estimate sourcing.
+```
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add references/forward-looking-discipline.md
+git commit -m "docs(forward-looking): add technical roadmap adaptation section"
+```
+
+---
+
+### Task 4: Update `checklists/final-audit.md`
+
+**Files:**
+- Modify: `checklists/final-audit.md`
+
+- [ ] **Step 4.1: Add roadmap state separation recall item**
+
+In the Recall discipline section, after the existing technical deep-dive items (line 168), add:
+
+```
+- [ ] for technical deep-dive / architecture analysis tasks, roadmap / feature-state claims separate stable shipped capability from announced roadmap, experimental extension, deprecated feature, and speculative direction
+```
+
+- [ ] **Step 4.2: Commit**
+
+```bash
+git add checklists/final-audit.md
+git commit -m "docs(final-audit): add roadmap state separation recall for technical deep-dive"
+```
+
+---
+
+### Task 5: Run tests and self-review (Reflexion)
+
+**Files:**
+- Run: `scripts/test_roadmap_state_stratification.py`
+
+- [ ] **Step 5.1: Run the property-based test suite**
+
+```bash
+python scripts/test_roadmap_state_stratification.py
+```
+
+Expected: ALL PASS
+
+- [ ] **Step 5.2: Run existing tests**
+
+```bash
+python scripts/test_doc_eval_sync.py
+```
+
+Expected: ALL PASS (regression check)
+
+- [ ] **Step 5.3: Final review**
+
+Check:
+- All 4 discipline files updated correctly
+- Property-based tests cover all new content
+- Existing test suite not broken
+- Cross-references between files are consistent
+
+- [ ] **Step 5.4: Final commit if needed**
+
+```bash
+git add -A
+git commit -m "fixup: address self-review findings"
+```

--- a/references/forward-looking-discipline.md
+++ b/references/forward-looking-discipline.md
@@ -54,6 +54,21 @@ When multiple forward-looking claims appear, signal their relative confidence:
 
 The report should not mix high-confidence and low-confidence forward claims in one undifferentiated outlook section.
 
+## Technical roadmap adaptation
+
+The categories above (announced / estimated / inferred) are designed for financial forecasts and corporate guidance. Technology roadmaps require additional dimensions:
+
+- **Feature lifecycle stage**: is the capability stable / experimental / deprecated / proposed?
+- **Specification status**: is the spec adopted / draft / SEP / archived?
+- **Implementation status**: is there a production implementation / reference implementation / proof-of-concept / none?
+
+Apply these rules when writing about technical roadmaps:
+
+1. **Confirmation scope is narrower for roadmap claims.** You can confirm that "the organization published a roadmap item," but you cannot confirm that "the roadmap outcome will be delivered." The former is an observed event; the latter is a forward-looking claim.
+2. **Do not mix lifecycle stages.** A deprecated feature is not "available but older" — it is explicitly superseded. An experimental extension is not "early production" — it is not yet stable.
+3. **Official roadmaps can confirm intent, not delivery.** Even when the source is the specification body itself, roadmap priority is not a commitment. Label accordingly.
+4. **When in doubt, use the stratification table in `references/technical-analysis-discipline.md` §Roadmap/feature state stratification.**
+
 ## Assumption chains
 
 When the report derives a forward-looking number (revenue projection, market size forecast, adoption timeline), make the assumption chain visible:
@@ -101,6 +116,7 @@ Fix: `假设年均增长率15%（基于[来源]的行业预测），到2030年�
 ## Relationship to other discipline files
 
 - `references/finance-date-discipline.md` covers the broader time-layer separation for financial numbers, including historical reported facts and current market snapshots. This file focuses specifically on the forward-looking subset.
+- `references/technical-analysis-discipline.md` §Roadmap/feature state stratification provides a state classification table specific to technical roadmap claims.
 - `checklists/forward-looking-claims.md` is the delivery-time gate: run it to catch unlabeled forward claims before the report goes out.
 - `checklists/final-audit.md` includes forward-looking gates for precision and estimate sourcing.
 

--- a/references/technical-analysis-discipline.md
+++ b/references/technical-analysis-discipline.md
@@ -62,6 +62,20 @@ Do not use this discipline when:
 - What could derail the roadmap?
 - What is the realistic timeline vs. optimistic claims?
 
+### Roadmap/feature state stratification
+
+When evaluating a technology roadmap, classify each claim into exactly one of these states.
+Do not mix multiple states in the same claim.
+
+| 状态 | 含义 | 允许标签 | 写作要求 |
+|------|------|----------|----------|
+| Stable / shipped | 当前稳定规范或已发布实现支持 | [CONF] | 标明版本和验证日期 |
+| Experimental | 规范/扩展标明 experimental | [CONF] for status, [INFER] for maturity | 不得写成生产稳定能力 |
+| Deprecated / superseded | 已弃用或被替代 | [CONF] for status | 必须说明迁移或风险 |
+| Announced roadmap | 官方 roadmap / WG priority | [CONF] for announcement, not outcome | 必须写明不是已交付能力 |
+| Proposed / SEP draft | 提案、草案、PR | [INFER] or scoped [CONF] for proposal existence | 不得当成 adopted spec |
+| Rumored / community signal | 媒体、社区、issue、论坛 | [INFER]/[UNKN] | 必须标低置信或 discovery |
+
 ## Evidence standards
 
 For technical claims, prioritize:
@@ -116,7 +130,7 @@ Watch for these failure patterns:
 2. **Missing comparison dimensions**: compares on only 1-2 dimensions when 4-5 are decision-relevant
 3. **Stale technical state**: uses outdated version numbers, deprecated features, or superseded benchmarks
 4. **Vendor claims treated as technical facts**: marketing specs mixed with engineering evidence
-5. **Roadmap optimism**: treats announced features as shipped capabilities
+5. **Roadmap optimism**: treats announced features as shipped capabilities, or mixes stable/shipped, experimental, deprecated, announced, proposed, and rumored states into one undifferentiated layer
 6. **Ignoring operational burden**: focuses on capabilities while ignoring deployment, maintenance, and scaling costs
 7. **Patent counting without analysis**: lists patents without understanding technical coverage or freedom-to-operate
 
@@ -166,7 +180,7 @@ Fail the report if:
 
 ## Related references
 
-- `references/forward-looking-discipline.md` — for forecasts, roadmap statements, announced-vs-rumored separation, and forward-looking assumption chains. Use when the task involves technology roadmap evaluation.
+- `references/forward-looking-discipline.md` — for forecasts, roadmap statements, announced-vs-rumored separation, forward-looking assumption chains, and technical roadmap adaptation. Use when the task involves technology roadmap evaluation. See also §Roadmap/feature state stratification above for state-level classification.
 - `references/source-traceability-and-claim-citation.md` — for source type classification and inline citation. Use for all technical claims.
 - `references/source-quality.md` — for source ranking dimensions and tie-break rules. Use when source credibility is ambiguous.
 - `references/counter-evidence.md` — for actively seeking contradicting evidence. Use when the technical claim is contentious or high-stakes.

--- a/references/technical-analysis-discipline.md
+++ b/references/technical-analysis-discipline.md
@@ -62,7 +62,7 @@ Do not use this discipline when:
 - What could derail the roadmap?
 - What is the realistic timeline vs. optimistic claims?
 
-### Roadmap/feature state stratification
+### 6. Roadmap/feature state stratification
 
 When evaluating a technology roadmap, classify each claim into exactly one of these states.
 Do not mix multiple states in the same claim.

--- a/scripts/test_roadmap_state_stratification.py
+++ b/scripts/test_roadmap_state_stratification.py
@@ -12,10 +12,10 @@ Each test asserts a PROPERTY (invariant) about the documentation:
   - P3: Forward-looking property — forward-looking discipline references technical roadmap
   - P4: Final-audit property — final audit recalls roadmap state separation for tech deep-dive
   - P5: Hard-fail preservation property — existing hard-fail condition is preserved
+  - P6: Commitment property — audit checklist contains commitment/disclaimer item
 """
 
 from pathlib import Path
-import re
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -41,7 +41,7 @@ EXPECTED_STATUSES: list[dict] = [
     {"label": "Stable / shipped", "aliases": ["stable", "shipped", "已发布", "稳定"]},
     {"label": "Experimental", "aliases": ["experimental", "实验"]},
     {"label": "Deprecated / superseded", "aliases": ["deprecated", "superseded", "弃用", "替代"]},
-    {"label": "Announced roadmap", "aliases": ["announced roadmap", "announced roadmap", "announced", "路线图", "计划"]},
+    {"label": "Announced roadmap", "aliases": ["announced roadmap", "announced", "路线图", "计划"]},
     {"label": "Proposed / SEP draft", "aliases": ["proposed", "sep", "draft", "草案", "提案"]},
     {"label": "Rumored / community signal", "aliases": ["rumored", "community signal", "推测", "社区"]},
 ]
@@ -141,12 +141,11 @@ def test_p1_checklist_coverage() -> None:
     for status in EXPECTED_STATUSES:
         found = any(alias.lower() in items_text for alias in status["aliases"])
         if not found:
-            # Soft check — warn but don't fail for aliases that might not match
-            # Try the label itself
+            # Fallback: try the full label
             if status["label"].lower() in items_text:
                 found = True
         if not found:
-            # Try partial match of first word of label
+            # Fallback: try partial match of first word of label
             first_word = status["label"].split("/")[0].strip().lower()
             if first_word in items_text:
                 found = True
@@ -164,18 +163,21 @@ def test_p1_checklist_coverage() -> None:
 def test_p3_forward_looking_technical_section() -> None:
     """
     P3 (Forward-looking property): forward-looking-discipline.md has a section
-    heading that mentions technical roadmap or 技术路线图.
+    heading that mentions technical roadmap or 技术路线图, and the section body
+    references the stratification table.
     """
     text = read(FORWARD_LOOKING_FILE)
     lines = text.split("\n")
 
     found_heading = False
-    for line in lines:
+    heading_idx = None
+    for i, line in enumerate(lines):
         stripped = line.strip()
         if stripped.startswith("##") or stripped.startswith("###"):
             lower = stripped.lower()
             if "technical roadmap" in lower or "技术路线图" in lower:
                 found_heading = True
+                heading_idx = i
                 break
 
     if not found_heading:
@@ -184,54 +186,88 @@ def test_p3_forward_looking_technical_section() -> None:
             f"'技术路线图' found in {FORWARD_LOOKING_FILE}"
         )
 
-    print(f"  PASS  P3: forward-looking discipline has technical roadmap section")
+    # Verify the section body references the stratification table
+    # Collect lines until next heading at same or higher level
+    section_lines = []
+    heading_level = len(lines[heading_idx]) - len(lines[heading_idx].lstrip("#"))
+    for j in range(heading_idx + 1, len(lines)):
+        next_line = lines[j]
+        if next_line.startswith("#") and (len(next_line) - len(next_line.lstrip("#"))) <= heading_level:
+            break
+        section_lines.append(next_line)
+    section_body = "\n".join(section_lines).lower()
+
+    if "technical-analysis-discipline.md" not in section_body and "stratification" not in section_body:
+        fail(
+            f"P3 FAIL: Technical roadmap section body does not reference "
+            f"the stratification table in technical-analysis-discipline.md"
+        )
+
+    print(f"  PASS  P3: forward-looking discipline has technical roadmap section with table reference")
 
 
 def test_p4_final_audit_recall() -> None:
     """
     P4 (Final-audit property): final-audit.md's technical deep-dive recall
-    items mention roadmap state separation.
+    items mention roadmap state separation with consistent terminology
+    matching the stratification table's 6 states.
     """
     text = read(FINAL_AUDIT_FILE)
     lines = text.split("\n")
 
-    # Find technical deep-dive recall items (after a heading + "for technical deep-dive")
-    in_tech_section = False
-    found_recall = False
+    # Find technical deep-dive recall items within the Recall discipline section
+    in_recall_section = False
+    recall_line = None
 
     for line in lines:
         stripped = line.strip()
 
         # Detect section boundaries
         if stripped.startswith("##") or stripped.startswith("###"):
-            # Check if we're entering the Recall discipline section
-            if "recall" in stripped.lower() or "recall" in stripped.lower():
-                in_tech_section = True
+            if "recall" in stripped.lower():
+                in_recall_section = True
             else:
-                in_tech_section = False
+                in_recall_section = False
             continue
 
-        if in_tech_section and (stripped.startswith("- [ ]") or stripped.startswith("- [x]")):
+        if in_recall_section and (
+            stripped.startswith("- [ ]")
+            or stripped.startswith("- [x]")
+            or stripped.startswith("- [X]")
+        ):
             lower = stripped.lower()
-            if "technical deep-dive" in lower and ("roadmap" in lower and "state" in lower):
-                found_recall = True
+            if "technical deep-dive" in lower and "roadmap" in lower and "state" in lower:
+                recall_line = lower
 
-    if not found_recall:
+    if recall_line is None:
         # Broader search: look for any checklist item mentioning both "roadmap" and "technical"
         all_items = get_checklist_items(text)
         for item in all_items:
             lower = item.lower()
             if "roadmap" in lower and "technical" in lower and "state" in lower:
-                found_recall = True
+                recall_line = lower
                 break
 
-    if not found_recall:
+    if recall_line is None:
         fail(
             f"P4 FAIL: No recall item for technical deep-dive mentioning "
             f"roadmap state separation found in {FINAL_AUDIT_FILE}"
         )
 
-    print(f"  PASS  P4: final-audit recalls roadmap state separation for technical deep-dive")
+    # Verify the recall item references at least 4 of the 6 table states
+    state_signals = {
+        "stable", "shipped", "experimental", "deprecated", "superseded",
+        "announced", "roadmap", "proposed", "sep draft",
+        "rumored", "community signal", "speculative",
+    }
+    found_signals = sum(1 for s in state_signals if s in recall_line)
+    if found_signals < 4:
+        fail(
+            f"P4 FAIL: Recall item only references {found_signals} state signals "
+            f"(need ≥4). Item text: {recall_line}"
+        )
+
+    print(f"  PASS  P4: final-audit recalls roadmap state separation ({found_signals} state signals)")
 
 
 def test_p5_hard_fail_preserved() -> None:
@@ -267,6 +303,22 @@ def test_p5_hard_fail_preserved() -> None:
     print(f"  PASS  P5: hard-fail condition for announced-vs-shipped preserved")
 
 
+def test_p6_commitment_checklist_item() -> None:
+    """
+    P6 (Commitment property): The audit checklist contains an item about
+    roadmap commitment/disclaimer — whether the roadmap is a commitment.
+    This was specifically called out in issue #243.
+    """
+    text = read(AUDIT_FILE)
+    items_text = text.lower()
+    if "commitment" not in items_text and "承诺" not in items_text:
+        fail(
+            f"P6 FAIL: No checklist item mentioning 'commitment' or '承诺' "
+            f"found in {AUDIT_FILE}"
+        )
+    print(f"  PASS  P6: commitment/disclaimer checklist item present")
+
+
 def test_p2_no_orphan_checklist_items() -> None:
     """
     P2 (No-orphan property): Every roadmap-related checklist item in
@@ -294,9 +346,10 @@ def test_p2_no_orphan_checklist_items() -> None:
     ])
 
     # Find roadmap-related checklist items
+    # Note: deliberately avoids broad terms like "状态" to minimize false positives
     roadmap_items = [
         item for item in items
-        if any(kw in item.lower() for kw in ["roadmap", "路线图", "feature-state", "状态", "shipped", "deprecated", "experimental", "proposed", "rumored"])
+        if any(kw in item.lower() for kw in ["roadmap", "路线图", "feature-state", "shipped", "deprecated", "experimental", "proposed", "rumored"])
     ]
 
     for item in roadmap_items:
@@ -322,6 +375,7 @@ def main() -> int:
         ("P3: Forward-looking section", test_p3_forward_looking_technical_section),
         ("P4: Final-audit recall", test_p4_final_audit_recall),
         ("P5: Hard-fail preserved", test_p5_hard_fail_preserved),
+        ("P6: Commitment item", test_p6_commitment_checklist_item),
     ]
 
     failures = []
@@ -338,7 +392,7 @@ def main() -> int:
         return 1
 
     print(f"\n{'='*60}")
-    print("✅ All 6 property tests PASSED — all cross-document invariants hold.")
+    print("✅ All 7 property tests PASSED — all cross-document invariants hold.")
     return 0
 
 

--- a/scripts/test_roadmap_state_stratification.py
+++ b/scripts/test_roadmap_state_stratification.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""
+Property-based consistency tests for roadmap state stratification (issue #243).
+
+These tests verify cross-document invariants that must hold across
+4 discipline/checklist files after the roadmap state stratification update.
+
+Each test asserts a PROPERTY (invariant) about the documentation:
+  - P0: Table structure property — stratification table has required columns and ≥6 rows
+  - P1: Coverage property — every status in the table has a corresponding audit check
+  - P2: No-orphan property — every audit check maps to a status in the table
+  - P3: Forward-looking property — forward-looking discipline references technical roadmap
+  - P4: Final-audit property — final audit recalls roadmap state separation for tech deep-dive
+  - P5: Hard-fail preservation property — existing hard-fail condition is preserved
+"""
+
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def fail(msg: str) -> None:
+    raise AssertionError(msg)
+
+
+# ─── helpers ─────────────────────────────────────────────────────────────────
+
+STRATIFICATION_FILE = "references/technical-analysis-discipline.md"
+AUDIT_FILE = "checklists/technical-analysis-audit.md"
+FORWARD_LOOKING_FILE = "references/forward-looking-discipline.md"
+FINAL_AUDIT_FILE = "checklists/final-audit.md"
+
+# Statuses we expect in the stratification table, with their canonical labels
+# and alternative search terms for matching checklist items.
+EXPECTED_STATUSES: list[dict] = [
+    {"label": "Stable / shipped", "aliases": ["stable", "shipped", "已发布", "稳定"]},
+    {"label": "Experimental", "aliases": ["experimental", "实验"]},
+    {"label": "Deprecated / superseded", "aliases": ["deprecated", "superseded", "弃用", "替代"]},
+    {"label": "Announced roadmap", "aliases": ["announced roadmap", "announced roadmap", "announced", "路线图", "计划"]},
+    {"label": "Proposed / SEP draft", "aliases": ["proposed", "sep", "draft", "草案", "提案"]},
+    {"label": "Rumored / community signal", "aliases": ["rumored", "community signal", "推测", "社区"]},
+]
+
+EXPECTED_TABLE_COLUMNS = ["状态", "含义", "允许标签", "写作要求"]
+MIN_TABLE_ROWS = 6
+
+
+def extract_table(text: str, headers: list[str]) -> list[list[str]] | None:
+    """Find a markdown table with the given headers and return its data rows.
+
+    Returns a list of rows, where each row is a list of cell values.
+    Returns None if not found.
+    """
+    lines = text.split("\n")
+    header_idx = None
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("|") and stripped.endswith("|"):
+            cells = [c.strip() for c in stripped.strip("|").split("|")]
+            if len(cells) == len(headers) and all(
+                h in cells[j] for j, h in enumerate(headers)
+            ):
+                header_idx = i
+                break
+
+    if header_idx is None:
+        return None
+
+    # Next line should be separator
+    if header_idx + 1 >= len(lines):
+        return None
+
+    separator = lines[header_idx + 1].strip()
+    if not separator.startswith("|") or not all(c.strip()[0] in "-:" for c in separator.strip("|").split("|") if c.strip()):
+        return None
+
+    # Data rows follow
+    rows = []
+    for j in range(header_idx + 2, len(lines)):
+        line = lines[j].strip()
+        if not line.startswith("|"):
+            break
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if len(cells) >= len(headers):
+            rows.append(cells[: len(headers)])
+
+    return rows
+
+
+def get_checklist_items(text: str) -> list[str]:
+    """Extract all checklist items from a checklist file."""
+    items = []
+    for line in text.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("- [ ]") or stripped.startswith("- [x]") or stripped.startswith("- [X]"):
+            items.append(stripped)
+    return items
+
+
+# ─── Property Tests ──────────────────────────────────────────────────────────
+
+
+def test_p0_table_structure() -> None:
+    """
+    P0 (Table completeness): The stratification table must exist with
+    the required columns and at least 6 data rows (one per status).
+    """
+    text = read(STRATIFICATION_FILE)
+    table = extract_table(text, EXPECTED_TABLE_COLUMNS)
+
+    if table is None:
+        fail(
+            f"P0 FAIL: Could not find stratification table with columns "
+            f"{EXPECTED_TABLE_COLUMNS} in {STRATIFICATION_FILE}"
+        )
+
+    actual_rows = len(table)
+    if actual_rows < MIN_TABLE_ROWS:
+        fail(
+            f"P0 FAIL: Stratification table has {actual_rows} data rows, "
+            f"expected at least {MIN_TABLE_ROWS}"
+        )
+
+    print(f"  PASS  P0: table found with {actual_rows} rows, all required columns present")
+
+
+def test_p1_checklist_coverage() -> None:
+    """
+    P1 (Coverage): Every status in the stratification table has at least
+    one corresponding checklist item in technical-analysis-audit.md.
+    """
+    text = read(AUDIT_FILE)
+    items = get_checklist_items(text)
+    items_text = "\n".join(items).lower()
+
+    for status in EXPECTED_STATUSES:
+        found = any(alias.lower() in items_text for alias in status["aliases"])
+        if not found:
+            # Soft check — warn but don't fail for aliases that might not match
+            # Try the label itself
+            if status["label"].lower() in items_text:
+                found = True
+        if not found:
+            # Try partial match of first word of label
+            first_word = status["label"].split("/")[0].strip().lower()
+            if first_word in items_text:
+                found = True
+        if not found:
+            fail(
+                f"P1 FAIL: Status '{status['label']}' has no corresponding "
+                f"checklist item in {AUDIT_FILE}.\n"
+                f"Searched aliases: {status['aliases']}\n"
+                f"Checklist items found: {len(items)}"
+            )
+
+    print(f"  PASS  P1: all {len(EXPECTED_STATUSES)} statuses have corresponding audit checks")
+
+
+def test_p3_forward_looking_technical_section() -> None:
+    """
+    P3 (Forward-looking property): forward-looking-discipline.md has a section
+    heading that mentions technical roadmap or 技术路线图.
+    """
+    text = read(FORWARD_LOOKING_FILE)
+    lines = text.split("\n")
+
+    found_heading = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("##") or stripped.startswith("###"):
+            lower = stripped.lower()
+            if "technical roadmap" in lower or "技术路线图" in lower:
+                found_heading = True
+                break
+
+    if not found_heading:
+        fail(
+            f"P3 FAIL: No section heading mentioning 'technical roadmap' or "
+            f"'技术路线图' found in {FORWARD_LOOKING_FILE}"
+        )
+
+    print(f"  PASS  P3: forward-looking discipline has technical roadmap section")
+
+
+def test_p4_final_audit_recall() -> None:
+    """
+    P4 (Final-audit property): final-audit.md's technical deep-dive recall
+    items mention roadmap state separation.
+    """
+    text = read(FINAL_AUDIT_FILE)
+    lines = text.split("\n")
+
+    # Find technical deep-dive recall items (after a heading + "for technical deep-dive")
+    in_tech_section = False
+    found_recall = False
+
+    for line in lines:
+        stripped = line.strip()
+
+        # Detect section boundaries
+        if stripped.startswith("##") or stripped.startswith("###"):
+            # Check if we're entering the Recall discipline section
+            if "recall" in stripped.lower() or "recall" in stripped.lower():
+                in_tech_section = True
+            else:
+                in_tech_section = False
+            continue
+
+        if in_tech_section and (stripped.startswith("- [ ]") or stripped.startswith("- [x]")):
+            lower = stripped.lower()
+            if "technical deep-dive" in lower and ("roadmap" in lower and "state" in lower):
+                found_recall = True
+
+    if not found_recall:
+        # Broader search: look for any checklist item mentioning both "roadmap" and "technical"
+        all_items = get_checklist_items(text)
+        for item in all_items:
+            lower = item.lower()
+            if "roadmap" in lower and "technical" in lower and "state" in lower:
+                found_recall = True
+                break
+
+    if not found_recall:
+        fail(
+            f"P4 FAIL: No recall item for technical deep-dive mentioning "
+            f"roadmap state separation found in {FINAL_AUDIT_FILE}"
+        )
+
+    print(f"  PASS  P4: final-audit recalls roadmap state separation for technical deep-dive")
+
+
+def test_p5_hard_fail_preserved() -> None:
+    """
+    P5 (Hard-fail preservation property): The existing hard-fail condition
+    'roadmap evaluation treats announced features as shipped' must be preserved
+    in technical-analysis-discipline.md's hard-fail section.
+    """
+    text = read(STRATIFICATION_FILE)
+    hard_fail_section = False
+    found_hard_fail = False
+
+    for line in text.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("##") and "hard fail" in stripped.lower():
+            hard_fail_section = True
+            continue
+        if stripped.startswith("##") and hard_fail_section:
+            # Exited the hard-fail section
+            hard_fail_section = False
+            continue
+        if hard_fail_section:
+            lower = stripped.lower()
+            if "announced" in lower and "shipped" in lower and "roadmap" in lower:
+                found_hard_fail = True
+
+    if not found_hard_fail:
+        fail(
+            f"P5 FAIL: Existing hard-fail condition about roadmap evaluation "
+            f"treating announced features as shipped not found in {STRATIFICATION_FILE}"
+        )
+
+    print(f"  PASS  P5: hard-fail condition for announced-vs-shipped preserved")
+
+
+def test_p2_no_orphan_checklist_items() -> None:
+    """
+    P2 (No-orphan property): Every roadmap-related checklist item in
+    technical-analysis-audit.md maps to a status in the stratification table.
+    """
+    text = read(AUDIT_FILE)
+    items = get_checklist_items(text)
+
+    # Collect all known status keywords from the table
+    known_keywords = set()
+    for status in EXPECTED_STATUSES:
+        known_keywords.add(status["label"].lower())
+        for alias in status["aliases"]:
+            known_keywords.add(alias.lower())
+
+    # Additional legitimate multi-status terms
+    known_keywords.update([
+        "roadmap", "路线图",
+        "commitment",
+        "confirm", "confirmed", "conf",
+        "未来能力", "outcome",
+        "当前推荐",
+        "superseded",
+        "影响",
+    ])
+
+    # Find roadmap-related checklist items
+    roadmap_items = [
+        item for item in items
+        if any(kw in item.lower() for kw in ["roadmap", "路线图", "feature-state", "状态", "shipped", "deprecated", "experimental", "proposed", "rumored"])
+    ]
+
+    for item in roadmap_items:
+        lower = item.lower()
+        # Check that at least one known keyword appears in this item
+        matches_known = any(kw in lower for kw in known_keywords)
+        if not matches_known:
+            # This is a soft warning, not a hard fail — the item might use
+            # legitimate terminology we didn't anticipate
+            print(f"  WARN  P2: possible orphan item — '{item[:80]}...'")
+
+    print(f"  PASS  P2: {len(roadmap_items)} roadmap-related items checked for coverage mapping")
+
+
+# ─── main ────────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    tests = [
+        ("P0: Table structure", test_p0_table_structure),
+        ("P1: Checklist coverage", test_p1_checklist_coverage),
+        ("P2: No orphan items", test_p2_no_orphan_checklist_items),
+        ("P3: Forward-looking section", test_p3_forward_looking_technical_section),
+        ("P4: Final-audit recall", test_p4_final_audit_recall),
+        ("P5: Hard-fail preserved", test_p5_hard_fail_preserved),
+    ]
+
+    failures = []
+    for name, fn in tests:
+        try:
+            fn()
+        except AssertionError as exc:
+            failures.append(name)
+            print(f"  FAIL  {name}: {exc}")
+
+    if failures:
+        print(f"\n{'='*60}")
+        print(f"❌ {len(failures)} property test(s) FAILED: {', '.join(failures)}")
+        return 1
+
+    print(f"\n{'='*60}")
+    print("✅ All 6 property tests PASSED — all cross-document invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Issue #243 要求强化 technical deep-dive 的技术路线图状态分层纪律。当前仓库已经有基本防御（announced/rumored/speculative 分离 + deprecated 检查），但缺少系统的状态分层表和跨文档一致性保证。

本 PR 在 4 个 discipline/checklist 文件中增加系统化的状态分层规则，弥合现有 eval（MCP 时间线/路线图 case）与文档规则之间的 gap。

## Changes

### references/technical-analysis-discipline.md
- 新增 **§Roadmap/feature state stratification** 表格（6 行状态：Stable/shipped / Experimental / Deprecated / Announced roadmap / Proposed / Rumored），每行含含义、允许标签、写作要求
- 更新 Common failure mode #5，增加状态混写描述
- 更新 Related references 交叉引用

### checklists/technical-analysis-audit.md
- 将原有单行检查 `roadmap claims are separated into: announced / rumored / speculative` 替换为 4 条精细化检查
- 覆盖 6 类状态分离、confirmed event vs outcome 区分、deprecated 保护、commitment 声明要求

### references/forward-looking-discipline.md
- 新增 **§Technical roadmap adaptation** 小节，说明财务预测的 3 类（announced/estimated/inferred）不足以覆盖技术路线图
- 增加 feature lifecycle / spec status / implementation status 三维度
- 4 条技术路线图写作规则

### checklists/final-audit.md
- Recall discipline 中 technical deep-dive 项从 3 条扩展为 4 条，新增路线图状态分离检查

### scripts/test_roadmap_state_stratification.py
- 新增 6 条 property-based 跨文档一致性测试（P0-P5）
- 覆盖表格结构、覆盖完备性、无孤立项、前向引用、final-audit 召回、hard-fail 保留

## Examples

### ✅ 正例（正确定义状态分层）

报告写法：
```
| 状态 | 来源与置信 |
|------|-----------|
| MCP 协议当前支持 JSON-RPC 2.0 传输（Stable / shipped, v2025-11-25） | [CONF] |
| 实验性 Streamable HTTP 扩展（Experimental） | [CONF for status][INFER for maturity] |
| 已弃用的原始 HTTP 绑定（Deprecated） | [CONF] — 建议迁移至 Streamable HTTP |
| 官方路线图优先级：Root Key 分离（Announced roadmap） | [CONF for announcement] — 非已交付能力 |
| SEP-002: 下一代传输协议（Proposed / SEP draft） | [INFER] — 草案阶段，不作为当前能力 |
| 社区讨论：MCP over WebTransport（Rumored / community signal） | [UNKN] — 无官方确认 |
```

### ❌ 反例（状态混写，本 PR 要拦截的）

```
MCP 协议支持 JSON-RPC 2.0、Streamable HTTP、Root Key 分离和下一代传输。
未来将考虑 WebTransport 支持。
```

问题：
- Streamable HTTP 是实验扩展，未标明 experimental
- Root Key 分离只是路线图优先级，被写成已支持能力
- 下一代传输是 SEP 草案，被当成路线图常规项
- WebTransport 仅为社区讨论，被写成未来将考虑

## Verification

- ✅ All 7 property tests pass
- ✅ Existing `test_doc_eval_sync.py` passes (no regression)
- ✅ 6 clean commits with descriptive messages

## Related

- Closes #243
- References #242 (technical opening baseline — partially overlapping files, no merge conflict expected)
- Existing eval `evals/cases/mcp-technical-deep-dive-timeline-roadmap-case.md` now has explicit rule backing in the discipline docs