### PR TITLE
P0: 强化来源类型归一与标签校准 — 区分 multilateral/government、vendor、Wikipedia 与传闻 (#317)

### DIFF
--- a/references/source-traceability-and-claim-citation.md
+++ b/references/source-traceability-and-claim-citation.md
@@ -256,13 +256,15 @@ Classify every source in the register by type. Use these types consistently:
 - `PRIMARY_FILING` — official regulatory filing (招股书, 年报, 季报, 交易所公告)
 - `PRIMARY_COMPANY` — official company website, press release, official social media, product documentation
 - `PRIMARY_PARTNER` — official statement from a named partner or customer
+- `PRIMARY_INSTITUTION` — official multilateral, government agency, regulator, or public institution source (not company self-report; no vendor caveat required)
 - `PRIMARY_DEV` — official developer material: GitHub repository, issue, PR, release, API docs, changelog, commit log
 - `SECONDARY_MEDIA` — news article, industry report, analyst commentary
 - `SECONDARY_ANALYST` — analyst report, investment bank research
 - `SECONDARY_FEED` — RSS feed, newsletter, curated content stream
 - `TRANSCRIPT` — verbatim or near-verbatim transcript of an interview, press conference, earnings call, podcast, tutorial, or presentation
 - `INFERRED` — model inference with explicit reasoning chain documented
-- `UNCONFIRMED` — claim found in one or more sources but not independently verified
+- `CROWDSOURCED` — Wikipedia, crowdsourced compilation, tertiary sources (must not carry confirmed labels)
+- `UNCONFIRMED` — claim found in one or more sources but not independently verified; also covers rumor, leak, unconfirmed attribution (must not carry confirmed labels)
 - `WEAK_SIGNAL` — anecdotal, social media, unnamed sources, community forum speculation
 
 **`DISCOVERY` is not a valid Source Register source type.** Search-level discovery results (Exa search summaries, Agent-Reach `POST /search` output) are candidate sources only. They must be recorded in the source intake log (see `references/external-channel-preflight.md`) and may only enter the Source Register after content fetch and reclassification into one of the types above. Body citations of the form `[Sxx]` must never reference raw discovery output.
@@ -287,6 +289,10 @@ Classify every source in the register by type. Use these types consistently:
 | 微信公众号 / 公众号 | WEAK_SIGNAL | [推断]/[未知] | 只作补充 |
 | 多来源综合 / 技术分析 | INFERRED | [推断] | 必须有推理链 |
 | 专家访谈 / 访谈 / 财报电话会 | TRANSCRIPT | [确认事实] or [推断] | verbatim → confirmed; summary → inferred |
+| Primary (multilateral) / Primary (US govt agency) / government agency / regulator / public agency | PRIMARY_INSTITUTION | [确认事实] | 机构/政府来源，非厂商自述，不需 caveat |
+| Primary (vendor) | PRIMARY_COMPANY | [确认事实] + caveat | 厂商自述需 caveat，同其他公司来源处理 |
+| Secondary (crowdsourced) / crowdsourced / Wikipedia / wiki | CROWDSOURCED | [推断]/[未知] | 不可承载 [确认事实] |
+| rumor / leak / 传闻 / unconfirmed | UNCONFIRMED | [未知]/[推断] | 不可承载 [确认事实] |
 
 **使用说明：**
 - 此映射是示例性而非穷举性。新增常见写法应添加到 `scripts/validate_source_label_consistency.py` 的 `_FREETEXT_TYPE_MAP` 中。

--- a/scripts/test_source_label_consistency.py
+++ b/scripts/test_source_label_consistency.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 import tempfile
 
+from hypothesis import given, strategies as st
+
 SCRIPT = str(
     Path(__file__).resolve().parent / "validate_source_label_consistency.py"
 )
@@ -227,6 +229,224 @@ def test_secondary_source_in_english_sentence_passes() -> None:
     )
 
 
