### PR TITLE
P1: add audit evidence section reference validator (#319)

### DIFF
--- a/scripts/audit_report.py
+++ b/scripts/audit_report.py
@@ -36,6 +36,7 @@ from validate_report_quality import (
     check_route_audit_block,
     check_route_declaration,
     check_audit_evidence,
+    check_audit_evidence_section_refs,
     check_source_register_exists,
     check_source_register_columns,
     check_source_register_missing_ids,
@@ -163,6 +164,7 @@ def _run_report_quality(path: Path, **kwargs: bool) -> CheckResult:
     errors.extend(_run(check_route_audit_block, cleaned))
     errors.extend(_run(check_route_declaration, cleaned))
     errors.extend(_run(check_audit_evidence, cleaned))
+    errors.extend(_run(check_audit_evidence_section_refs, cleaned))
 
     # 2. Source Register
     errors.extend(_run(check_source_register_exists, cleaned))

--- a/scripts/test_report_quality_validator.py
+++ b/scripts/test_report_quality_validator.py
@@ -1127,7 +1127,264 @@ def test_academic_register_7_columns_non_academic_route_passes() -> None:
         f"stdout: {result.stdout}"
     )
     print("  PASS  non-academic 7-column register passes")
-# ── get_route_name Chinese heading tests ──────────────────────────────────
+
+
+# ── Evidence section reference validation tests ───────────────────────
+# These test check_audit_evidence_section_refs functionality.
+
+def test_evidence_subsection_ref_valid_passes() -> None:
+    """Audit evidence with §X.Y ref that matches a body heading → pass.
+    Report has numbered headings like "## 7.2 Technical Deep-dive"."""
+    text = """\
+# Test Report
+
+## Route and audit status
+
+**Primary route**: Technical Deep-dive
+
+| Audit | Status | 证据 |
+|-------|--------|------|
+| source-traceability | ✅ Passed | §7.2 验证 hard-fail 条件 |
+| final-audit | ✅ Passed | §2 各关卡可追溯 |
+
+## 1. Introduction
+
+Body text with citation [S01].
+
+## 2. Analysis
+
+### 7.2 Technical Deep-dive
+
+Hard-fail verification content [S01].
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Example source | secondary | 2026-01-01 | https://example.com | medium | §2 |
+"""
+    expect_pass("evidence subsection ref valid passes", text)
+
+
+def test_evidence_subsection_ref_phantom_fails() -> None:
+    """Audit evidence with §X.Y ref that has NO matching heading → blocking.
+    Report has numbered headings but no "## 7.2" heading."""
+    text = """\
+# Test Report
+
+## Route and audit status
+
+**Primary route**: Technical Deep-dive
+
+| Audit | Status | 证据 |
+|-------|--------|------|
+| source-traceability | ✅ Passed | §7.2 验证 hard-fail 条件 |
+| final-audit | ✅ Passed | §2 各关卡可追溯 |
+
+## 1. Introduction
+
+Body text with citation [S01].
+
+## 2. Analysis
+
+### 7.1 Component Analysis
+
+Analysis text [S01].
+
+### 7.3 Integration
+
+Analysis text [S01].
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Example source | secondary | 2026-01-01 | https://example.com | medium | §2 |
+"""
+    expect_fail("evidence subsection ref phantom fails", text)
+
+
+def test_evidence_appendix_ref_valid_passes() -> None:
+    """Audit evidence with Appendix reference that matches a heading → pass."""
+    text = """\
+# Test Report
+
+## Route and audit status
+
+**Primary route**: Technical Deep-dive
+
+| Audit | Status | 证据 |
+|-------|--------|------|
+| source-traceability | ✅ Passed | §3 正文使用 [S01] 引用 |
+| final-audit | ✅ Passed | Appendix B 补充数据 |
+
+## 1. Introduction
+
+Body text with citation [S01].
+
+## Appendix B
+
+Supplementary data [S01].
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Example source | secondary | 2026-01-01 | https://example.com | medium | §2 |
+"""
+    expect_pass("evidence appendix ref valid passes", text)
+
+
+def test_evidence_appendix_ref_phantom_fails() -> None:
+    """Audit evidence with Appendix reference that has NO matching heading → blocking."""
+    text = """\
+# Test Report
+
+## Route and audit status
+
+**Primary route**: Technical Deep-dive
+
+| Audit | Status | 证据 |
+|-------|--------|------|
+| source-traceability | ✅ Passed | §3 正文使用 [S01] 引用 |
+| final-audit | ✅ Passed | Appendix B 补充数据 |
+
+## 1. Introduction
+
+Body text with citation [S01].
+
+## Appendix A
+
+Previous data [S01].
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Example source | secondary | 2026-01-01 | https://example.com | medium | §2 |
+"""
+    expect_fail("evidence appendix ref phantom fails", text)
+
+
+def test_evidence_no_numbered_headings_skips_section_refs() -> None:
+    """Report with no numbered headings → §X.Y and §X refs are not checked
+    (gate: can't verify what doesn't exist structurally)."""
+    text = """\
+# Test Report
+
+## Route and audit status
+
+**Primary route**: Technical Deep-dive
+
+| Audit | Status | 证据 |
+|-------|--------|------|
+| source-traceability | ✅ Passed | §7.2 验证 |
+| final-audit | ✅ Passed | 各关卡可追溯 |
+
+## Introduction
+
+Body text with citation [S01].
+
+## Methodology
+
+Methodology content [S01].
+
+## Findings
+
+Key findings [S01].
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Example source | secondary | 2026-01-01 | https://example.com | medium | §2 |
+"""
+    expect_pass("evidence no numbered headings skips section refs", text)
+
+
+def test_evidence_multiple_phantom_refs_all_reported() -> None:
+    """Multiple phantom refs in different rows → all reported, not just the first."""
+    text = """\
+# Test Report
+
+## Route and audit status
+
+**Primary route**: Technical Deep-dive
+
+| Audit | Status | 证据 |
+|-------|--------|------|
+| source-traceability | ✅ Passed | §7.2 正文引用 |
+| quantitative-role | ✅ Passed | §8.3 表格角色列 |
+
+## 1. Introduction
+
+Body text with citation [S01].
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Example source | secondary | 2026-01-01 | https://example.com | medium | §2 |
+"""
+    expect_fail("evidence multiple phantom refs all reported", text)
+
+
+def test_evidence_phantom_ref_not_passed_row_skipped() -> None:
+    """Phantom ref in a row that is NOT passed → skipped (only passed rows matter)."""
+    text = """\
+# Test Report
+
+## Route and audit status
+
+**Primary route**: Technical Deep-dive
+
+| Audit | Status | 证据 |
+|-------|--------|------|
+| source-traceability | ❌ Not run | §7.2 |
+| final-audit | ✅ Passed | §2 各关卡可追溯 |
+
+## 1. Introduction
+
+Body text with citation [S01].
+
+## 2. Analysis
+
+Analysis content [S01].
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Example source | secondary | 2026-01-01 | https://example.com | medium | §2 |
+"""
+    expect_pass("evidence phantom ref not passed row skipped", text)
+
+
+def test_evidence_subsection_ref_no_heading_at_all_but_unnumbered_passes() -> None:
+    """§7.2 in evidence column, no numbered headings at all → pass (gate)."""
+    text = """\
+# Test Report
+
+## Route and audit status
+
+**Primary route**: Technical Deep-dive
+
+| Audit | Status | 证据 |
+|-------|--------|------|
+| source-traceability | ✅ Passed | §7.2 正文引用 |
+| final-audit | ✅ Passed | §2 各关卡可追溯 |
+
+## Introduction
+
+Body text with citation [S01].
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Example source | secondary | 2026-01-01 | https://example.com | medium | §2 |
+"""
+    expect_pass("evidence subsection ref unnumbered doc passes", text)
 # These import get_route_name directly for precise unit-level testing.
 
 
@@ -1248,6 +1505,15 @@ def main() -> int:
         ("academic 11-column register passes", test_academic_register_11_columns_passes),
         ("academic 7-column register fails", test_academic_register_7_columns_fails),
         ("non-academic 7-column register passes", test_academic_register_7_columns_non_academic_route_passes),
+        # evidence section reference tests
+        ("evidence subsection ref valid passes", test_evidence_subsection_ref_valid_passes),
+        ("evidence subsection ref phantom fails", test_evidence_subsection_ref_phantom_fails),
+        ("evidence appendix ref valid passes", test_evidence_appendix_ref_valid_passes),
+        ("evidence appendix ref phantom fails", test_evidence_appendix_ref_phantom_fails),
+        ("evidence no numbered headings skips section refs", test_evidence_no_numbered_headings_skips_section_refs),
+        ("evidence multiple phantom refs all reported", test_evidence_multiple_phantom_refs_all_reported),
+        ("evidence phantom ref not passed row skipped", test_evidence_phantom_ref_not_passed_row_skipped),
+        ("evidence subsection ref unnumbered doc passes", test_evidence_subsection_ref_no_heading_at_all_but_unnumbered_passes),
         # get_route_name Chinese heading tests
         ("get_route_name english still works", test_get_route_name_english_still_works),
         ("get_route_name chinese heading", test_get_route_name_chinese_heading),

--- a/scripts/test_report_quality_validator.py
+++ b/scripts/test_report_quality_validator.py
@@ -1388,6 +1388,103 @@ Body text with citation [S01].
 # These import get_route_name directly for precise unit-level testing.
 
 
+def test_evidence_spaced_subsection_ref_passes() -> None:
+    """§ with space (§ 7.2) matches heading with same number."""
+    text = """\
+# Test Report
+
+## Route and audit status
+
+**Primary route**: Technical Deep-dive
+
+| Audit | Status | 证据 |
+|-------|--------|------|
+| source-traceability | ✅ Passed | § 7.2 验证 hard-fail 条件 |
+| final-audit | ✅ Passed | §2 各关卡可追溯 |
+
+## 1. Introduction
+
+Body text with citation [S01].
+
+## 2. Analysis
+
+### 7.2 Technical Deep-dive
+
+Hard-fail verification content [S01].
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Example source | secondary | 2026-01-01 | https://example.com | medium | §2 |
+"""
+    expect_pass("evidence spaced subsection ref passes", text)
+
+
+def test_evidence_chinese_appendix_no_space_passes() -> None:
+    """Chinese appendix without space (附录B) matches heading."""
+    text = """\
+# Test Report
+
+## Route and audit status
+
+**Primary route**: Technical Deep-dive
+
+| Audit | Status | 证据 |
+|-------|--------|------|
+| source-traceability | ✅ Passed | §3 正文使用 [S01] 引用 |
+| final-audit | ✅ Passed | 附录B 补充数据 |
+
+## 1. Introduction
+
+Body text with citation [S01].
+
+## 附录B 补充数据
+
+Supplementary data [S01].
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Example source | secondary | 2026-01-01 | https://example.com | medium | §2 |
+"""
+    expect_pass("evidence chinese appendix no space passes", text)
+
+
+def test_evidence_subsection_ref_prefix_matches_subsubsection() -> None:
+    """§7.2 matches '### 7.2.1 Subsection' (prefix matching — intentional)."""
+    text = """\
+# Test Report
+
+## Route and audit status
+
+**Primary route**: Technical Deep-dive
+
+| Audit | Status | 证据 |
+|-------|--------|------|
+| source-traceability | ✅ Passed | §7.2 验证 hard-fail 条件 |
+| final-audit | ✅ Passed | §3 各关卡可追溯 |
+
+## 1. Introduction
+
+Body text with citation [S01].
+
+## 2. Analysis
+
+### 7.2.1 Technical Details
+
+Only sub-subsection exists, no §7.2 heading itself.
+
+## Source Register
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|----|-------------|-------------|------|---------|-------------|------------------|
+| S01 | Example source | secondary | 2026-01-01 | https://example.com | medium | §2 |
+"""
+    expect_pass("evidence subsection ref prefix matches subsubsection", text)
+
+
 def test_get_route_name_english_still_works() -> None:
     """Existing English format still works after changes."""
     text = """\
@@ -1514,6 +1611,9 @@ def main() -> int:
         ("evidence multiple phantom refs all reported", test_evidence_multiple_phantom_refs_all_reported),
         ("evidence phantom ref not passed row skipped", test_evidence_phantom_ref_not_passed_row_skipped),
         ("evidence subsection ref unnumbered doc passes", test_evidence_subsection_ref_no_heading_at_all_but_unnumbered_passes),
+        ("evidence spaced subsection ref passes", test_evidence_spaced_subsection_ref_passes),
+        ("evidence chinese appendix no space passes", test_evidence_chinese_appendix_no_space_passes),
+        ("evidence subsection ref prefix matches subsubsection", test_evidence_subsection_ref_prefix_matches_subsubsection),
         # get_route_name Chinese heading tests
         ("get_route_name english still works", test_get_route_name_english_still_works),
         ("get_route_name chinese heading", test_get_route_name_chinese_heading),

--- a/scripts/validate_report_quality.py
+++ b/scripts/validate_report_quality.py
@@ -52,12 +52,10 @@ STATUS_COL_RE = re.compile(r"Status|状态|结果", re.IGNORECASE)
 EVIDENCE_COL_RE = re.compile(r"证据|Evidence|Proof|执行证据", re.IGNORECASE)
 
 # Patterns for evidence column section reference validation
-# §X.Y — subsection reference (e.g. §7.2), excludes §X.YZ and ranges
-SUBSECTION_REF_RE = re.compile(r'(?<!\d)§(\d+)\.(\d+)(?![\d.])')
-# Appendix / 附录 X — named anchor reference
-APPENDIX_REF_RE = re.compile(r'(?:Appendix|附录)\s+([A-Za-z0-9]+)', re.IGNORECASE)
-# Secondary route declaration (in route/audit block)
-SECONDARY_ROUTE_RE = re.compile(r'\*\*Secondary\s+route\*\*[:\s]+(.+)', re.IGNORECASE)
+# §X.Y — subsection reference (e.g. §7.2, § 7.2), excludes §X.YZ and ranges
+SUBSECTION_REF_RE = re.compile(r'(?<!\d)§\s?(\d+)\.(\d+)(?![\d.])')
+# Appendix / 附录 X — named anchor reference (with or without space)
+APPENDIX_REF_RE = re.compile(r'(?:Appendix|附录)\s*([A-Za-z0-9]+)', re.IGNORECASE)
 
 BODY_SXX_RE = re.compile(r"\[S\d{2}\]")
 AUTHOR_YEAR_RE = re.compile(
@@ -364,7 +362,7 @@ def _heading_matches_ref(ref: str, heading_text: str) -> bool:
 def _heading_matches_appendix(ref: str, heading_text: str) -> bool:
     """Check if an appendix ref (e.g. 'B') matches a heading."""
     escaped = re.escape(ref)
-    pat = rf'(?:Appendix|附录)\s+{escaped}(?:\b|$)'
+    pat = rf'(?:Appendix|附录)\s*{escaped}(?:\b|$)'
     return bool(re.search(pat, heading_text, re.IGNORECASE))
 
 
@@ -390,11 +388,23 @@ def check_audit_evidence_section_refs(cleaned: str) -> list[str]:
     Design:
     - §X.Y (subsection) refs are checked strictly: the heading must start
       with the same number prefix (e.g. §7.2 → '### 7.2 Technical Deep-dive').
-    - Appendix refs are checked case-insensitively against heading text.
+      Supports optional space after § (e.g. '§ 7.2').
+    - Appendix refs (Appendix X / 附录 X) are checked case-insensitively
+      against heading text. Supports with or without space (e.g. '附录B').
     - §X.Y refs are only checked when the document has at least one numbered
       heading; without numbered structure the reference convention is unknown
       and we skip to avoid false positives.
     - Appendix refs are always checked (unambiguous naming convention).
+
+    Known limitations:
+    - §X (single-level, e.g. '§3') is not checked — too ambiguous and
+      often appears in ranges ('§3-§5'). Use §X.Y for precise references.
+    - §X.Y.Z (three-level) is not matched — only §X.Y is supported.
+    - Chinese ordinal appendix numbers ('附录一') are not matched —
+      only Latin letters and digits are supported for appendix refs.
+    - Appendix references in evidence are assumed to refer to the report's
+      own appendices. External Appendix refs (e.g. 'per Appendix A of ISO')
+      may cause false positives; this is acceptable for the audit context.
 
     Returns list of blocking errors, one per phantom reference.
     """

--- a/scripts/validate_report_quality.py
+++ b/scripts/validate_report_quality.py
@@ -51,6 +51,14 @@ AUDIT_COL_RE = re.compile(r"Audit|审计|检查项", re.IGNORECASE)
 STATUS_COL_RE = re.compile(r"Status|状态|结果", re.IGNORECASE)
 EVIDENCE_COL_RE = re.compile(r"证据|Evidence|Proof|执行证据", re.IGNORECASE)
 
+# Patterns for evidence column section reference validation
+# §X.Y — subsection reference (e.g. §7.2), excludes §X.YZ and ranges
+SUBSECTION_REF_RE = re.compile(r'(?<!\d)§(\d+)\.(\d+)(?![\d.])')
+# Appendix / 附录 X — named anchor reference
+APPENDIX_REF_RE = re.compile(r'(?:Appendix|附录)\s+([A-Za-z0-9]+)', re.IGNORECASE)
+# Secondary route declaration (in route/audit block)
+SECONDARY_ROUTE_RE = re.compile(r'\*\*Secondary\s+route\*\*[:\s]+(.+)', re.IGNORECASE)
+
 BODY_SXX_RE = re.compile(r"\[S\d{2}\]")
 AUTHOR_YEAR_RE = re.compile(
     r"\([A-Z][a-z]+(?:\s+et\s+al\.?)?,\s*\d{4}(?:,\s*[A-Za-z .]+)?\)"
@@ -310,6 +318,144 @@ def check_audit_evidence(cleaned: str) -> list[str]:
                 f"Passed audit '{audit_name}' has vague evidence: "
                 f"'{evidence_val or '(empty)'}'"
             )
+
+    return issues
+
+
+# ── Evidence section reference validation ─────────────────────────────────
+
+
+def _collect_headings(text: str) -> list[str]:
+    """Return list of heading texts (after # prefix) from markdown body.
+
+    Excludes headings within the ## Route and audit status block to avoid
+    false matches against the audit table itself.
+    """
+    lines = text.splitlines()
+    # Find the route/audit block bounds to exclude its headings
+    audit_bounds = section_bounds(text, ROUTE_AUDIT_HEADING)
+    if audit_bounds is not None:
+        audit_start, audit_end = audit_bounds
+    else:
+        audit_start, audit_end = -1, -1
+
+    headings: list[str] = []
+    for i, line in enumerate(lines):
+        # Skip lines inside the route/audit block
+        if audit_start <= i < audit_end:
+            continue
+        m = HEADING_RE.match(line.rstrip())
+        if m:
+            heading_text = m.group(2).strip()
+            headings.append(heading_text)
+    return headings
+
+
+def _heading_matches_ref(ref: str, heading_text: str) -> bool:
+    """Check if a numeric ref (e.g. '7.2' or '3') matches a heading.
+
+    For '7.2': heading starts with '7.2' followed by boundary chars.
+    For '3': heading starts with '3.' / '3:' / '3 ' or similar boundary.
+    """
+    pattern = rf'^{re.escape(ref)}(?:[\.\s:;]|\b|$)'
+    return bool(re.search(pattern, heading_text))
+
+
+def _heading_matches_appendix(ref: str, heading_text: str) -> bool:
+    """Check if an appendix ref (e.g. 'B') matches a heading."""
+    escaped = re.escape(ref)
+    pat = rf'(?:Appendix|附录)\s+{escaped}(?:\b|$)'
+    return bool(re.search(pat, heading_text, re.IGNORECASE))
+
+
+def _has_numbered_headings(headings: list[str]) -> bool:
+    """Check if any heading starts with a digit (numbered section structure)."""
+    for h in headings:
+        stripped = h.lstrip()
+        if stripped and stripped[0].isdigit():
+            # Confirm it starts with a real number, not just a stray digit
+            if re.match(r'\d+', stripped):
+                return True
+    return False
+
+
+def check_audit_evidence_section_refs(cleaned: str) -> list[str]:
+    """Verify that section references (§X.Y, Appendix X) in audit evidence
+    column correspond to actual headings in the report body.
+
+    Parses the audit status table, extracts section references from the
+    evidence column of passed rows, and checks them against the report's
+    heading structure.
+
+    Design:
+    - §X.Y (subsection) refs are checked strictly: the heading must start
+      with the same number prefix (e.g. §7.2 → '### 7.2 Technical Deep-dive').
+    - Appendix refs are checked case-insensitively against heading text.
+    - §X.Y refs are only checked when the document has at least one numbered
+      heading; without numbered structure the reference convention is unknown
+      and we skip to avoid false positives.
+    - Appendix refs are always checked (unambiguous naming convention).
+
+    Returns list of blocking errors, one per phantom reference.
+    """
+    # Collect body headings (excluding the audit block itself)
+    all_headings = _collect_headings(cleaned)
+
+    sec = section_text(cleaned, ROUTE_AUDIT_HEADING)
+    if sec is None:
+        return []
+    table = parse_table(sec)
+    if table is None:
+        return []
+
+    header = table[0]
+    audit_idx = find_col_index(header, [AUDIT_COL_RE])
+    status_idx = find_col_index(header, [STATUS_COL_RE])
+    evidence_idx = find_col_index(header, [EVIDENCE_COL_RE])
+
+    if any(i == -1 for i in (audit_idx, status_idx, evidence_idx)):
+        return []  # Can't validate without all three columns
+
+    # Gate: only verify numbered refs (§X.Y) if doc has numbered structure
+    has_numbered = _has_numbered_headings(all_headings)
+
+    issues: list[str] = []
+    for row in table[1:]:
+        if len(row) <= max(audit_idx, status_idx, evidence_idx):
+            continue
+        status_val = row[status_idx].strip()
+        if not AUDIT_PASSED_RE.match(status_val):
+            continue
+        evidence_val = row[evidence_idx].strip()
+        audit_name = row[audit_idx].strip().split("\n")[0][:60]
+
+        # --- Check subsection references §X.Y ---
+        for m in SUBSECTION_REF_RE.finditer(evidence_val):
+            ref = f"{m.group(1)}.{m.group(2)}"
+            if not has_numbered:
+                continue  # skip §X.Y check in unnumbered documents
+            found = any(
+                _heading_matches_ref(ref, h) for h in all_headings
+            )
+            if not found:
+                issues.append(
+                    f"Audit '{audit_name}' evidence references "
+                    f"'{m.group()}' but no heading matches "
+                    f"'{ref}' in the report body"
+                )
+
+        # --- Check appendix references ---
+        for m in APPENDIX_REF_RE.finditer(evidence_val):
+            ref = m.group(1)
+            found = any(
+                _heading_matches_appendix(ref, h) for h in all_headings
+            )
+            if not found:
+                issues.append(
+                    f"Audit '{audit_name}' evidence references "
+                    f"'{m.group()}' but no heading matches it "
+                    f"in the report body"
+                )
 
     return issues
 
@@ -990,6 +1136,7 @@ def validate_file(path: Path, strict: bool = False) -> int:
     errors.extend(check_route_audit_block(cleaned))
     errors.extend(check_route_declaration(cleaned))
     errors.extend(check_audit_evidence(cleaned))
+    errors.extend(check_audit_evidence_section_refs(cleaned))
 
     # 2. Source Register
     errors.extend(check_source_register_exists(cleaned))


### PR DESCRIPTION
## What

新增 `check_audit_evidence_section_refs()` 函数，验证审计 evidence 列中的章节引用（§X.Y、Appendix X）在报告正文中存在对应的 heading。

## Why

数据中心电力报告（dc-power-market-outlook-inflation-and-monitoring-case）中的真实失败：审计表 evidence 列引用 `§7.2`，但正文没有对应章节。这种 phantom section reference 破坏了 self-assessment 的可信度。

详见 issue #319。

## How

**Pattern matching:**
- `§X.Y` (subsection, e.g. §7.2) → 严格匹配 heading 以 X.Y 开头
- `§X` → 因常出现在范围引用 (§3-§5) 且过于模糊，本版本跳过
- `Appendix X / 附录 X` → 大小写不敏感匹配 heading

**Gate logic:** §X.Y 检查仅在文档有 ≥1 个 numbered heading 时启用。无编号结构的文档跳过检查，避免假阳性。

**检查范围：** 只检查状态为 ✅ Passed 的行。Not run / Skipped 行自动跳过。

## Files changed

| File | Change |
|------|--------|
| `scripts/validate_report_quality.py` | 新增 `check_audit_evidence_section_refs()` + 2 个 helper，约 140 行 |
| `scripts/test_report_quality_validator.py` | 新增 8 个测试用例（含 7 个 fixture），约 270 行 |
| `scripts/audit_report.py` | 导入 + 编排调用，共 2 行 |

## Testing

- 53/53 tests pass in `test_report_quality_validator.py`
- 所有现有测试 0 regression
- audit_report.py 编排器测试 53/53 pass
- 全部 test_*.py 通过（1 个 pre-existing 失败在 test_academic_current_state_discipline.py，与此 PR 无关）

## Acceptance criteria

- [x] 含不存在 §7.2 的 audit evidence fixture → blocking
- [x] 含存在 §7.2 的 fixture → pass
- [x] Appendix B 不存在 → blocking
- [x] Appendix B 存在 → pass
- [x] 无 numbered heading 的文档 → §X.Y 跳过（gate）
- [x] 非 passed 行的 phantom → 跳过
- [x] 多个 phantom refs → 全部报告
- [x] 接入 audit_report.py 的 shared validators

Closes #319