### PR TITLE
P0: market-outlook 接入 audit_report 总控 — 注册路由 + monitoring actionability 门禁 (#316)

### DIFF
--- a/scripts/audit_report.py
+++ b/scripts/audit_report.py
@@ -21,6 +21,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -95,6 +96,9 @@ _ROUTE_ALIASES: dict[str, str] = {
     "constrained choice / shortlist / option selection": "constrained-choice",
     "option selection": "constrained-choice",
     "shortlist": "constrained-choice",
+    "market outlook": "market-outlook",
+    "market outlook / industry evolution": "market-outlook",
+    "industry evolution": "market-outlook",
 }
 
 # Default route used when auto-detection fails or an unknown route is given.
@@ -247,6 +251,165 @@ def _run_scoring_replicability(path: Path, **kwargs: bool) -> CheckResult:
     return CheckResult(name="scoring-replicability", errors=errors, warnings=[])
 
 
+def _run_market_outlook_monitoring_actionability(
+    path: Path, **kwargs: bool
+) -> CheckResult:
+    """Validate ≥3 fully-defined monitoring signals with actionability fields.
+
+    Scans monitoring-related sections for tables containing all four
+    actionability columns: threshold, cadence, source, and trigger-to-action.
+    Each data row with all four fields populated counts as one fully-defined
+    signal.  Fewer than 3 such signals is a blocking error.
+
+    Accepts ``strict`` keyword to enable warnings for partially-defined
+    signals.
+    """
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except (OSError, UnicodeError) as exc:
+        return CheckResult(
+            name="market-outlook-monitoring",
+            errors=[f"{path}: cannot read file — {exc}"],
+        )
+
+    # ── Split into sections by heading level (## or ###) ──────────────────
+    lines = text.split("\n")
+    sections: list[tuple[str, list[str]]] = []
+    current_heading: str | None = None
+    current_body: list[str] = []
+
+    for line in lines:
+        m = re.match(r"^#{2,3}\s+(.+)$", line)
+        if m:
+            if current_heading is not None:
+                sections.append((current_heading, current_body))
+            current_heading = m.group(1).strip()
+            current_body = []
+        else:
+            current_body.append(line)
+    if current_heading is not None:
+        sections.append((current_heading, current_body))
+
+    # Find monitoring-related sections
+    monitoring_sections = [
+        (h, b) for h, b in sections if "monitoring" in h.lower()
+    ]
+
+    if not monitoring_sections:
+        return CheckResult(
+            name="market-outlook-monitoring",
+            errors=[
+                "No monitoring section found — market-outlook report must "
+                "include monitoring signals with actionable fields "
+                "(threshold, cadence, source, trigger-to-action)"
+            ],
+        )
+
+    # ── Actionability field keyword sets ──────────────────────────────────
+    FIELD_KEYWORDS: dict[str, set[str]] = {
+        "threshold": {"threshold", "阈值"},
+        "cadence": {"cadence", "frequency", "频率"},
+        "source": {"source", "来源"},
+        "trigger_to_action": {"trigger", "action", "应对"},
+    }
+
+    def _map_table_header(header_line: str) -> dict[str, int]:
+        """Match markdown table header columns to actionability fields.
+
+        Returns a dict {field_name: column_index}.  Columns are matched
+        in priority order (threshold → cadence → source → trigger_to_action);
+        each column can match at most one field.
+        """
+        cols = [
+            c.strip().lower()
+            for c in header_line.split("|")
+            if c.strip()
+        ]
+        mapping: dict[str, int] = {}
+        used: set[int] = set()
+
+        for field, keywords in FIELD_KEYWORDS.items():
+            for i, col in enumerate(cols):
+                if i in used:
+                    continue
+                if any(kw in col for kw in keywords):
+                    mapping[field] = i
+                    used.add(i)
+                    break
+
+        return mapping
+
+    # ── Parse tables within monitoring sections ────────────────────────────
+    fully_defined = 0
+    partial_signals: list[str] = []
+
+    for _heading, body_lines in monitoring_sections:
+        i = 0
+        while i < len(body_lines):
+            line = body_lines[i].strip()
+            if line.startswith("|") and not line.startswith("|--"):
+                header_line = line
+                i += 1
+                # Skip separator row (|--|--|...|)
+                if i < len(body_lines) and body_lines[i].strip().startswith("|") and "---" in body_lines[i]:
+                    i += 1
+                else:
+                    continue
+
+                col_map = _map_table_header(header_line)
+                if len(col_map) < 4:
+                    # Table does not have all 4 actionability columns; skip
+                    while i < len(body_lines) and body_lines[i].strip().startswith("|"):
+                        i += 1
+                    continue
+
+                # Parse data rows
+                while i < len(body_lines) and body_lines[i].strip().startswith("|"):
+                    row = body_lines[i].strip()
+                    cells = [c.strip() for c in row.split("|") if c.strip()]
+                    all_filled = True
+                    missing_fields: list[str] = []
+                    for field, col_idx in col_map.items():
+                        if col_idx >= len(cells) or not cells[col_idx]:
+                            all_filled = False
+                            missing_fields.append(field)
+                            break
+                    if all_filled:
+                        fully_defined += 1
+                    else:
+                        signal_name = cells[0] if cells else "(unknown)"
+                        partial_signals.append(
+                            f"Signal '{signal_name}' missing: "
+                            f"{', '.join(missing_fields)}"
+                        )
+                    i += 1
+            else:
+                i += 1
+
+    # ── Compute verdict ────────────────────────────────────────────────────
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if fully_defined < 3:
+        errors.append(
+            f"Only {fully_defined} fully-defined monitoring signal(s) "
+            f"found; need ≥3 with all four actionability fields "
+            f"(threshold, cadence, source, trigger-to-action)"
+        )
+
+    if kwargs.get("strict") and partial_signals:
+        warnings.append(
+            f"{len(partial_signals)} partially-defined monitoring signal(s):"
+        )
+        warnings.extend(f"  {s}" for s in partial_signals)
+
+    return CheckResult(
+        name="market-outlook-monitoring",
+        errors=errors,
+        warnings=warnings,
+    )
+
+
 # ── Route → validator mapping ──────────────────────────────────────────────
 
 ROUTE_VALIDATORS: dict[str, list[ValidatorFn]] = {
@@ -275,6 +438,13 @@ ROUTE_VALIDATORS: dict[str, list[ValidatorFn]] = {
         _run_table_role_labels,
         _run_source_label_consistency,
         _run_scoring_replicability,
+    ],
+    "market-outlook": [
+        _run_report_quality,
+        _run_declared_execution,
+        _run_table_role_labels,
+        _run_source_label_consistency,
+        _run_market_outlook_monitoring_actionability,
     ],
 }
 

--- a/scripts/audit_report.py
+++ b/scripts/audit_report.py
@@ -104,6 +104,10 @@ _ROUTE_ALIASES: dict[str, str] = {
 # Default route used when auto-detection fails or an unknown route is given.
 _DEFAULT_ROUTE = "technical-deep-dive"
 
+# Minimum number of fully-defined monitoring signals required for
+# market-outlook reports to pass the actionability gate.
+MIN_MONITORING_SIGNALS = 3
+
 
 def _normalize_route(name: str) -> str:
     """Normalize a display route name to a canonical key.
@@ -292,7 +296,8 @@ def _run_market_outlook_monitoring_actionability(
 
     # Find monitoring-related sections
     monitoring_sections = [
-        (h, b) for h, b in sections if "monitoring" in h.lower()
+        (h, b) for h, b in sections
+        if "monitoring" in h.lower() or "监测" in h
     ]
 
     if not monitoring_sections:
@@ -320,11 +325,9 @@ def _run_market_outlook_monitoring_actionability(
         in priority order (threshold → cadence → source → trigger_to_action);
         each column can match at most one field.
         """
-        cols = [
-            c.strip().lower()
-            for c in header_line.split("|")
-            if c.strip()
-        ]
+        # Split and drop leading/trailing artifacts from | markers
+        raw = header_line.split("|")
+        cols = [c.strip().lower() for c in raw[1:-1]]
         mapping: dict[str, int] = {}
         used: set[int] = set()
 
@@ -366,14 +369,15 @@ def _run_market_outlook_monitoring_actionability(
                 # Parse data rows
                 while i < len(body_lines) and body_lines[i].strip().startswith("|"):
                     row = body_lines[i].strip()
-                    cells = [c.strip() for c in row.split("|") if c.strip()]
+                    # Keep empty cells to preserve column index alignment
+                    raw_cells = row.split("|")
+                    cells = [c.strip() for c in raw_cells[1:-1]]
                     all_filled = True
                     missing_fields: list[str] = []
                     for field, col_idx in col_map.items():
                         if col_idx >= len(cells) or not cells[col_idx]:
                             all_filled = False
                             missing_fields.append(field)
-                            break
                     if all_filled:
                         fully_defined += 1
                     else:
@@ -390,14 +394,16 @@ def _run_market_outlook_monitoring_actionability(
     errors: list[str] = []
     warnings: list[str] = []
 
-    if fully_defined < 3:
+    if fully_defined < MIN_MONITORING_SIGNALS:
         errors.append(
             f"Only {fully_defined} fully-defined monitoring signal(s) "
-            f"found; need ≥3 with all four actionability fields "
-            f"(threshold, cadence, source, trigger-to-action)"
+            f"found; need ≥{MIN_MONITORING_SIGNALS} with all four "
+            f"actionability fields (threshold, cadence, source, "
+            f"trigger-to-action)"
         )
 
-    if kwargs.get("strict") and partial_signals:
+    strict = kwargs.get("strict", False)
+    if strict and partial_signals:
         warnings.append(
             f"{len(partial_signals)} partially-defined monitoring signal(s):"
         )

--- a/scripts/test_audit_report.py
+++ b/scripts/test_audit_report.py
@@ -457,6 +457,159 @@ Each dimension conclusion is backed by [S01] and [S02].
 """
 
 
+def _valid_market_outlook_report() -> str:
+    """A minimal valid market-outlook report that passes all checks.
+
+    Passes shared validators AND monitoring actionability (3+ signals
+    with all four fields: threshold, cadence, source, trigger-to-action).
+    """
+    return """\
+# Power Market Outlook 2026
+
+## Route and audit status
+
+**Primary route**: Market Outlook / Industry Evolution
+
+| Audit | Status | 证据 |
+|-------|--------|------|
+| source-traceability | ✅ Passed | §3 正文使用 [S01] 与 [S02] 引用 |
+| quantitative-role-labeling | ✅ Passed | §5 Comparison 表格含数字角色列 |
+| final-audit | ✅ Passed | §2-§6 各核心关卡可追溯 |
+
+## 执行摘要
+
+Power constraints are tightening across global data center markets [S01].
+
+## 市场现状
+
+Current snapshot shows 5.2 GW under construction in North America [S02].
+
+## Dimension conclusions
+
+Each dimension conclusion is backed by [S01] and [S02].
+
+## Comparison Table
+
+| Metric | 2025 | 2026E | 数字角色 |
+|--------|------|-------|---------|
+| DC Power | 50GW | 65GW | observed |
+| Growth | 20% | 30% | estimate |
+
+## Monitoring Signals
+
+| Signal | Threshold | Cadence | Source | Trigger-to-action | 数字角色 |
+|--------|-----------|---------|--------|-------------------|---------|
+| GPU utilization | >85% for 3 months | Monthly | Cloud provider API | Notify capacity team | observed |
+| Power cost | >$0.12/kWh | Quarterly | EIA report | Reassess location strategy | observed |
+| Grid interconnection | >6 months delay | Per project | Utility queue data | Explore colocation option | observed |
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Example A | secondary | 2026-01-01 | https://example.com/a | medium | §3 |
+| S02 | Example B | secondary | 2026-02-01 | https://example.com/b | high | §5 |
+"""
+
+
+def _market_outlook_no_monitoring_actionability() -> str:
+    """Market-outlook report with monitoring signals lacking actionability.
+
+    Has only 'Signal' and 'Threshold' columns — missing cadence,
+    source, and trigger-to-action.  <3 fully-defined → blocking.
+    """
+    return """\
+# Power Market Outlook 2026
+
+## Route and audit status
+
+**Primary route**: Market Outlook / Industry Evolution
+
+| Audit | Status | 证据 |
+|-------|--------|------|
+| source-traceability | ✅ Passed | §3 正文使用 [S01] 与 [S02] 引用 |
+| quantitative-role-labeling | ✅ Passed | §5 Comparison 表格含数字角色列 |
+| final-audit | ✅ Passed | §2-§6 各核心关卡可追溯 |
+
+## 执行摘要
+
+Power constraints are tightening across global data center markets [S01].
+
+## 市场现状
+
+Current snapshot shows 5.2 GW under construction in North America [S02].
+
+## Dimension conclusions
+
+Each dimension conclusion is backed by [S01] and [S02].
+
+## Comparison Table
+
+| Metric | 2025 | 2026E | 数字角色 |
+|--------|------|-------|---------|
+| DC Power | 50GW | 65GW | observed |
+| Growth | 20% | 30% | estimate |
+
+## Monitoring Signals
+
+| Signal | Threshold | 数字角色 |
+|--------|-----------|---------|
+| GPU utilization | >85% | observed |
+| Power cost | >$0.12/kWh | observed |
+| Grid interconnection | >6 months delay | observed |
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Example A | secondary | 2026-01-01 | https://example.com/a | medium | §3 |
+| S02 | Example B | secondary | 2026-02-01 | https://example.com/b | high | §5 |
+"""
+
+
+def _market_outlook_no_monitoring_section() -> str:
+    """Market-outlook report with no monitoring section at all."""
+    return """\
+# Power Market Outlook 2026
+
+## Route and audit status
+
+**Primary route**: Market Outlook / Industry Evolution
+
+| Audit | Status | 证据 |
+|-------|--------|------|
+| source-traceability | ✅ Passed | §3 正文使用 [S01] 与 [S02] 引用 |
+| quantitative-role-labeling | ✅ Passed | §5 Comparison 表格含数字角色列 |
+| final-audit | ✅ Passed | §2-§6 各核心关卡可追溯 |
+
+## 执行摘要
+
+Power constraints are tightening across global data center markets [S01].
+
+## 市场现状
+
+Current snapshot shows 5.2 GW under construction in North America [S02].
+
+## Dimension conclusions
+
+Each dimension conclusion is backed by [S01] and [S02].
+
+## Comparison Table
+
+| Metric | 2025 | 2026E | 数字角色 |
+|--------|------|-------|---------|
+| DC Power | 50GW | 65GW | observed |
+| Growth | 20% | 30% | estimate |
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Example A | secondary | 2026-01-01 | https://example.com/a | medium | §3 |
+| S02 | Example B | secondary | 2026-02-01 | https://example.com/b | high | §5 |
+"""
+
+
 def _report_shared_workflow() -> str:
     """Report using shared-workflow path (no primary route).
 
@@ -1011,6 +1164,107 @@ class TestConstrainedChoiceScoringReplicability:
         )
 
 
+class TestMarketOutlookRoute:
+    """Market-outlook route must be recognized without fallback."""
+
+    def test_market_outlook_route_recognized(self) -> None:
+        """--route market-outlook should show 'market-outlook' in output."""
+        result = _run_audit(
+            _valid_market_outlook_report(),
+            extra_args=["--route", "market-outlook"],
+        )
+        assert "market-outlook" in result.stdout, (
+            f"Expected 'market-outlook' in route output, got:\n{result.stdout}"
+        )
+
+    def test_market_outlook_no_fallback_warning(self) -> None:
+        """stderr must NOT contain 'falling back' for --route market-outlook."""
+        result = _run_audit(
+            _valid_market_outlook_report(),
+            extra_args=["--route", "market-outlook"],
+        )
+        assert "falling back" not in result.stderr.lower(), (
+            f"Unexpected fallback warning in stderr:\n{result.stderr}"
+        )
+
+    def test_market_outlook_auto_detect(self) -> None:
+        """Report with 'Market Outlook / Industry Evolution' route auto-detects."""
+        result = _run_audit(_valid_market_outlook_report())
+        assert "market-outlook" in result.stdout, (
+            f"Expected auto-detected 'market-outlook' in output, got:\n{result.stdout}"
+        )
+        assert "falling back" not in result.stderr.lower(), (
+            f"Unexpected fallback warning in stderr:\n{result.stderr}"
+        )
+
+    def test_market_outlook_alias_no_fallback(self) -> None:
+        """Each alias must resolve without fallback warning."""
+        for alias in [
+            "market-outlook",
+            "market outlook",
+            "market outlook / industry evolution",
+            "industry evolution",
+        ]:
+            result = _run_audit(
+                _valid_market_outlook_report(),
+                extra_args=["--route", alias],
+            )
+            assert "falling back" not in result.stderr.lower(), (
+                f"Alias '{alias}' triggered fallback:\n{result.stderr}"
+            )
+            assert "market-outlook" in result.stdout, (
+                f"Alias '{alias}' did not show 'market-outlook' in output:\n{result.stdout}"
+            )
+
+
+class TestMarketOutlookMonitoringActionability:
+    """Market-outlook monitoring actionability validator must enforce the
+    <3 fully-defined signals → blocking gate."""
+
+    def test_actionable_monitoring_passes(self) -> None:
+        """Report with 3+ fully-defined monitoring signals must pass."""
+        result = _run_audit(
+            _valid_market_outlook_report(),
+            extra_args=["--route", "market-outlook"],
+        )
+        assert result.returncode == 0, (
+            f"Expected exit 0 for actionable monitoring, got {result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+    def test_non_actionable_monitoring_blocking(self) -> None:
+        """Report with monitoring lacking cadence/source/trigger → exit 2."""
+        result = _run_audit(
+            _market_outlook_no_monitoring_actionability(),
+            extra_args=["--route", "market-outlook"],
+        )
+        assert result.returncode == 2, (
+            f"Expected exit 2 for non-actionable monitoring, got {result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+    def test_no_monitoring_section_blocking(self) -> None:
+        """Report with no monitoring section → exit 2."""
+        result = _run_audit(
+            _market_outlook_no_monitoring_section(),
+            extra_args=["--route", "market-outlook"],
+        )
+        assert result.returncode == 2, (
+            f"Expected exit 2 for missing monitoring section, got {result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+    def test_non_actionable_error_mentions_monitoring(self) -> None:
+        """Error output must mention 'market-outlook-monitoring' or 'monitoring'."""
+        result = _run_audit(
+            _market_outlook_no_monitoring_actionability(),
+            extra_args=["--route", "market-outlook"],
+        )
+        assert "monitoring" in result.stdout.lower(), (
+            f"Expected monitoring-related error, got:\n{result.stdout}"
+        )
+
+
 class TestSharedWorkflow:
     """Shared-workflow reports should fall back to default validators."""
 
@@ -1082,6 +1336,52 @@ Primary company source S01 lacks the required caveat.
                 f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
             )
 
+    def test_market_outlook_validators_all_run(self) -> None:
+        """Market-outlook route must run all 5 validators, including monitoring."""
+        content = """\
+# Test
+
+## Route and audit status
+
+**Primary route**: Market Outlook / Industry Evolution
+
+| Audit | Status | 证据 |
+|-------|--------|------|
+| source-traceability | ✅ Passed | §3 引用 [S01] |
+| final-audit | ✅ Passed | §2 可追溯 |
+
+## Body
+
+Body text with citation [S01].
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Ex | secondary | 2026-01-01 | https://ex.com | medium | §3 |
+"""
+        result = _run_audit(content, extra_args=["--route", "market-outlook"])
+        # The market-outlook validator chain: report-quality, declared-execution,
+        # table-role-labels, source-label-consistency, market-outlook-monitoring
+        expected_prefixes = [
+            "report-quality",
+            "declared-execution",
+            "table-role-labels",
+            "source-label-consistency",
+            "market-outlook-monitoring",
+        ]
+        for prefix in expected_prefixes:
+            marker_bracket = f"[{prefix}]"
+            marker_plain = f"{prefix}:"
+            assert (
+                marker_bracket in result.stdout
+                or marker_bracket in result.stderr
+                or marker_plain in result.stdout
+            ), (
+                f"Missing '{prefix}' in output — market-outlook validator "
+                f"may not have run\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+            )
+
 
 if __name__ == "__main__":
     # Self-contained test runner (no external dependencies).
@@ -1132,11 +1432,26 @@ if __name__ == "__main__":
          TestConstrainedChoiceScoringReplicability().test_scoring_table_with_rules_passes),
         ("cc scoring table with rules no scoring-replicability errors",
          TestConstrainedChoiceScoringReplicability().test_scoring_table_with_rules_no_scoring_replicability_errors),
+        # TestMarketOutlookRoute
+        ("market-outlook route recognized", TestMarketOutlookRoute().test_market_outlook_route_recognized),
+        ("market-outlook no fallback warning", TestMarketOutlookRoute().test_market_outlook_no_fallback_warning),
+        ("market-outlook auto-detect", TestMarketOutlookRoute().test_market_outlook_auto_detect),
+        ("market-outlook alias no fallback", TestMarketOutlookRoute().test_market_outlook_alias_no_fallback),
+        # TestMarketOutlookMonitoringActionability
+        ("market-outlook actionable monitoring passes",
+         TestMarketOutlookMonitoringActionability().test_actionable_monitoring_passes),
+        ("market-outlook non-actionable monitoring blocking",
+         TestMarketOutlookMonitoringActionability().test_non_actionable_monitoring_blocking),
+        ("market-outlook no monitoring section blocking",
+         TestMarketOutlookMonitoringActionability().test_no_monitoring_section_blocking),
+        ("market-outlook monitoring error message",
+         TestMarketOutlookMonitoringActionability().test_non_actionable_error_mentions_monitoring),
         # TestSharedWorkflow
         ("shared-workflow valid passes", TestSharedWorkflow().test_exit_code_zero_when_valid),
         ("shared-workflow fallback warning", TestSharedWorkflow().test_fallback_warning_in_stderr),
         # TestValidatorCount
         ("all 5 validators run on failing report", TestValidatorCount().test_all_validators_executed_on_failing_report),
+        ("market-outlook all 5 validators run", TestValidatorCount().test_market_outlook_validators_all_run),
         # TestProperties
         ("property: exit 0 iff overall pass", TestProperties().test_exit_code_zero_iff_overall_pass),
         ("property: exit 2 iff blocking", TestProperties().test_exit_code_two_iff_blocking),

--- a/scripts/test_audit_report.py
+++ b/scripts/test_audit_report.py
@@ -610,6 +610,125 @@ Each dimension conclusion is backed by [S01] and [S02].
 """
 
 
+# ── Shared base for market-outlook monitoring test fixtures ────────────
+
+_MO_BODY_PREFIX = """\
+# Power Market Outlook 2026
+
+## Route and audit status
+
+**Primary route**: Market Outlook / Industry Evolution
+
+| Audit | Status | 证据 |
+|-------|--------|------|
+| source-traceability | ✅ Passed | §3 正文使用 [S01] 与 [S02] 引用 |
+| quantitative-role-labeling | ✅ Passed | §5 Comparison 表格含数字角色列 |
+| final-audit | ✅ Passed | §2-§6 各核心关卡可追溯 |
+
+## 执行摘要
+
+Power constraints are tightening across global data center markets [S01].
+
+## 市场现状
+
+Current snapshot shows 5.2 GW under construction [S02].
+
+## Dimension conclusions
+
+Each dimension conclusion is backed by [S01] and [S02].
+
+## Comparison Table
+
+| Metric | 2025 | 2026E | 数字角色 |
+|--------|------|-------|---------|
+| DC Power | 50GW | 65GW | observed |
+| Growth | 20% | 30% | estimate |
+
+"""
+
+_MO_SOURCE_REGISTER = """
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Example A | secondary | 2026-01-01 | https://example.com/a | medium | §3 |
+| S02 | Example B | secondary | 2026-02-01 | https://example.com/b | high | §5 |
+"""
+
+
+def _market_outlook_with_monitoring(monitoring_body: str) -> str:
+    """Build a valid market-outlook report with a given monitoring section body."""
+    return _MO_BODY_PREFIX + monitoring_body + _MO_SOURCE_REGISTER
+
+
+def _market_outlook_with_empty_cell() -> str:
+    """Report where one monitoring signal has an empty Cadence cell.
+
+    Tests the cell-index alignment fix: the empty cell must NOT shift
+    subsequent column indices, so the signal is correctly detected as
+    not fully-defined.
+    """
+    table = """\
+## Monitoring Signals
+
+| Signal | Threshold | Cadence | Source | Trigger-to-action | 数字角色 |
+|--------|-----------|---------|--------|-------------------|---------|
+| GPU utilization | >85% for 3 months | Monthly | Cloud provider API | Notify capacity team | observed |
+| Power cost | >$0.12/kWh | | EIA report | Reassess location strategy | observed |
+| Grid interconnection | >6 months delay | Per project | Utility queue data | Explore colocation option | observed |
+"""
+    return _market_outlook_with_monitoring(table)
+
+
+def _market_outlook_uppercase_columns() -> str:
+    """Report with UPPERCASE monitoring table column headers.
+
+    Validates case-insensitive keyword matching in _map_table_header.
+    """
+    table = """\
+## Monitoring Signals
+
+| SIGNAL | THRESHOLD | CADENCE | SOURCE | TRIGGER-TO-ACTION | 数字角色 |
+|--------|-----------|---------|--------|-------------------|---------|
+| GPU utilization | >85% 3mo | Monthly | Cloud API | Notify team | observed |
+| Power cost | >$0.12/kWh | Quarterly | EIA report | Reassess | observed |
+| Grid delay | >6 months | Per proj | Utility queue | Explore colo | observed |
+"""
+    return _market_outlook_with_monitoring(table)
+
+
+def _market_outlook_two_signals() -> str:
+    """Report with only 2 fully-defined monitoring signals (<3 threshold)."""
+    table = """\
+## Monitoring Signals
+
+| Signal | Threshold | Cadence | Source | Trigger-to-action | 数字角色 |
+|--------|-----------|---------|--------|-------------------|---------|
+| GPU utilization | >85% 3mo | Monthly | Cloud API | Notify team | observed |
+| Power cost | >$0.12/kWh | Quarterly | EIA report | Reassess | observed |
+"""
+    return _market_outlook_with_monitoring(table)
+
+
+def _market_outlook_strict_with_partial() -> str:
+    """Report with 3 fully-defined + 1 partially-defined monitoring signal.
+
+    Without --strict: passes (exit 0).  With --strict: passes with warnings.
+    """
+    table = """\
+## Monitoring Signals
+
+| Signal | Threshold | Cadence | Source | Trigger-to-action | 数字角色 |
+|--------|-----------|---------|--------|-------------------|---------|
+| GPU utilization | >85% 3mo | Monthly | Cloud API | Notify team | observed |
+| Power cost | >$0.12/kWh | Quarterly | EIA report | Reassess | observed |
+| Grid delay | >6 months | Per proj | Utility queue | Explore colo | observed |
+| New entrant | announced | | Vendor press | | observed |
+"""
+    return _market_outlook_with_monitoring(table)
+
+
 def _report_shared_workflow() -> str:
     """Report using shared-workflow path (no primary route).
 
@@ -1264,6 +1383,73 @@ class TestMarketOutlookMonitoringActionability:
             f"Expected monitoring-related error, got:\n{result.stdout}"
         )
 
+    def test_empty_cell_does_not_shift_indices(self) -> None:
+        """Row with an empty cell must NOT be counted as fully-defined.
+
+        Regression test for the `if c.strip()` cell-parsing bug found in
+        cross-review: filtering empty cells shifts column indices and
+        causes false positives.
+        """
+        result = _run_audit(
+            _market_outlook_with_empty_cell(),
+            extra_args=["--route", "market-outlook"],
+        )
+        assert result.returncode == 2, (
+            f"Expected exit 2 for row with empty cell, got {result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        # Should report only 2 fully-defined signals (GPU + Grid, not Power cost)
+        assert "2" in result.stdout, (
+            f"Expected '2' fully-defined signals in output, got:\n{result.stdout}"
+        )
+
+    def test_uppercase_column_headers(self) -> None:
+        """UPPERCASE column headers must be matched case-insensitively."""
+        result = _run_audit(
+            _market_outlook_uppercase_columns(),
+            extra_args=["--route", "market-outlook"],
+        )
+        assert result.returncode == 0, (
+            f"Expected exit 0 for uppercase columns, got {result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+    def test_two_signals_blocking(self) -> None:
+        """Only 2 fully-defined signals (<3 threshold) must block."""
+        result = _run_audit(
+            _market_outlook_two_signals(),
+            extra_args=["--route", "market-outlook"],
+        )
+        assert result.returncode == 2, (
+            f"Expected exit 2 for 2 signals only, got {result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+    def test_strict_mode_warns_on_partial(self) -> None:
+        """--strict mode adds warnings for partially-defined signals.
+
+        Exit code 1 (=warnings) because partial-signal warnings exist;
+        not exit 0 (no warnings) and not exit 2 (blocking errors).
+        """
+        result = _run_audit(
+            _market_outlook_strict_with_partial(),
+            extra_args=["--route", "market-outlook", "--strict"],
+        )
+        # Warnings exist → exit 1 (not blocking, not fully pass)
+        assert result.returncode == 1, (
+            f"Expected exit 1 (warnings) for partial signals, "
+            f"got {result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        # Overall verdict should be conditional-pass
+        assert "conditional-pass" in result.stdout, (
+            f"Expected 'conditional-pass' for partial signals, got:\n{result.stdout}"
+        )
+        # Should generate warnings about the partial signal
+        assert "⚠" in result.stdout or "warning" in result.stdout.lower(), (
+            f"Expected strict mode warnings, got:\n{result.stdout}"
+        )
+
 
 class TestSharedWorkflow:
     """Shared-workflow reports should fall back to default validators."""
@@ -1446,6 +1632,14 @@ if __name__ == "__main__":
          TestMarketOutlookMonitoringActionability().test_no_monitoring_section_blocking),
         ("market-outlook monitoring error message",
          TestMarketOutlookMonitoringActionability().test_non_actionable_error_mentions_monitoring),
+        ("market-outlook empty cell no false positive",
+         TestMarketOutlookMonitoringActionability().test_empty_cell_does_not_shift_indices),
+        ("market-outlook uppercase columns match",
+         TestMarketOutlookMonitoringActionability().test_uppercase_column_headers),
+        ("market-outlook 2 signals blocking",
+         TestMarketOutlookMonitoringActionability().test_two_signals_blocking),
+        ("market-outlook strict mode warns partial",
+         TestMarketOutlookMonitoringActionability().test_strict_mode_warns_on_partial),
         # TestSharedWorkflow
         ("shared-workflow valid passes", TestSharedWorkflow().test_exit_code_zero_when_valid),
         ("shared-workflow fallback warning", TestSharedWorkflow().test_fallback_warning_in_stderr),


### PR DESCRIPTION
## 问题

`--route market-outlook` 当前因 `ROUTE_VALIDATORS` 未注册而静默回退到 `technical-deep-dive` 的 validator 链，导致 market-outlook 独有的硬失败门禁（register inflation、monitoring actionability、forward-looking label 等）无法被自动捕获。

见 #316 完整分析。

## 变更

### `scripts/audit_report.py`

1. **`_ROUTE_ALIASES` 新增 3 个别名：**
   - `market outlook` → `market-outlook`
   - `market outlook / industry evolution` → `market-outlook`
   - `industry evolution` → `market-outlook`

2. **`ROUTE_VALIDATORS` 新增 `market-outlook` 键**，validator 链含 5 个：
   - `_run_report_quality`（共享 — 覆盖 register inflation、route block、self-assessment consistency 等）
   - `_run_declared_execution`（共享 — 覆盖自评声明与执行一致性）
   - `_run_table_role_labels`（共享 — 覆盖数字角色标签）
   - `_run_source_label_consistency`（共享 — 覆盖来源标签一致性）
   - `_run_market_outlook_monitoring_actionability`（新增 — 监测信号行动化门禁）

3. **新增 `_run_market_outlook_monitoring_actionability`**：
   - 按 heading 分割报告，找到 monitoring 相关章节
   - 解析 Markdown 表格表头，匹配 threshold / cadence / source / trigger-to-action 四列
   - 统计所有四字段均非空的数据行数
   - <3 条完全定义的信号 → blocking error

### `scripts/test_audit_report.py`

- 新增 3 个 fixture：有效 / 不可执行 / 无 monitoring 章节
- 新增 `TestMarketOutlookRoute`（route 注册、alias、auto-detect、fallback 阻断）
- 新增 `TestMarketOutlookMonitoringActionability`（pass / blocking / 错误信息）
- `TestValidatorCount` 增加 market-outlook 5 个 validator 覆盖验证
- 测试注册表增加 8 个新测试条目

## 验收标准

- [x] `--route market-outlook` 输出 `Route: market-outlook`，无 fallback warning
- [x] 有效报告（3+ 可执行 monitoring signals）exit 0
- [x] 不可执行的 monitoring 报告 exit 2（阻断信息明确）
- [x] 缺失 monitoring 章节的报告 exit 2
- [x] 所有别名均正确解析且不触发 fallback
- [x] 全部 49 个测试通过（原 41 + 新增 8）
- [x] 回归验证：`test_report_quality_validator.py` (45/45)、`test_market_outlook_monitoring_contract.py` (3/3)

## 未包含在本次 PR（见 issue）

- Forward-looking label validator（现有 `check_audit_self_assessment_consistency` 已覆盖大部分）
- Secondary route evidence / phantom section validator（可后续 issue）
- 全局 fallback 行为变更（已最小化：只阻断 market-outlook fallback）

Closes #316