+# ---------------------------------------------------------------------------
+# Issue #317: 机构来源不应触发 vendor caveat；弱源不得承载 [确认事实]
+# ---------------------------------------------------------------------------
+
+
+def test_multilateral_source_without_caveat_passes() -> None:
+    """Primary (multilateral) 来源即使无 caveat 也应通过（非厂商自述）。"""
+    expect_pass(
+        "multilateral source without caveat",
+        "## Source Register\n\n"
+        "| ID | Source Name | Source Type | Date | DOI/URL | Reliability | "
+        "Claims Supported |\n"
+        "|----|-------------|-------------|------|---------|-------------|-"
+        "-----------------|\n"
+        "| S01 | IEA Report | Primary (multilateral) | 2026-01 | https://iea.org "
+        "| High | §3 |\n\n"
+        "[CONF] According to S01, data center energy will reach 500 TWh.\n",
+    )
+
+
+def test_government_agency_source_without_caveat_passes() -> None:
+    """Primary (US govt agency) 来源不应触发 vendor caveat 检查。"""
+    expect_pass(
+        "government agency source without caveat",
+        "## Source Register\n\n"
+        "| ID | Source Name | Source Type | Date | DOI/URL | Reliability | "
+        "Claims Supported |\n"
+        "|----|-------------|-------------|------|---------|-------------|-"
+        "-----------------|\n"
+        "| S01 | DOE Report | Primary (US govt agency) | 2026-02 | https://energy.gov "
+        "| High | §2 |\n\n"
+        "[CONF] According to S01, electricity demand is rising.\n",
+    )
+
+
+def test_crowdsourced_source_with_confirmed_label_fails() -> None:
+    """Secondary (crowdsourced) 使用 [CONF] 应报错。"""
+    expect_fail(
+        "crowdsourced source with confirmed label",
+        "## Source Register\n\n"
+        "| ID | Source Name | Source Type | Date | DOI/URL | Reliability | "
+        "Claims Supported |\n"
+        "|----|-------------|-------------|------|---------|-------------|-"
+        "-----------------|\n"
+        "| S01 | Wiki Compilation | Secondary (crowdsourced) | 2026-01 | "
+        "https://wiki.example.com | Low | §2 |\n\n"
+        "[CONF] According to S01, the specification is confirmed.\n",
+    )
+
+
+def test_wikipedia_source_with_confirmed_label_fails() -> None:
+    """Wikipedia 来源使用 [确认事实] 应报错。"""
+    expect_fail(
+        "Wikipedia source with confirmed label",
+        "## Source Register\n\n"
+        "| ID | Source Name | Source Type | Date | DOI/URL | Reliability | "
+        "Claims Supported |\n"
+        "|----|-------------|-------------|------|---------|-------------|-"
+        "-----------------|\n"
+        "| S01 | Wikipedia Article | Wikipedia | 2026-01 | https://en.wikipedia.org "
+        "| Low | §3 |\n\n"
+        "[确认事实] S01 报告称市场规模达 500 亿美元。\n",
+    )
+
+
+def test_rumor_source_with_confirmed_label_fails() -> None:
+    """rumor 来源使用 [CONF] 应报错。"""
+    expect_fail(
+        "rumor source with confirmed label",
+        "## Source Register\n\n"
+        "| ID | Source Name | Source Type | Date | DOI/URL | Reliability | "
+        "Claims Supported |\n"
+        "|----|-------------|-------------|------|---------|-------------|-"
+        "-----------------|\n"
+        "| S01 | Leak Source | rumor | 2026-03 | https://leak.example.com "
+        "| Low | §4 |\n\n"
+        "[CONF] According to S01, the product will launch in Q3.\n",
+    )
+
+
+def test_crowdsourced_source_with_infer_label_passes() -> None:
+    """crowdsourced 来源使用 [推断] 应通过。"""
+    expect_pass(
+        "crowdsourced source with infer label",
+        "## Source Register\n\n"
+        "| ID | Source Name | Source Type | Date | DOI/URL | Reliability | "
+        "Claims Supported |\n"
+        "|----|-------------|-------------|------|---------|-------------|-"
+        "-----------------|\n"
+        "| S01 | Forum Post | crowdsourced | 2026-01 | "
+        "https://forum.example.com | Low | §5 |\n\n"
+        "[推断] S01 推测市场可能增长。\n",
+    )
+
+
+def test_primary_vendor_without_caveat_still_fails() -> None:
+    """Primary (vendor) 无 caveat 应继续报错（回归）。"""
+    expect_fail(
+        "primary vendor without caveat still fails",
+        "## Source Register\n\n"
+        "| ID | Source Name | Source Type | Date | DOI/URL | Reliability | "
+        "Claims Supported |\n"
+        "|----|-------------|-------------|------|---------|-------------|-"
+        "-----------------|\n"
+        "| S01 | NVIDIA Blog | Primary (vendor) | 2026-01 | https://nvidia.com "
+        "| Medium | Performance claim |\n\n"
+        "[CONF] According to S01, the chip is 25x faster.\n",
+    )
+
+
+def test_multilateral_source_with_confirmed_passes() -> None:
+    """PRIMARY_INSTITUTION 规范类型使用 [CONF] 应通过（回归）。"""
+    expect_pass(
+        "PRIMARY_INSTITUTION with confirmed label",
+        "## Source Register\n\n"
+        "| ID | Source Name | Source Type | Date | DOI/URL | Reliability | "
+        "Claims Supported |\n"
+        "|----|-------------|-------------|------|---------|-------------|-"
+        "-----------------|\n"
+        "| S01 | IEA Report | PRIMARY_INSTITUTION | 2026-01 | https://iea.org "
+        "| High | §3 |\n\n"
+        "[CONF] According to S01, data center energy will reach 500 TWh.\n",
+    )
+
+
+def test_crowdsourced_canonical_type_with_confirmed_fails() -> None:
+    """CROWDSOURCED 规范类型使用 [CONF] 应报错。"""
+    expect_fail(
+        "CROWDSOURCED canonical with confirmed label",
+        "## Source Register\n\n"
+        "| ID | Source Name | Source Type | Date | DOI/URL | Reliability | "
+        "Claims Supported |\n"
+        "|----|-------------|-------------|------|---------|-------------|-"
+        "-----------------|\n"
+        "| S01 | Wiki | CROWDSOURCED | 2026-01 | https://wiki.example.com "
+        "| Low | §2 |\n\n"
+        "[CONF] According to S01.\n",
+    )
+
+
+def test_unconfirmed_canonical_type_with_confirmed_fails() -> None:
+    """UNCONFIRMED 规范类型使用 [CONF] 应报错。"""
+    expect_fail(
+        "UNCONFIRMED canonical with confirmed label",
+        "## Source Register\n\n"
+        "| ID | Source Name | Source Type | Date | DOI/URL | Reliability | "
+        "Claims Supported |\n"
+        "|----|-------------|-------------|------|---------|-------------|-"
+        "-----------------|\n"
+        "| S01 | Rumor | UNCONFIRMED | 2026-01 | https://example.com "
+        "| Low | §2 |\n\n"
+        "[CONF] According to S01.\n",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Property-based test: _normalize_source_type idempotency and roundtrip
+# ---------------------------------------------------------------------------
+
+# All valid canonical types used in the system.
+_VALID_CANONICAL_TYPES: frozenset[str] = frozenset({
+    "PRIMARY_FILING", "PRIMARY_COMPANY", "PRIMARY_PARTNER",
+    "PRIMARY_INSTITUTION", "PRIMARY_DEV", "SECONDARY_MEDIA",
+    "SECONDARY_ANALYST", "SECONDARY_FEED", "SECONDARY",
+    "TRANSCRIPT", "INFERRED", "UNCONFIRMED", "WEAK_SIGNAL",
+    "CROWDSOURCED", "PRIMARY",
+})
+
+
+@given(st.sampled_from([
+    "Primary (multilateral)",
+    "Primary (multilateral report)",
+    "Primary (multilateral analysis)",
+    "Primary (US govt agency)",
+    "Primary (government agency)",
+    "government agency",
+    "regulator",
+    "public agency",
+    "Secondary (crowdsourced)",
+    "crowdsourced",
+    "Wikipedia",
+    "wiki",
+    "rumor",
+    "leak",
+    "传闻",
+    "unconfirmed",
+    "Primary (vendor)",  # 仍为 PRIMARY_COMPANY
+    "PRIMARY_INSTITUTION",
+    "CROWDSOURCED",
+    "PRIMARY_COMPANY",
+    "SECONDARY_MEDIA",
+]))
+def test_normalize_source_type_property(source_type: str) -> None:
+    """Property: normalized canonical type is idempotent and valid.
+
+    For all known free-text and canonical source types, _normalize_source_type
+    returns a stable value, running it twice is idempotent, and the output
+    is one of the valid canonical types.
+    """
+    from validate_source_label_consistency import _normalize_source_type
+
+    first = _normalize_source_type(source_type)
+    second = _normalize_source_type(first)
+
+    # Idempotent: second application should not change value
+    assert first == second, (
+        f"normalize_source_type not idempotent for {source_type!r}: "
+        f"{first!r} -> {second!r}"
+    )
+    # Result is not empty
+    assert first.strip(), f"normalize_source_type returned empty for {source_type!r}"
+    # Result is a valid canonical type
+    assert first.upper() in _VALID_CANONICAL_TYPES, (
+        f"normalize_source_type returned unexpected canonical type "
+        f"{first!r} for {source_type!r}"
+    )
+
+
 def main() -> int:
     tests = [
         test_secondary_source_with_confirmed_label_fails,
@@ -241,6 +461,18 @@ def main() -> int:
         test_primary_partner_with_caveat_passes,
         test_infer_label_on_secondary_passes,
         test_secondary_source_in_english_sentence_passes,
+        # Issue #317 tests
+        test_multilateral_source_without_caveat_passes,
+        test_government_agency_source_without_caveat_passes,
+        test_crowdsourced_source_with_confirmed_label_fails,
+        test_wikipedia_source_with_confirmed_label_fails,
+        test_rumor_source_with_confirmed_label_fails,
+        test_crowdsourced_source_with_infer_label_passes,
+        test_primary_vendor_without_caveat_still_fails,
+        test_multilateral_source_with_confirmed_passes,
+        test_crowdsourced_canonical_type_with_confirmed_fails,
+        test_unconfirmed_canonical_type_with_confirmed_fails,
+        test_normalize_source_type_property,
     ]
     failures = []
     for test in tests:

--- a/scripts/validate_source_label_consistency.py
+++ b/scripts/validate_source_label_consistency.py
@@ -48,6 +48,25 @@ _PRIMARY_COMPANY_TYPES: frozenset[str] = frozenset({
     "PRIMARY",  # simplified 5-class system
 })
 
+# Primary institution / agency / multilateral source types.
+# These are authoritative public sources (not company self-report),
+# so they do NOT need a vendor self-reporting caveat.
+_PRIMARY_INSTITUTION_TYPES: frozenset[str] = frozenset({
+    "PRIMARY_INSTITUTION",
+})
+
+# Crowdsourced / tertiary source types. These must NOT use confirmed labels.
+_CROWDSOURCED_TYPES: frozenset[str] = frozenset({
+    "CROWDSOURCED",
+})
+
+# Unconfirmed / rumor / leak source types. These must NOT use confirmed labels.
+# Note: UNCONFIRMED is already in _KNOWN_OTHER_TYPES; the dedicated frozenset
+# allows the elif chain to catch it before _is_unknown_type.
+_UNCONFIRMED_TYPES: frozenset[str] = frozenset({
+    "UNCONFIRMED",
+})
+
 # Free-text source type to canonical type mapping (Chinese + common English aliases).
 # Used by _normalize_source_type() to map free-text source types
 # (common in technical reports) to the canonical types that the validator checks.
@@ -101,6 +120,27 @@ _FREETEXT_TYPE_MAP: dict[str, str] = {
     # Inference
     "技术分析": "INFERRED",
     "多来源综合": "INFERRED",
+    # Multilateral / government / agency → PRIMARY_INSTITUTION
+    "primary (multilateral)": "PRIMARY_INSTITUTION",
+    "primary (multilateral report)": "PRIMARY_INSTITUTION",
+    "primary (multilateral analysis)": "PRIMARY_INSTITUTION",
+    "primary (us govt agency)": "PRIMARY_INSTITUTION",
+    "primary (government agency)": "PRIMARY_INSTITUTION",
+    "government agency": "PRIMARY_INSTITUTION",
+    "regulator": "PRIMARY_INSTITUTION",
+    "public agency": "PRIMARY_INSTITUTION",
+    # Vendor claim → PRIMARY_COMPANY (统一处理 caveat)
+    "primary (vendor)": "PRIMARY_COMPANY",
+    # Crowdsourced / tertiary → CROWDSOURCED
+    "secondary (crowdsourced)": "CROWDSOURCED",
+    "crowdsourced": "CROWDSOURCED",
+    "wikipedia": "CROWDSOURCED",
+    "wiki": "CROWDSOURCED",
+    # Rumor / leak → UNCONFIRMED
+    "rumor": "UNCONFIRMED",
+    "leak": "UNCONFIRMED",
+    "传闻": "UNCONFIRMED",
+    "unconfirmed": "UNCONFIRMED",
 }
 
 # Case-insensitive lookup map built from _FREETEXT_TYPE_MAP.
@@ -238,16 +278,34 @@ def _parse_register_table(table_lines: list[str]) -> list[tuple[str, str]]:
     return sources
 
 
+def _is_type_in(source_type: str, type_set: frozenset[str]) -> bool:
+    """Check if a normalized source type belongs to a given frozenset."""
+    return source_type.strip().upper() in type_set
+
+
 def _is_secondary_type(source_type: str) -> bool:
     """Check if a source type is secondary (granular or simplified)."""
-    upper = source_type.strip().upper()
-    return upper in _SECONDARY_TYPES
+    return _is_type_in(source_type, _SECONDARY_TYPES)
 
 
 def _is_primary_company_type(source_type: str) -> bool:
     """Check if a source type is a primary company (needs caveat)."""
-    upper = source_type.strip().upper()
-    return upper in _PRIMARY_COMPANY_TYPES
+    return _is_type_in(source_type, _PRIMARY_COMPANY_TYPES)
+
+
+def _is_institution_type(source_type: str) -> bool:
+    """Check if a source type is a primary institution/agency (no caveat)."""
+    return _is_type_in(source_type, _PRIMARY_INSTITUTION_TYPES)
+
+
+def _is_crowdsourced_type(source_type: str) -> bool:
+    """Check if a source type is crowdsourced/tertiary (no confirmed label)."""
+    return _is_type_in(source_type, _CROWDSOURCED_TYPES)
+
+
+def _is_unconfirmed_type(source_type: str) -> bool:
+    """Check if a source type is unconfirmed/rumor (no confirmed label)."""
+    return _is_type_in(source_type, _UNCONFIRMED_TYPES)
 
 
 def _source_ref_re(source_id: str) -> re.Pattern:
@@ -275,21 +333,36 @@ def _normalize_source_type(source_type: str) -> str:
 
     Steps:
     1. Strip leading/trailing whitespace
-    2. Strip parenthetical content: both CJK （arXiv） and half-width (arXiv)
-    3. Do case-insensitive lookup in _FREETEXT_TYPE_MAP
-    4. If found, return the canonical type; otherwise return the stripped string
+    2. Case-insensitive lookup in _FREETEXT_TYPE_MAP (complete string,
+       including parenthetical content)
+    3. If not found, strip parenthetical content: both CJK （arXiv） and
+       half-width (arXiv), then try lookup again
+    4. If still not found, return the stripped string for canonical type matching
+       (e.g. \"PRIMARY\" for the simplified 5-class system)
 
-    Always returns a parentheses-stripped value so canonical types like
-    \"PRIMARY_FILING (annual report)\" still match _is_secondary_type() etc.
+    The two-pass lookup ensures parenthetical variants like
+    \"Primary (multilateral)\" are matched before the parenthetical content
+    is stripped (which would leave just \"Primary\", conflating it with
+    the simplified 5-class PRIMARY).
     """
+    # Pass 1: whole-string lookup (preserves parenthetical context)
     s = source_type.strip()
-    # Strip parenthetical content (CJK and half-width parentheses)
-    s = re.sub(r'[（(][^）)]*[）)]', '', s).strip()
-    s = re.sub(r'\([^)]*\)', '', s).strip()
-    # Case-insensitive lookup in freetext map
     lower = s.lower()
     if lower in _FREETEXT_TYPE_MAP_CI:
         return _FREETEXT_TYPE_MAP_CI[lower]
+
+    # Pass 2: strip parenthetical content and retry.
+    # Loop to handle potential nested parentheses (e.g. "Primary (multilateral (report))").
+    # Each iteration strips one level; stops when no more parentheses remain.
+    while True:
+        stripped = re.sub(r'[（(][^）)]*[）)]|\([^)]*\)', '', s).strip()
+        if stripped == s:
+            break
+        s = stripped
+    lower = s.lower()
+    if lower in _FREETEXT_TYPE_MAP_CI:
+        return _FREETEXT_TYPE_MAP_CI[lower]
+
     return s  # Return sanitized string for canonical type matching
 
 
@@ -312,6 +385,7 @@ def _is_unknown_type(source_type: str) -> bool:
     _KNOWN_OTHER_TYPES: frozenset[str] = frozenset({
         "PRIMARY_FILING", "PRIMARY_DEV", "INFERRED",
         "UNCONFIRMED", "WEAK_SIGNAL", "TRANSCRIPT",
+        "PRIMARY_INSTITUTION", "CROWDSOURCED",
     })
     if _is_secondary_type(source_type):
         return False
@@ -325,9 +399,13 @@ def _is_unknown_type(source_type: str) -> bool:
 def check_source_consistency(text: str, strict: bool = False) -> list[str]:
     """Check label/source type consistency. Returns list of error messages.
 
-    Two checks:
+    Checks (applied in order):
     1. Secondary sources must not be referenced with confirmed labels.
-    2. Primary company sources must have a self-reporting caveat nearby.
+    2. Primary institution/agency sources pass through (no caveat needed).
+    3. Primary company sources must have a self-reporting caveat nearby.
+    4. Crowdsourced/tertiary sources must not be referenced with confirmed labels.
+    5. Unconfirmed/rumor/leak sources must not be referenced with confirmed labels.
+    6. Unknown source types generate a warning (or error in strict mode).
 
     When strict=True, unknown source types cause errors (not just warnings).
     """
@@ -370,8 +448,14 @@ def check_source_consistency(text: str, strict: bool = False) -> list[str]:
                         f"but referenced with confirmed label: {sent[:100]}"
                     )
 
+        elif _is_institution_type(norm_type):
+            # Check 2: Primary institution/agency source — pass through.
+            # These are authoritative public sources (multilateral, government,
+            # regulator, agency). No caveat needed; no confirmed-label restriction.
+            pass
+
         elif _is_primary_company_type(norm_type):
-            # Check 2: Primary company source needs self-reporting caveat.
+            # Check 3: Primary company source needs self-reporting caveat.
             for sent in sentences:
                 if not ref_re.search(sent):
                     continue
@@ -382,8 +466,30 @@ def check_source_consistency(text: str, strict: bool = False) -> list[str]:
                         f"{sent[:100]}"
                     )
 
+        elif _is_crowdsourced_type(norm_type):
+            # Check 4: Crowdsourced/tertiary source must not use confirmed label.
+            for sent in sentences:
+                if not ref_re.search(sent):
+                    continue
+                if CONFIRMED_LABEL_RE.search(sent):
+                    errors.append(
+                        f"source {source_id} ({source_type}) is crowdsourced "
+                        f"but referenced with confirmed label: {sent[:100]}"
+                    )
+
+        elif _is_unconfirmed_type(norm_type):
+            # Check 5: Unconfirmed/rumor/leak source must not use confirmed label.
+            for sent in sentences:
+                if not ref_re.search(sent):
+                    continue
+                if CONFIRMED_LABEL_RE.search(sent):
+                    errors.append(
+                        f"source {source_id} ({source_type}) is unconfirmed "
+                        f"but referenced with confirmed label: {sent[:100]}"
+                    )
+
         elif _is_unknown_type(norm_type):
-            # Check 3: Unknown source type detection.
+            # Check 6: Unknown source type detection.
             msg = (
                 f"source {source_id} has unrecognized source type "
                 f"'{source_type}': map to a canonical type or correct the entry"


### PR DESCRIPTION
## 解决了什么问题

Issue #317 报告了 source-label validator 的两个相反问题：

1. **误报**: `Primary (multilateral)`、`Primary (US govt agency)` 被当作 primary company source，要求厂商自述 caveat
2. **漏报**: `Secondary (crowdsourced)`、Wikipedia、rumor/leak 没有被限制承载 `[确认事实]`

## 改动概要

### 新规范类型

| 类型 | 说明 |
|------|------|
| `PRIMARY_INSTITUTION` | 政府/多边/监管机构来源，非厂商自述，不需 caveat |
| `CROWDSOURCED` | Wikipedia/crowdsourced/tertiary，不可承载 [确认事实] |

### 关键代码改动

- `_FREETEXT_TYPE_MAP` 扩展 ~15 条（multilateral/gov/vendor/Wikipedia/rumor/leak）
- `_normalize_source_type` 改为两遍查找：先查完整字符串（含括号），再循环剥离括号查精简版 → 防止 `Primary (multilateral)` 被剥离为 `Primary` 后误入 PRIMARY_COMPANY
- elif 链新增：institution pass-through → crowdsourced [CONF] 检查 → unconfirmed [CONF] 检查
- 提取公共函数 `_is_type_in` 消除 5 个 `_is_*_type` 函数的重复
- 更新 `_KNOWN_OTHER_TYPES` 防止新类型被标 unknown

### 验收标准覆盖

- [x] `Primary (multilateral)` / `Primary (US govt agency)` 不再触发 vendor caveat 误报
- [x] `Primary (vendor)` 缺 caveat 时继续报错
- [x] `Secondary (crowdsourced)` / Wikipedia 被 [确认事实] 使用时报错
- [x] rumor/leak/unconfirmed 被 [确认事实] 使用时报错
- [x] 新增 10 个 example-based 测试 + 1 个 property-based idempotency + 合法性测试（23 个测试全部通过）
- [x] 更新 reference 文档

### 交叉审核修复

双 Subagent 交叉审核后修复了以下问题：
- 嵌套括号处理：循环剥离直到无剩余括号（替代单次 regex）
- 移除死代码 regex 行
- 提取 `_is_type_in` 公共函数消除 5 函数 DRY 重复
- 增加 CROWDSOURCED / UNCONFIRMED 规范类型直接测试
- property test 增加合法性断言

### 未包含（拆为后续 issue）

- cross-validator 协作（source-label + forward-looking）：scope 更大，需独立设计