### PR TITLE
P0: 将 constrained-choice 接入 audit_report 总控，避免路由回落与已有关卡未执行

### DIFF
--- a/scripts/audit_report.py
+++ b/scripts/audit_report.py
@@ -89,6 +89,11 @@ _ROUTE_ALIASES: dict[str, str] = {
     "listed company / investment-style research": "listed-company",
     "listed company": "listed-company",
     "investment-style research": "listed-company",
+    "constrained choice": "constrained-choice",
+    "constrained choice / shortlist": "constrained-choice",
+    "constrained choice / shortlist / option selection": "constrained-choice",
+    "option selection": "constrained-choice",
+    "shortlist": "constrained-choice",
 }
 
 # Default route used when auto-detection fails or an unknown route is given.
@@ -246,6 +251,12 @@ ROUTE_VALIDATORS: dict[str, list[ValidatorFn]] = {
         _run_source_label_consistency,
     ],
     "academic-review": [
+        _run_report_quality,
+        _run_declared_execution,
+        _run_table_role_labels,
+        _run_source_label_consistency,
+    ],
+    "constrained-choice": [
         _run_report_quality,
         _run_declared_execution,
         _run_table_role_labels,

--- a/scripts/test_audit_report.py
+++ b/scripts/test_audit_report.py
@@ -243,6 +243,101 @@ Body text with citation [S01].
 """
 
 
+def _valid_constrained_choice_report() -> str:
+    """A minimal valid report that passes all constrained-choice checks.
+
+    Same structure as _valid_report() but with Constrained Choice / Shortlist
+    route and route-specific audit rows.
+    """
+    return """\
+# Test Report
+
+## Route and audit status
+
+**Primary route**: Constrained Choice / Shortlist
+
+| Audit | Status | 证据 |
+|-------|--------|------|
+| source-traceability | ✅ Passed | §3 正文使用 [S01] 与 [S02] 引用 |
+| option-selection-final-audit | ✅ Passed | §2-§6 各核心关卡可追溯 |
+| final-audit | ✅ Passed | §5 Comparison 表格含数字角色列 |
+
+## 执行摘要
+
+Executive summary with citation [S01].
+
+## Findings
+
+Body text with citation [S02].
+
+## 维度结论
+
+Each dimension conclusion is backed by [S01] and [S02].
+
+## Comparison Table
+
+| Metric | System A | System B | 数字角色 |
+|--------|----------|----------|---------|
+| Cost | 100 | 80 | observed |
+| Speed | 200 | 150 | observed |
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Example A | secondary | 2026-01-01 | https://example.com/a | medium | §3 |
+| S02 | Example B | secondary | 2026-02-01 | https://example.com/b | high | §5 |
+"""
+
+
+def _valid_chinese_constrained_choice_report() -> str:
+    """A valid constrained-choice report with Chinese heading.
+
+    Uses ## 附录：路由与审计状态 instead of the English heading, with
+    **Primary route**: Constrained Choice / Shortlist so that both
+    get_route_name() and check_route_declaration() work correctly.
+    """
+    return """\
+# Test Report
+
+## 附录：路由与审计状态
+
+**Primary route**: Constrained Choice / Shortlist
+
+| Audit | Status | 证据 |
+|-------|--------|------|
+| source-traceability | ✅ Passed | §3 正文使用 [S01] 与 [S02] 引用 |
+| option-selection-final-audit | ✅ Passed | §2-§6 各核心关卡可追溯 |
+| final-audit | ✅ Passed | §5 Comparison 表格含数字角色列 |
+
+## 执行摘要
+
+Executive summary with citation [S01].
+
+## Findings
+
+Body text with citation [S02].
+
+## 维度结论
+
+Each dimension conclusion is backed by [S01] and [S02].
+
+## Comparison Table
+
+| Metric | System A | System B | 数字角色 |
+|--------|----------|----------|---------|
+| Cost | 100 | 80 | observed |
+| Speed | 200 | 150 | observed |
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Example A | secondary | 2026-01-01 | https://example.com/a | medium | §3 |
+| S02 | Example B | secondary | 2026-02-01 | https://example.com/b | high | §5 |
+"""
+
+
 def _report_shared_workflow() -> str:
     """Report using shared-workflow path (no primary route).
 
@@ -678,6 +773,55 @@ Body with [S01].
 
 
 
+class TestConstrainedChoice:
+    """Constrained-choice route must be recognized without fallback."""
+
+    def test_constrained_choice_route_recognized(self) -> None:
+        """`--route constrained-choice` should show `constrained-choice` in output."""
+        result = _run_audit(
+            _valid_report(),
+            extra_args=["--route", "constrained-choice"],
+        )
+        assert "constrained-choice" in result.stdout, (
+            f"Expected 'constrained-choice' in route output, got:\n{result.stdout}"
+        )
+
+    def test_constrained_choice_no_fallback_warning(self) -> None:
+        """stderr must NOT contain 'falling back' when using --route constrained-choice."""
+        result = _run_audit(
+            _valid_report(),
+            extra_args=["--route", "constrained-choice"],
+        )
+        assert "falling back" not in result.stderr.lower(), (
+            f"Unexpected fallback warning in stderr:\n{result.stderr}"
+        )
+
+    def test_constrained_choice_route_runs_validators(self) -> None:
+        """A valid report with --route constrained-choice must pass (exit 0)."""
+        result = _run_audit(
+            _valid_constrained_choice_report(),
+            extra_args=["--route", "constrained-choice"],
+        )
+        assert result.returncode == 0, (
+            f"Expected exit 0, got {result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+    def test_auto_detect_constrained_choice_via_chinese_heading(self) -> None:
+        """Chinese heading report with constrained-choice route auto-detects."""
+        result = _run_audit(_valid_chinese_constrained_choice_report())
+        assert result.returncode == 0, (
+            f"Expected exit 0 for Chinese constrained-choice report, "
+            f"got {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert "constrained-choice" in result.stdout, (
+            f"Expected auto-detected 'constrained-choice' in route output, got:\n{result.stdout}"
+        )
+        assert "falling back" not in result.stderr.lower(), (
+            f"Unexpected fallback warning in stderr:\n{result.stderr}"
+        )
+
+
 class TestSharedWorkflow:
     """Shared-workflow reports should fall back to default validators."""
 
@@ -774,6 +918,11 @@ if __name__ == "__main__":
         ("--route unknown falls back", TestRouteOverride().test_unknown_route_falls_back),
         # TestNonExistentFile
         ("non-existent file exit", TestNonExistentFile().test_exit_code_blocking),
+        # TestConstrainedChoice
+        ("constrained-choice route recognized", TestConstrainedChoice().test_constrained_choice_route_recognized),
+        ("constrained-choice no fallback warning", TestConstrainedChoice().test_constrained_choice_no_fallback_warning),
+        ("constrained-choice route runs validators", TestConstrainedChoice().test_constrained_choice_route_runs_validators),
+        ("constrained-choice auto-detect via chinese heading", TestConstrainedChoice().test_auto_detect_constrained_choice_via_chinese_heading),
         # TestSharedWorkflow
         ("shared-workflow valid passes", TestSharedWorkflow().test_exit_code_zero_when_valid),
         ("shared-workflow fallback warning", TestSharedWorkflow().test_fallback_warning_in_stderr),

--- a/scripts/test_report_quality_validator.py
+++ b/scripts/test_report_quality_validator.py
@@ -10,6 +10,10 @@ import sys
 import tempfile
 from pathlib import Path
 
+# Direct import for get_route_name unit tests
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from validate_report_quality import get_route_name
+
 SCRIPT = str(Path(__file__).resolve().parent / "validate_report_quality.py")
 
 # ── Minimal valid report (all required elements present) ─────────────────
@@ -1123,6 +1127,82 @@ def test_academic_register_7_columns_non_academic_route_passes() -> None:
         f"stdout: {result.stdout}"
     )
     print("  PASS  non-academic 7-column register passes")
+# ── get_route_name Chinese heading tests ──────────────────────────────────
+# These import get_route_name directly for precise unit-level testing.
+
+
+def test_get_route_name_english_still_works() -> None:
+    """Existing English format still works after changes."""
+    text = """\
+## Route and audit status
+
+**Primary route**: Provider / Vendor Selection
+"""
+    result = get_route_name(text)
+    assert result == "Provider / Vendor Selection", (
+        f"Expected 'Provider / Vendor Selection', got {result!r}"
+    )
+    print("  PASS  get_route_name english still works")
+
+
+def test_get_route_name_chinese_heading() -> None:
+    """Report with Chinese heading and 研究路线 should return route name."""
+    text = """\
+## 附录：路由与审计状态
+
+研究路线：Constrained Choice / Shortlist
+"""
+    result = get_route_name(text)
+    assert result == "Constrained Choice / Shortlist", (
+        f"Expected 'Constrained Choice / Shortlist', got {result!r}"
+    )
+    print("  PASS  get_route_name chinese heading")
+
+
+def test_get_route_name_chinese_heading_with_secondary() -> None:
+    """Chinese heading with secondary route in parentheses."""
+    text = """\
+## 附录：路由与审计状态
+
+研究路线：Constrained Choice / Shortlist（主）+ Market Outlook（辅助）
+"""
+    result = get_route_name(text)
+    assert result == "Constrained Choice / Shortlist", (
+        f"Expected 'Constrained Choice / Shortlist', got {result!r}"
+    )
+    print("  PASS  get_route_name chinese heading with secondary")
+
+
+def test_get_route_name_chinese_primary_route() -> None:
+    """Chinese heading with 主路由 declaration."""
+    text = """\
+## 附录：路由与审计状态
+
+主路由：Constrained Choice / Shortlist
+"""
+    result = get_route_name(text)
+    assert result == "Constrained Choice / Shortlist", (
+        f"Expected 'Constrained Choice / Shortlist', got {result!r}"
+    )
+    print("  PASS  get_route_name chinese primary route")
+
+
+def test_get_route_name_chinese_table_cell_pipe() -> None:
+    """Table cell format with pipe separator: 主路由 | Constrained Choice / Shortlist."""
+    text = """\
+## 附录：路由与审计状态
+
+| Audit | 路由 | 证据 |
+|-------|------|------|
+| 主路由 | Constrained Choice / Shortlist / Option Selection | ✅ |
+"""
+    result = get_route_name(text)
+    assert result == "Constrained Choice / Shortlist / Option Selection", (
+        f"Expected 'Constrained Choice / Shortlist / Option Selection', got {result!r}"
+    )
+    print("  PASS  get_route_name chinese table cell pipe")
+
+
 # ── Main ─────────────────────────────────────────────────────────────────
 
 
@@ -1168,6 +1248,12 @@ def main() -> int:
         ("academic 11-column register passes", test_academic_register_11_columns_passes),
         ("academic 7-column register fails", test_academic_register_7_columns_fails),
         ("non-academic 7-column register passes", test_academic_register_7_columns_non_academic_route_passes),
+        # get_route_name Chinese heading tests
+        ("get_route_name english still works", test_get_route_name_english_still_works),
+        ("get_route_name chinese heading", test_get_route_name_chinese_heading),
+        ("get_route_name chinese heading with secondary", test_get_route_name_chinese_heading_with_secondary),
+        ("get_route_name chinese primary route", test_get_route_name_chinese_primary_route),
+        ("get_route_name chinese table cell pipe", test_get_route_name_chinese_table_cell_pipe),
     ]
     failures = []
     for name, fn in tests:

--- a/scripts/validate_report_quality.py
+++ b/scripts/validate_report_quality.py
@@ -32,7 +32,10 @@ TABLE_DELIMITER_RE = re.compile(
     r"^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$"
 )
 
-ROUTE_AUDIT_HEADING = re.compile(r"Route\s+and\s+audit\s+status", re.IGNORECASE)
+ROUTE_AUDIT_HEADING = re.compile(
+    r"(?:Route\s+and\s+audit\s+status|附录[：:]\s*路由与审计状态)",
+    re.IGNORECASE,
+)
 SOURCE_REGISTER_HEADING = re.compile(r"Source\s+Register", re.IGNORECASE)
 PRIMARY_ROUTE_RE = re.compile(r"\*\*Primary\s+route\*\*", re.IGNORECASE)
 SHARED_WORKFLOW_RE = re.compile(
@@ -706,6 +709,14 @@ def get_route_name(cleaned: str) -> str | None:
     if m:
         return m.group(1).strip()
     m = re.search(r"\*\*Route\*\*[:\s]+(.+)", sec)
+    if m:
+        return m.group(1).strip()
+    # Chinese: 研究路线：... or 主路由：... (stop at （, space, pipe, or end of line)
+    # Also handles table-cell pipe separator: 主路由 | Constrained Choice / Shortlist
+    m = re.search(
+        r"(?:研究路线|主路由)\s*(?:[：:]|\|\s*)\s*(.+?)(?:\s*[（(]|\s*$|\s*\|\s*)",
+        sec,
+    )
     if m:
         return m.group(1).strip()
     return None


### PR DESCRIPTION
## Summary

将 constrained-choice / option-selection / shortlist 路由接入 `scripts/audit_report.py` 总控系统，使其不再回落为 `technical-deep-dive`，并增强中文标题自动检测能力。

## Changes

### `scripts/validate_report_quality.py` (+13/-1)
- `ROUTE_AUDIT_HEADING` 正则同时匹配中文标题 `## 附录：路由与审计状态`
- `get_route_name()` 支持中文模式 `研究路线：` 和 `主路由：`（含全角/半角冒号、管道符表格分隔）

### `scripts/audit_report.py` (+11)
- `_ROUTE_ALIASES` 新增 5 个别名：`constrained choice`, `constrained choice / shortlist`, `constrained choice / shortlist / option selection`, `option selection`, `shortlist`
- `ROUTE_VALIDATORS` 新增 `constrained-choice` 条目，复用现有 4 个通用 validators

### `scripts/test_audit_report.py` (+149)
- 2 个新 fixture：`_valid_constrained_choice_report()`, `_valid_chinese_constrained_choice_report()`
- 4 个新测试：route 识别、无 fallback 警告、validator 正常运行、中文标题自动检测

### `scripts/test_report_quality_validator.py` (+86)
- 5 个新测试：英文格式回归、中文标题、主路由/次级路由管道符表格格式

## Test Plan

- [x] `scripts/test_audit_report.py` — All 35 tests passed
- [x] `scripts/test_report_quality_validator.py` — All 45 tests passed
- [x] 全项目 200+ 测试通过（1 个预存失败无关）
- [x] E2E 验证：`--route constrained-choice` 不再 fallback，输出 `Route: constrained-choice`
- [x] E2E 验证：中文标题 `## 附录：路由与审计状态` + `研究路线：Constrained Choice / Shortlist` 自动检测为 `constrained-choice`

## Review Notes

- `constrained-choice` 路由复用 `technical-deep-dive` 相同的 4 个 validators（report-quality, declared-execution, table-role-labels, source-label-consistency），这些已经覆盖 hard-fail 条件。专属 validator（如短名单边界、聚合可复算）可后续独立 issue 添加。
- 中文 `研究路线：` 格式虽然被 `get_route_name()` 识别，但 `check_route_declaration()` 仍然要求英文 `**Primary route**` / `**Route**` 格式。这是有意设计——统一采用英文 route 关键字，中文标题只用于总控自动检测。

Fixes #306