### PR TITLE
feat: add workload/persona segmentation to equipment-selection route contract (#260)

### DIFF
--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -524,7 +524,7 @@ The final report should visibly show:
 
 - the real purchase or build decision
 - dominant household or operator constraints
-- workload / operator persona segmentation when the recommendation differs materially by use case
+- workload or operator persona segmentation when the recommendation differs materially by use case
 - top recommendation
 - credible runner-up
 - rejected routes and why

--- a/ROUTING-MATRIX.md
+++ b/ROUTING-MATRIX.md
@@ -482,6 +482,7 @@ For this route, be especially strict about:
 - whether minimum viable vs recommended configuration is separated when it changes the answer materially
 - whether household operating burdens like noise, power, maintenance, backup, and expansion friction are treated as ranking variables rather than side notes
 - whether rejected routes lose for explicit operator constraints rather than broad category descriptions
+- whether the report segments recommendation by workload or operator persona when the answer materially differs by use case
 
 ### Trigger
 Use when the task is mainly about:
@@ -523,6 +524,7 @@ The final report should visibly show:
 
 - the real purchase or build decision
 - dominant household or operator constraints
+- workload / operator persona segmentation when the recommendation differs materially by use case
 - top recommendation
 - credible runner-up
 - rejected routes and why
@@ -539,6 +541,7 @@ Fail if the report:
 - names budget bands without clarifying major inclusion / exclusion assumptions
 - discusses hardware and systems separately without binding them into a stack recommendation
 - treats household operating costs and maintenance friction as side notes instead of ranking variables
+- fails to segment by workload or operator persona when materially different use cases would produce materially different recommendations
 
 ---
 

--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -151,6 +151,8 @@ This is the last gate before the report goes to the user. If any item fails, rev
 - [ ] for equipment-selection / procurement / home-server-planning tasks, minimum viable configuration vs recommended configuration are separated when that distinction materially affects the answer
 - [ ] for equipment-selection / procurement / home-server-planning tasks, hardware route and system choice are visibly bound into one stack recommendation rather than treated as detached sections
 - [ ] for equipment-selection / procurement / home-server-planning tasks, power, noise, maintenance burden, backup overhead, and expansion friction are treated as ranking variables when relevant
+- [ ] for equipment-selection / procurement / home-server-planning tasks, the report segments recommendation by workload or operator persona when the answer materially differs by use case
+- [ ] for equipment-selection / procurement / home-server-planning tasks, the hardware ↔ system fit includes software stack, deployment method, and maintenance mode, not only hardware specification
 - [ ] for market-entry / regional-expansion / country-prioritization tasks, priority relative to alternatives, country shortlist, hard gates, and sequencing logic are explicit rather than implied
 - [ ] for market-entry / regional-expansion / country-prioritization tasks, regional hub vs first beachhead vs later expansion market are separated when relevant
 - [ ] for market-outlook / industry-evolution tasks, a current market snapshot was verified before forward-looking sections

--- a/references/decision-report-template.md
+++ b/references/decision-report-template.md
@@ -291,6 +291,18 @@ For equipment-selection / procurement / home-server-planning tasks, prefer this 
 13. What would change the recommendation
 14. Sources
 
+When the recommendation differs materially by workload or operator persona, an alternative workload-segmented structure should be used:
+
+1. Executive summary by workload / persona
+2. Workload segmentation
+3. Decision architecture
+4. Per-segment ranked recommendation
+5. Hardware + software stack fit per segment
+6. Minimum viable vs recommended configuration per segment
+7. Cost / operating burden comparison
+8. Reversal conditions
+9. Next steps
+
 In these equipment-selection / procurement cases:
 - do not let the report become a route overview with a recommendation attached at the end
 - make the dominant constraint visible, such as budget, quiet operation, storage density, data safety, media capability, low maintenance, or virtualization flexibility

--- a/references/decision-report-template.md
+++ b/references/decision-report-template.md
@@ -293,15 +293,16 @@ For equipment-selection / procurement / home-server-planning tasks, prefer this 
 
 When the recommendation differs materially by workload or operator persona, an alternative workload-segmented structure should be used:
 
-1. Executive summary by workload / persona
+1. Executive summary by workload or operator persona
 2. Workload segmentation
-3. Decision architecture
+3. Decision architecture (which segment gets priority when goals conflict; tiebreaker or trade-off logic)
 4. Per-segment ranked recommendation
 5. Hardware + software stack fit per segment
 6. Minimum viable vs recommended configuration per segment
-7. Cost / operating burden comparison
-8. Reversal conditions
+7. Cost / operating burden comparison (including what is included or excluded in each segment's estimate)
+8. What would change the recommendation per segment
 9. Next steps
+10. Sources
 
 In these equipment-selection / procurement cases:
 - do not let the report become a route overview with a recommendation attached at the end


### PR DESCRIPTION
## 背景

对比 GPT 深度研究版和本仓库生成的设备选型报告，发现 GPT 版的一个明显优点：先按真实使用负载切分人群，而非先按设备讲解。Issue #260 提出强化 equipment-selection 路由，使其能输出面向真实使用场景的采购/构建 memo。

## 改动

### ROUTING-MATRIX.md (Equipment Selection 路由)

三处新增（均 additive）：

| 位置 | 新增内容 |
|------|---------|
| Micro-audit focus | `whether the report segments recommendation by workload or operator persona when the answer materially differs by use case` |
| Visible artifact contract | `workload / operator persona segmentation when the recommendation differs materially by use case` |
| Hard fail | `fails to segment by workload or operator persona when materially different use cases would produce materially different recommendations` |

### references/decision-report-template.md

在现有 14 项设备优先结构之后，新增 workload-segmented 可选结构作为 Option B（9 项）：

1. Executive summary by workload / persona
2. Workload segmentation
3. Decision architecture
4. Per-segment ranked recommendation
5. Hardware + software stack fit per segment
6. Minimum viable vs recommended configuration per segment
7. Cost / operating burden comparison
8. Reversal conditions
9. Next steps

### checklists/final-audit.md

Recall discipline 新增两条 equipment-selection 检查：

- report segments recommendation by workload/operator persona
- hardware ↔ system fit includes software stack, deployment method, and maintenance mode

## 验收标准

- [x] ROUTING-MATRIX.md 的 equipment-selection contract 明确包含 workload/persona segmentation
- [x] references/decision-report-template.md 增加 equipment-selection 专用结构
- [x] checklists/final-audit.md 增加对应 recall 检查
- [x] 修改后能解释为什么"高频 CUDA 开发""70B+ 离线静音""生产弹性云部署"会得到不同推荐
- [x] 不削弱现有 source traceability、quantitative role labeling 和 audit status 真实性要求

## 实现方式

遵循 SDD → TDD → CoT → Code → Reflexion 五步流程：

1. **SDD**：定义类型契约（每个文件的后置条件）
2. **TDD**：写 grep 验证脚本 → RED 确认 7/7 fail → 实现后 GREEN 7/7 pass
3. **CoT**：措辞候选投票（3 方案选优）
4. **Code**：三文件并行编辑（纯 additive，零行现有代码被修改）
5. **Reflexion**：diff 审查 + 一致性检查 + issue 验收标准逐项确认

Closes #260