### PR TITLE
P0: add PR-issue acceptance validation gate (#326)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,6 +32,17 @@ What should the skill do better after this change?
 - Updated eval:
 - No eval change because:
 
+## Issue acceptance mapping
+
+If this PR closes or partially addresses an issue, list how each acceptance
+criterion maps to actual changed files or test commands.
+
+| Acceptance item (from issue) | Implementation file/section | Verification command |
+|---|---|---|
+| e.g. "Add input boundary table" | `references/report-template.md` | `python3 scripts/test_*.py` |
+
+Omit if PR is a trivial fix (typo, formatting) with no linked issue.
+
 ## Risks / possible regressions
 
 What might this change worsen or accidentally break?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       - run: python3 scripts/test_control_plane_architecture_discipline.py
       - run: python3 scripts/test_quantitative_role_audit.py
       - run: python3 scripts/test_audit_report.py
+      - run: python3 scripts/test_issue_pr_acceptance.py
 
   smoke:
     runs-on: ubuntu-latest

--- a/scripts/test_issue_pr_acceptance.py
+++ b/scripts/test_issue_pr_acceptance.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+"""
+Property-based contract tests for validate_issue_pr_acceptance.
+
+Invariants tested:
+  C1 (NO_OP_MERGE): identical merge/parent SHA → NO_OP_MERGE error
+  C2 (MISSING_FILE): issue checklist path not in PR files → MISSING_FILE error
+  C3 (PASS): no checklist paths + valid merge → empty findings
+  C4 (NO_CRASH): empty/malformed input → no crash, graceful handling
+  C5 (PATH_EXTRACTION): only checklist `- [ ] ` paths extracted, not body prose
+
+Usage:
+    python3 scripts/test_issue_pr_acceptance.py
+
+Expected: ALL PASS
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import os
+from pathlib import Path
+
+# ── Ensure the sibling module is importable ────────────────────────────────
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+# ── Import the validation module ───────────────────────────────────────────
+# We import after path fix; if module doesn't exist yet, the test
+# framework itself will fail (RED phase).
+try:
+    from validate_issue_pr_acceptance import (
+        core_validate,
+        extract_issue_paths,
+        ValidationFinding,
+    )
+except ImportError:
+    # In RED phase before implementation exists, define stubs so tests
+    # can at least be syntactically verified to fail for the right reason.
+    from dataclasses import dataclass
+    @dataclass
+    class ValidationFinding:
+        severity: str
+        code: str
+        message: str
+        detail: str
+
+    def core_validate(issue_body="", pr_files=None, pr_merge_sha=None, pr_parent_sha=None):
+        raise NotImplementedError("RED phase — implement me")
+
+    def extract_issue_paths(body: str) -> list[str]:
+        raise NotImplementedError("RED phase — implement me")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# C1: NO-OP MERGE DETECTION
+# ═══════════════════════════════════════════════════════════════════════════
+
+def test_c1_detects_no_op_merge():
+    """C1: Identical merge/parent SHA MUST produce NO_OP_MERGE error."""
+    findings = core_validate(
+        issue_body="## Acceptance\n- [x] done",
+        pr_files=["file1.py"],
+        pr_merge_sha="abc123",
+        pr_parent_sha="abc123",
+    )
+    codes = [f.code for f in findings]
+    assert "NO_OP_MERGE" in codes, (
+        f"Expected NO_OP_MERGE in findings, got {codes}"
+    )
+
+
+def test_c1_skips_when_different():
+    """C1: Different merge/parent SHA MUST NOT produce NO_OP_MERGE."""
+    findings = core_validate(
+        issue_body="## Acceptance\n- [x] done",
+        pr_files=["file1.py"],
+        pr_merge_sha="abc123",
+        pr_parent_sha="def456",
+    )
+    codes = [f.code for f in findings]
+    assert "NO_OP_MERGE" not in codes, (
+        f"Unexpected NO_OP_MERGE with different SHAs: {codes}"
+    )
+
+
+def test_c1_skips_when_none():
+    """C1: None SHA MUST NOT produce NO_OP_MERGE (PR not merged yet)."""
+    findings = core_validate(
+        issue_body="## Acceptance\n- [x] done",
+        pr_files=["file1.py"],
+        pr_merge_sha=None,
+        pr_parent_sha=None,
+    )
+    codes = [f.code for f in findings]
+    assert "NO_OP_MERGE" not in codes, (
+        f"Unexpected NO_OP_MERGE with None SHAs: {codes}"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# C2: MISSING FILE DETECTION
+# ═══════════════════════════════════════════════════════════════════════════
+
+SAMPLE_ISSUE_WITH_PATHS = """\
+## Background
+Some context.
+
+## Acceptance Criteria
+- [ ] `tests/test_issue_320_contracts.py` — verify contracts
+- [ ] `references/report-template.md` — update template
+- [ ] `checklists/market-outlook-audit.md` — add sections
+
+## Notes
+Additional details.
+"""
+
+
+def test_c2_detects_missing_file():
+    """C2: Issue path not in PR files MUST produce MISSING_FILE."""
+    findings = core_validate(
+        issue_body=SAMPLE_ISSUE_WITH_PATHS,
+        pr_files=["scripts/validate_report_quality.py"],
+        pr_merge_sha="abc123",
+        pr_parent_sha="def456",
+    )
+    missing = [f for f in findings if f.code == "MISSING_FILE"]
+    assert len(missing) >= 1, (
+        f"Expected at least one MISSING_FILE, got codes: {[f.code for f in findings]}"
+    )
+    # At least one of the three paths should be flagged
+    flagged_paths = set(m.detail for m in missing)
+    expected = {"tests/test_issue_320_contracts.py",
+                "references/report-template.md",
+                "checklists/market-outlook-audit.md"}
+    assert flagged_paths & expected, (
+        f"Expected any of {expected} flagged, got {flagged_paths}"
+    )
+
+
+def test_c2_all_files_present():
+    """C2: All issue paths in PR files MUST NOT produce MISSING_FILE."""
+    findings = core_validate(
+        issue_body=SAMPLE_ISSUE_WITH_PATHS,
+        pr_files=[
+            "tests/test_issue_320_contracts.py",
+            "references/report-template.md",
+            "checklists/market-outlook-audit.md",
+            "scripts/something_else.py",
+        ],
+        pr_merge_sha="abc123",
+        pr_parent_sha="def456",
+    )
+    missing = [f for f in findings if f.code == "MISSING_FILE"]
+    assert len(missing) == 0, (
+        f"Expected no MISSING_FILE, got: {[(m.detail, m.message) for m in missing]}"
+    )
+
+
+def test_c2_empty_pr_files():
+    """C2: Empty PR file list SHOULD still detect missing paths."""
+    findings = core_validate(
+        issue_body=SAMPLE_ISSUE_WITH_PATHS,
+        pr_files=[],
+        pr_merge_sha="abc123",
+        pr_parent_sha="def456",
+    )
+    missing = [f for f in findings if f.code == "MISSING_FILE"]
+    assert len(missing) >= 1, "Expected MISSING_FILE when PR files is empty"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# C3: PASS — no checklist paths + valid merge
+# ═══════════════════════════════════════════════════════════════════════════
+
+ISSUE_NO_PATHS = """\
+## Enhancement
+Add a new validator.
+
+## Acceptance Criteria
+- [ ] Implement the feature
+- [ ] All tests pass
+"""
+
+
+def test_c3_pass_no_checklist_paths():
+    """C3: No checklist paths + valid merge → empty findings."""
+    findings = core_validate(
+        issue_body=ISSUE_NO_PATHS,
+        pr_files=["scripts/new_validator.py"],
+        pr_merge_sha="abc123",
+        pr_parent_sha="def456",
+    )
+    assert len(findings) == 0, (
+        f"Expected empty findings, got: {[(f.code, f.detail) for f in findings]}"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# C4: NO CRASH — graceful handling of edge inputs
+# ═══════════════════════════════════════════════════════════════════════════
+
+def test_c4_empty_issue_body():
+    """C4: Empty issue body MUST NOT crash."""
+    try:
+        findings = core_validate(
+            issue_body="",
+            pr_files=["file.py"],
+            pr_merge_sha="abc",
+            pr_parent_sha="def",
+        )
+        assert isinstance(findings, list)
+    except Exception as e:
+        assert False, f"Empty issue body crashed: {e}"
+
+
+def test_c4_none_issue_body():
+    """C4: None issue body MUST NOT crash."""
+    try:
+        findings = core_validate(
+            issue_body=None,  # type: ignore[arg-type]
+            pr_files=["file.py"],
+            pr_merge_sha="abc",
+            pr_parent_sha="def",
+        )
+        assert isinstance(findings, list)
+    except Exception as e:
+        assert False, f"None issue body crashed: {e}"
+
+
+def test_c4_none_pr_files():
+    """C4: None pr_files MUST NOT crash."""
+    try:
+        findings = core_validate(
+            issue_body="## Acceptance\n- [x] done",
+            pr_files=None,  # type: ignore[arg-type]
+            pr_merge_sha="abc",
+            pr_parent_sha="def",
+        )
+        assert isinstance(findings, list)
+    except Exception as e:
+        assert False, f"None pr_files crashed: {e}"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# C5: PATH EXTRACTION — only checklist paths, not prose
+# ═══════════════════════════════════════════════════════════════════════════
+
+ISSUE_WITH_PROSE_PATHS = """\
+## Background
+
+The file `scripts/validate_report_quality.py` needs updating.
+Also see `references/report-template.md` for context.
+
+## Acceptance Criteria
+- [ ] `tests/test_issue_320_contracts.py` — new contract tests
+- [ ] Implement the feature
+"""
+
+
+def test_c5_only_checklist_paths_extracted():
+    """C5: Line-start paths extracted; prose paths ignored."""
+    extracted = extract_issue_paths(ISSUE_WITH_PROSE_PATHS)
+    # The checklist path should be extracted
+    assert "tests/test_issue_320_contracts.py" in extracted, (
+        "Checklist path not extracted"
+    )
+    # Prose paths (embedded in sentences, not at line start) should NOT be extracted
+    assert "scripts/validate_report_quality.py" not in extracted, (
+        "Prose path should NOT be extracted"
+    )
+    assert "references/report-template.md" not in extracted, (
+        "Prose path should NOT be extracted"
+    )
+
+
+def test_c5_no_checklist_returns_empty():
+    """C5: No checklist/bullet items → empty list."""
+    extracted = extract_issue_paths("# Just a heading\nNo paths here.")
+    assert extracted == [], f"Expected empty list, got {extracted}"
+
+
+def test_c5_bullet_paths_extracted():
+    """C5: Bullet list paths ARE extracted."""
+    body = """\
+## Scope
+- `references/report-template.md`
+- `references/decision-report-template.md`
+"""
+    extracted = extract_issue_paths(body)
+    assert "references/report-template.md" in extracted, (
+        "Bullet path not extracted"
+    )
+    assert "references/decision-report-template.md" in extracted, (
+        "Bullet path not extracted"
+    )
+
+
+def test_c5_checklist_variants():
+    """C5: Support `- [ ]`, `- [x]`, `* [ ]` checklist prefixes."""
+    body = """\
+- [ ] `file1.py` — unchecked
+- [x] `file2.py` — checked
+* [ ] `file3.py` — asterisk variant
+"""
+    extracted = extract_issue_paths(body)
+    assert "file1.py" in extracted, "Missing unchecked item"
+    assert "file2.py" in extracted, "Missing checked (x) item"
+    assert "file3.py" in extracted, "Missing asterisk variant"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# C6: DIRECTORY PREFIX MATCHING
+# ═══════════════════════════════════════════════════════════════════════════
+
+def test_c6_directory_prefix_matches():
+    """C6: Directory `dir/` matches file `dir/foo.py` in PR files."""
+    findings = core_validate(
+        issue_body="- `mydir/` — all files in this dir",
+        pr_files=["mydir/foo.py", "mydir/bar.py"],
+        pr_merge_sha="abc",
+        pr_parent_sha="def",
+    )
+    missing = [f for f in findings if f.code == "MISSING_FILE"]
+    assert len(missing) == 0, (
+        f"Directory prefix should match subfiles, got: "
+        f"{[(m.detail, m.message) for m in missing]}"
+    )
+
+
+def test_c6_directory_prefix_no_match():
+    """C6: Directory `dir/` with no matching PR file produces MISSING_FILE."""
+    findings = core_validate(
+        issue_body="- `mydir/` — all files in this dir",
+        pr_files=["other/foo.py"],
+        pr_merge_sha="abc",
+        pr_parent_sha="def",
+    )
+    missing = [f for f in findings if f.code == "MISSING_FILE"]
+    assert len(missing) >= 1, (
+        "Directory prefix should produce MISSING_FILE when no file matches"
+    )
+    assert "mydir/" in {m.detail for m in missing}, (
+        "Missing file detail should reference the directory path"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# REGRESSION FIXTURE: #320 / #324
+# ═══════════════════════════════════════════════════════════════════════════
+
+ISSUE_320_BODY_EXCERPT = """\
+## 实现范围
+
+建议更新：
+
+- `references/report-template.md`
+- `references/decision-report-template.md`
+- `references/market-outlook-and-scenario-discipline.md`
+- `checklists/market-outlook-audit.md`
+- `evals/comparative-distillation/` 下增加或更新两组 GPT 对照的 distilled learning artifact
+- `evals/templates/decision-utility-rubric.md`
+
+## 验收标准
+
+- [ ] 模板中出现 `Input boundary / 未指定项` 小节建议，且说明未指定项如何转 assumptions / uncertainty。
+- [ ] market-outlook 产业链题默认建议 `Value-chain sensitivity map`。
+- [ ] global scope 题默认建议 `Regional coverage matrix`，并要求 source role / data role。
+- [ ] stakeholder implications 从"影响描述"升级为"decision/action/metric/trigger"结构。
+- [ ] 文档明确说明：GPT 对照可学习结构，不继承 bibliography-only sourcing 或不可复查 citation。
+- [ ] 至少新增一个 eval 或 comparative-distillation artifact，覆盖两组对照中的可迁移结构能力和不可迁移证据问题。
+"""
+
+
+PR_324_FILES = [
+    "scripts/audit_report.py",
+    "scripts/test_report_quality_validator.py",
+    "scripts/validate_report_quality.py",
+]
+
+
+def test_regression_320_324_detects_no_op():
+    """Regression: #324 was a no-op merge. Must detect NO_OP_MERGE."""
+    findings = core_validate(
+        issue_body=ISSUE_320_BODY_EXCERPT,
+        pr_files=PR_324_FILES,
+        pr_merge_sha="e8bfc976fbc40dfcab5833c824d95a0951a59716",
+        pr_parent_sha="e8bfc976fbc40dfcab5833c824d95a0951a59716",
+    )
+    codes = [f.code for f in findings]
+    assert "NO_OP_MERGE" in codes, (
+        f"Regression: #324 no-op merge not detected. Codes: {codes}"
+    )
+
+
+def test_regression_320_324_detects_missing_templates():
+    """Regression: #324 claimed template changes but didn't touch them."""
+    findings = core_validate(
+        issue_body=ISSUE_320_BODY_EXCERPT,
+        pr_files=PR_324_FILES,
+        pr_merge_sha="e8bfc",
+        pr_parent_sha="82b6ec",
+    )
+    missing = [f for f in findings if f.code == "MISSING_FILE"]
+    missing_details = {m.detail for m in missing}
+
+    # At minimum, the specific template files from acceptance criteria
+    # should be flagged as missing from PR diff
+    expected = {
+        "references/report-template.md",
+        "references/decision-report-template.md",
+    }
+    assert expected & missing_details, (
+        f"Expected template files flagged as missing. "
+        f"Flagged: {missing_details}"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# MAIN
+# ═══════════════════════════════════════════════════════════════════════════
+
+if __name__ == "__main__":
+    import inspect
+
+    # Collect all test functions
+    tests = [
+        obj for name, obj in globals().items()
+        if name.startswith("test_") and inspect.isfunction(obj)
+    ]
+    tests.sort(key=lambda f: f.__name__)
+
+    passed = 0
+    failed = 0
+
+    for test_fn in tests:
+        try:
+            test_fn()
+            print(f"  ✅ {test_fn.__name__}")
+            passed += 1
+        except AssertionError as e:
+            print(f"  ❌ {test_fn.__name__}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"  💥 {test_fn.__name__}: {e}")
+            failed += 1
+
+    print(f"\n{'=' * 50}")
+    print(f"  Total: {passed + failed}  |  Passed: {passed}  |  Failed: {failed}")
+    if failed:
+        sys.exit(1)

--- a/scripts/test_issue_pr_acceptance.py
+++ b/scripts/test_issue_pr_acceptance.py
@@ -47,7 +47,7 @@ except ImportError:
         message: str
         detail: str
 
-    def core_validate(issue_body="", pr_files=None, pr_merge_sha=None, pr_parent_sha=None):
+    def core_validate(issue_body="", pr_files=None, pr_merge_tree_sha=None, pr_parent_tree_sha=None):
         raise NotImplementedError("RED phase — implement me")
 
     def extract_issue_paths(body: str) -> list[str]:
@@ -63,8 +63,8 @@ def test_c1_detects_no_op_merge():
     findings = core_validate(
         issue_body="## Acceptance\n- [x] done",
         pr_files=["file1.py"],
-        pr_merge_sha="abc123",
-        pr_parent_sha="abc123",
+        pr_merge_tree_sha="abc123",
+        pr_parent_tree_sha="abc123",
     )
     codes = [f.code for f in findings]
     assert "NO_OP_MERGE" in codes, (
@@ -77,8 +77,8 @@ def test_c1_skips_when_different():
     findings = core_validate(
         issue_body="## Acceptance\n- [x] done",
         pr_files=["file1.py"],
-        pr_merge_sha="abc123",
-        pr_parent_sha="def456",
+        pr_merge_tree_sha="abc123",
+        pr_parent_tree_sha="def456",
     )
     codes = [f.code for f in findings]
     assert "NO_OP_MERGE" not in codes, (
@@ -91,8 +91,8 @@ def test_c1_skips_when_none():
     findings = core_validate(
         issue_body="## Acceptance\n- [x] done",
         pr_files=["file1.py"],
-        pr_merge_sha=None,
-        pr_parent_sha=None,
+        pr_merge_tree_sha=None,
+        pr_parent_tree_sha=None,
     )
     codes = [f.code for f in findings]
     assert "NO_OP_MERGE" not in codes, (
@@ -119,24 +119,21 @@ Additional details.
 
 
 def test_c2_detects_missing_file():
-    """C2: Issue path not in PR files MUST produce MISSING_FILE."""
+    """C2: Issue path not in PR files MUST produce MISSING_FILE for ALL."""
     findings = core_validate(
         issue_body=SAMPLE_ISSUE_WITH_PATHS,
         pr_files=["scripts/validate_report_quality.py"],
-        pr_merge_sha="abc123",
-        pr_parent_sha="def456",
+        pr_merge_tree_sha="abc123",
+        pr_parent_tree_sha="def456",
     )
     missing = [f for f in findings if f.code == "MISSING_FILE"]
-    assert len(missing) >= 1, (
-        f"Expected at least one MISSING_FILE, got codes: {[f.code for f in findings]}"
-    )
-    # At least one of the three paths should be flagged
     flagged_paths = set(m.detail for m in missing)
     expected = {"tests/test_issue_320_contracts.py",
                 "references/report-template.md",
                 "checklists/market-outlook-audit.md"}
-    assert flagged_paths & expected, (
-        f"Expected any of {expected} flagged, got {flagged_paths}"
+    # All three issue checklist paths must be flagged as missing
+    assert expected.issubset(flagged_paths), (
+        f"Expected ALL of {expected} flagged, got {flagged_paths}"
     )
 
 
@@ -150,8 +147,8 @@ def test_c2_all_files_present():
             "checklists/market-outlook-audit.md",
             "scripts/something_else.py",
         ],
-        pr_merge_sha="abc123",
-        pr_parent_sha="def456",
+        pr_merge_tree_sha="abc123",
+        pr_parent_tree_sha="def456",
     )
     missing = [f for f in findings if f.code == "MISSING_FILE"]
     assert len(missing) == 0, (
@@ -160,15 +157,21 @@ def test_c2_all_files_present():
 
 
 def test_c2_empty_pr_files():
-    """C2: Empty PR file list SHOULD still detect missing paths."""
+    """C2: Empty PR file list SHOULD flag ALL checklist paths."""
     findings = core_validate(
         issue_body=SAMPLE_ISSUE_WITH_PATHS,
         pr_files=[],
-        pr_merge_sha="abc123",
-        pr_parent_sha="def456",
+        pr_merge_tree_sha="abc123",
+        pr_parent_tree_sha="def456",
     )
     missing = [f for f in findings if f.code == "MISSING_FILE"]
-    assert len(missing) >= 1, "Expected MISSING_FILE when PR files is empty"
+    flagged_paths = set(m.detail for m in missing)
+    expected = {"tests/test_issue_320_contracts.py",
+                "references/report-template.md",
+                "checklists/market-outlook-audit.md"}
+    assert expected.issubset(flagged_paths), (
+        f"Expected ALL of {expected} flagged when PR files empty, got {flagged_paths}"
+    )
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -190,8 +193,8 @@ def test_c3_pass_no_checklist_paths():
     findings = core_validate(
         issue_body=ISSUE_NO_PATHS,
         pr_files=["scripts/new_validator.py"],
-        pr_merge_sha="abc123",
-        pr_parent_sha="def456",
+        pr_merge_tree_sha="abc123",
+        pr_parent_tree_sha="def456",
     )
     assert len(findings) == 0, (
         f"Expected empty findings, got: {[(f.code, f.detail) for f in findings]}"
@@ -208,8 +211,8 @@ def test_c4_empty_issue_body():
         findings = core_validate(
             issue_body="",
             pr_files=["file.py"],
-            pr_merge_sha="abc",
-            pr_parent_sha="def",
+            pr_merge_tree_sha="abc",
+            pr_parent_tree_sha="def",
         )
         assert isinstance(findings, list)
     except Exception as e:
@@ -222,8 +225,8 @@ def test_c4_none_issue_body():
         findings = core_validate(
             issue_body=None,  # type: ignore[arg-type]
             pr_files=["file.py"],
-            pr_merge_sha="abc",
-            pr_parent_sha="def",
+            pr_merge_tree_sha="abc",
+            pr_parent_tree_sha="def",
         )
         assert isinstance(findings, list)
     except Exception as e:
@@ -236,8 +239,8 @@ def test_c4_none_pr_files():
         findings = core_validate(
             issue_body="## Acceptance\n- [x] done",
             pr_files=None,  # type: ignore[arg-type]
-            pr_merge_sha="abc",
-            pr_parent_sha="def",
+            pr_merge_tree_sha="abc",
+            pr_parent_tree_sha="def",
         )
         assert isinstance(findings, list)
     except Exception as e:
@@ -320,8 +323,8 @@ def test_c6_directory_prefix_matches():
     findings = core_validate(
         issue_body="- `mydir/` — all files in this dir",
         pr_files=["mydir/foo.py", "mydir/bar.py"],
-        pr_merge_sha="abc",
-        pr_parent_sha="def",
+        pr_merge_tree_sha="abc",
+        pr_parent_tree_sha="def",
     )
     missing = [f for f in findings if f.code == "MISSING_FILE"]
     assert len(missing) == 0, (
@@ -335,8 +338,8 @@ def test_c6_directory_prefix_no_match():
     findings = core_validate(
         issue_body="- `mydir/` — all files in this dir",
         pr_files=["other/foo.py"],
-        pr_merge_sha="abc",
-        pr_parent_sha="def",
+        pr_merge_tree_sha="abc",
+        pr_parent_tree_sha="def",
     )
     missing = [f for f in findings if f.code == "MISSING_FILE"]
     assert len(missing) >= 1, (
@@ -382,16 +385,19 @@ PR_324_FILES = [
 
 
 def test_regression_320_324_detects_no_op():
-    """Regression: #324 was a no-op merge. Must detect NO_OP_MERGE."""
+    """Regression: #324 was a no-op merge. Must detect NO_OP_MERGE + MISSING_FILE."""
     findings = core_validate(
         issue_body=ISSUE_320_BODY_EXCERPT,
         pr_files=PR_324_FILES,
-        pr_merge_sha="e8bfc976fbc40dfcab5833c824d95a0951a59716",
-        pr_parent_sha="e8bfc976fbc40dfcab5833c824d95a0951a59716",
+        pr_merge_tree_sha="e8bfc976fbc40dfcab5833c824d95a0951a59716",
+        pr_parent_tree_sha="e8bfc976fbc40dfcab5833c824d95a0951a59716",
     )
     codes = [f.code for f in findings]
     assert "NO_OP_MERGE" in codes, (
         f"Regression: #324 no-op merge not detected. Codes: {codes}"
+    )
+    assert "MISSING_FILE" in codes, (
+        f"Regression: #324 missing templates not detected. Codes: {codes}"
     )
 
 
@@ -400,22 +406,95 @@ def test_regression_320_324_detects_missing_templates():
     findings = core_validate(
         issue_body=ISSUE_320_BODY_EXCERPT,
         pr_files=PR_324_FILES,
-        pr_merge_sha="e8bfc",
-        pr_parent_sha="82b6ec",
+        pr_merge_tree_sha="e8bfc",
+        pr_parent_tree_sha="82b6ec",
     )
     missing = [f for f in findings if f.code == "MISSING_FILE"]
     missing_details = {m.detail for m in missing}
 
-    # At minimum, the specific template files from acceptance criteria
-    # should be flagged as missing from PR diff
+    # All specific template files from acceptance criteria must be flagged
     expected = {
         "references/report-template.md",
         "references/decision-report-template.md",
+        "references/market-outlook-and-scenario-discipline.md",
+        "checklists/market-outlook-audit.md",
+        "evals/templates/decision-utility-rubric.md",
     }
-    assert expected & missing_details, (
-        f"Expected template files flagged as missing. "
+    assert expected.issubset(missing_details), (
+        f"Expected ALL template files flagged as missing. "
+        f"Missing: {expected - missing_details}. "
         f"Flagged: {missing_details}"
     )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# C7: COMBINED AND EDGE-CASE SCENARIOS
+# ═══════════════════════════════════════════════════════════════════════════
+
+def test_c7_combined_noop_and_missing():
+    """C7: Both NO_OP_MERGE and MISSING_FILE can fire simultaneously."""
+    findings = core_validate(
+        issue_body="- [ ] `missing.py`",
+        pr_files=["present.py"],
+        pr_merge_tree_sha="same_sha",
+        pr_parent_tree_sha="same_sha",
+    )
+    codes = [f.code for f in findings]
+    assert "NO_OP_MERGE" in codes, f"NO_OP_MERGE missing: {codes}"
+    assert "MISSING_FILE" in codes, f"MISSING_FILE missing: {codes}"
+
+
+def test_c7_directory_prefix_no_overmatch():
+    """C7: Directory prefix `mydir/` must NOT match `mydir-other/`."""
+    findings = core_validate(
+        issue_body="- `mydir/`",
+        pr_files=["mydir-other/foo.py"],
+        pr_merge_tree_sha="abc",
+        pr_parent_tree_sha="def",
+    )
+    missing = [f for f in findings if f.code == "MISSING_FILE"]
+    missing_paths = {m.detail for m in missing}
+    assert "mydir/" in missing_paths, (
+        f"Directory prefix must NOT match sibling dir. Got: {missing_paths}"
+    )
+
+
+def test_c7_deep_directory_prefix():
+    """C7: Deep directory `a/b/c/` matches `a/b/c/d/e.py`."""
+    findings = core_validate(
+        issue_body="- `a/b/c/`",
+        pr_files=["a/b/c/d/e.py", "a/b/c/f/g/h.py"],
+        pr_merge_tree_sha="abc",
+        pr_parent_tree_sha="def",
+    )
+    missing = [f for f in findings if f.code == "MISSING_FILE"]
+    assert len(missing) == 0, (
+        f"Deep directory prefix should match nested files: "
+        f"{[(m.detail, m.message) for m in missing]}"
+    )
+
+
+def test_c7_uppercase_x_checkbox():
+    """C7: `- [X]` (uppercase) MUST be treated same as `- [x]`."""
+    body = "- [X] `uppercase.py`"
+    extracted = extract_issue_paths(body)
+    assert "uppercase.py" in extracted, (
+        f"Uppercase [X] path not extracted: {extracted}"
+    )
+
+
+def test_c7_asymmetric_none_does_not_crash():
+    """C7: `merge_tree=None, parent_tree='abc'` does not crash."""
+    try:
+        findings = core_validate(
+            issue_body="- [ ] `file.py`",
+            pr_files=["file.py"],
+            pr_merge_tree_sha=None,
+            pr_parent_tree_sha="abc",
+        )
+        assert isinstance(findings, list)
+    except Exception as e:
+        assert False, f"Asymmetric None crashed: {e}"
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/scripts/validate_issue_pr_acceptance.py
+++ b/scripts/validate_issue_pr_acceptance.py
@@ -55,7 +55,7 @@ EXIT_BLOCKING = 2
 # Regex 1: checklist line `- [ ] ` / `- [x] ` / `* [ ] ` / `* [x] `
 # followed by a backtick-enclosed path.
 _CHECKLIST_PATH_RE = re.compile(
-    r"^[\s]*[-*]\s+\[[\sx]\]\s+`([^`]+)`",
+    r"^[\s]*[-*]\s+\[[\sxX]\]\s+`([^`]+)`",
     re.MULTILINE,
 )
 
@@ -99,16 +99,18 @@ def extract_issue_paths(body: str) -> list[str]:
 def core_validate(
     issue_body: Optional[str],
     pr_files: Optional[list[str]],
-    pr_merge_sha: Optional[str],
-    pr_parent_sha: Optional[str],
+    pr_merge_tree_sha: Optional[str],
+    pr_parent_tree_sha: Optional[str],
 ) -> list[ValidationFinding]:
     """Validate PR-issue acceptance consistency (pure function).
 
     Args:
         issue_body: Issue body markdown text. None/empty treated as no issue.
         pr_files: List of file paths changed in the PR. None treated as empty.
-        pr_merge_sha: SHA of the PR merge commit. None if not merged.
-        pr_parent_sha: SHA of the parent commit. None if not merged.
+        pr_merge_tree_sha: Tree SHA of the PR merge commit (NOT the commit SHA).
+                           None if PR not merged.
+        pr_parent_tree_sha: Tree SHA of the first parent commit.
+                            None if PR not merged.
 
     Returns:
         List of ValidationFinding. Empty = all checks pass.
@@ -120,14 +122,14 @@ def core_validate(
     files: set[str] = set(pr_files or [])
 
     # ── R1: No-op merge detection ──────────────────────────────────────
-    if pr_merge_sha is not None and pr_parent_sha is not None:
-        if pr_merge_sha == pr_parent_sha:
+    if pr_merge_tree_sha is not None and pr_parent_tree_sha is not None:
+        if pr_merge_tree_sha == pr_parent_tree_sha:
             findings.append(ValidationFinding(
                 severity="error",
                 code="NO_OP_MERGE",
                 message="PR merge commit has the same tree SHA as its parent — "
                         "zero files changed (no-op merge).",
-                detail=f"merge/parent tree SHA: {pr_merge_sha}",
+                detail=f"merge/parent tree SHA: {pr_merge_tree_sha}",
             ))
 
     # ── R2: Missing file / directory detection ─────────────────────────
@@ -235,11 +237,16 @@ def fetch_pr_files(pr_number: int) -> list[str]:
         return []
 
 
-def fetch_pr_merge_sha(pr_number: int) -> tuple[Optional[str], Optional[str]]:
-    """Fetch merge commit SHA and parent commit SHA for a merged PR.
+def fetch_pr_tree_shas(pr_number: int) -> tuple[Optional[str], Optional[str]]:
+    """Fetch merge tree SHA and parent tree SHA for a merged PR.
 
-    Returns:
-        (merge_sha, parent_sha) or (None, None) if PR not merged / unavailable.
+    Returns (tree SHA of merge commit, tree SHA of first parent).
+    Returns (None, None) if PR not merged, git data unavailable, or
+    either tree cannot be resolved (e.g. shallow clone).
+
+    Note: returns tree SHAs, NOT commit SHAs — two different commits
+    can produce the same tree (= no-op merge). Comparing tree SHAs
+    catches this correctly.
     """
     try:
         raw = _gh_run([
@@ -253,7 +260,8 @@ def fetch_pr_merge_sha(pr_number: int) -> tuple[Optional[str], Optional[str]]:
     except RuntimeError:
         return None, None
 
-    # Get tree of merge commit via git plumbing
+    # Get trees via git plumbing; if any step fails, return (None, None)
+    # consistently to avoid asymmetric partial results.
     try:
         tree_result = subprocess.run(
             ["git", "rev-parse", f"{merge_sha}^{{tree}}"],
@@ -263,16 +271,14 @@ def fetch_pr_merge_sha(pr_number: int) -> tuple[Optional[str], Optional[str]]:
             return None, None
         merge_tree = tree_result.stdout.strip()
 
-        # Get tree of first parent
         parent_result = subprocess.run(
             ["git", "rev-parse", f"{merge_sha}^1^{{tree}}"],
             capture_output=True, text=True, timeout=10,
         )
         if parent_result.returncode != 0:
-            return merge_tree, None
+            return None, None
         parent_tree = parent_result.stdout.strip()
 
-        # Return tree SHAs (not commit SHAs) for comparison
         return merge_tree, parent_tree
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return None, None
@@ -294,10 +300,6 @@ def build_parser() -> argparse.ArgumentParser:
         "pr_number", type=int,
         help="GitHub PR number",
     )
-    parser.add_argument(
-        "--no-fetch", action="store_true",
-        help="Skip gh CLI fetching (for testing with pre-supplied data)",
-    )
     return parser
 
 
@@ -316,11 +318,13 @@ def main() -> int:
     # Fetch data
     issue_body = fetch_issue_body(args.issue_number)
     pr_files = fetch_pr_files(args.pr_number)
-    merge_sha, parent_sha = fetch_pr_merge_sha(args.pr_number)
+    merge_tree, parent_tree = fetch_pr_tree_shas(args.pr_number)
 
     if not issue_body and not pr_files:
         print(
-            "warning: could not fetch issue body or PR files — skipping validation.",
+            "note: could not fetch issue body or PR files — "
+            "skipping validation (this is expected if the issue/PR "
+            "does not exist or gh is not configured).",
             file=sys.stderr,
         )
         return EXIT_PASS
@@ -329,8 +333,8 @@ def main() -> int:
     findings = core_validate(
         issue_body=issue_body,
         pr_files=pr_files,
-        pr_merge_sha=merge_sha,
-        pr_parent_sha=parent_sha,
+        pr_merge_tree_sha=merge_tree,
+        pr_parent_tree_sha=parent_tree,
     )
 
     if not findings:

--- a/scripts/validate_issue_pr_acceptance.py
+++ b/scripts/validate_issue_pr_acceptance.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""
+Validate PR-issue acceptance consistency.
+
+Detects:
+  - NO_OP_MERGE:  merge commit with same tree SHA as parent (zero diff)
+  - MISSING_FILE: issue acceptance checklist path not in PR changed files
+
+Usage:
+    python3 scripts/validate_issue_pr_acceptance.py <ISSUE_NUMBER> <PR_NUMBER>
+
+Requires:
+  - gh CLI (GitHub CLI) authenticated for the repository
+  - git (for tree SHA comparison)
+
+Exit codes:
+    0 = all checks pass (or gh unavailable — advisory only)
+    1 = warnings only
+    2 = one or more blocking errors
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Types
+# ═══════════════════════════════════════════════════════════════════════════
+
+@dataclass
+class ValidationFinding:
+    """A single validation finding from PR-issue acceptance checks."""
+
+    severity: str  # "error" | "warning"
+    code: str      # machine-readable code
+    message: str   # human-readable summary
+    detail: str    # additional context (e.g., the file path or SHA)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Constants
+# ═══════════════════════════════════════════════════════════════════════════
+
+EXIT_PASS = 0
+EXIT_WARNINGS = 1
+EXIT_BLOCKING = 2
+
+# Regex 1: checklist line `- [ ] ` / `- [x] ` / `* [ ] ` / `* [x] `
+# followed by a backtick-enclosed path.
+_CHECKLIST_PATH_RE = re.compile(
+    r"^[\s]*[-*]\s+\[[\sx]\]\s+`([^`]+)`",
+    re.MULTILINE,
+)
+
+# Regex 2: prose bullet list `- `path`` / `* `path`` (no checkbox).
+# This catches "实现范围" sections where paths are listed as plain bullets.
+_BULLET_PATH_RE = re.compile(
+    r"^[\s]*[-*]\s+`([^`]+)`",
+    re.MULTILINE,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Core validation logic (pure, no side effects — fully testable)
+# ═══════════════════════════════════════════════════════════════════════════
+
+def extract_issue_paths(body: str) -> list[str]:
+    r"""Extract file paths from issue body's path listings.
+
+    Extracts from two formats:
+      1. Checklist items: ``- [ ] `path` `` and ``- [x] `path` ``
+      2. Bullet lists:   ``- `path` `` and ``* `path` `` (no checkbox)
+
+    Paths embedded in running prose paragraphs are NOT extracted
+    (they must be at the start of a bullet/checklist line).
+
+    Args:
+        body: Issue body markdown text.
+
+    Returns:
+        Sorted list of unique file paths found in checklist/bullet items.
+    """
+    if not body:
+        return []
+    matches = []
+    matches.extend(_CHECKLIST_PATH_RE.findall(body))
+    matches.extend(_BULLET_PATH_RE.findall(body))
+    paths = sorted({p.strip() for p in matches if p.strip()})
+    return paths
+
+
+def core_validate(
+    issue_body: Optional[str],
+    pr_files: Optional[list[str]],
+    pr_merge_sha: Optional[str],
+    pr_parent_sha: Optional[str],
+) -> list[ValidationFinding]:
+    """Validate PR-issue acceptance consistency (pure function).
+
+    Args:
+        issue_body: Issue body markdown text. None/empty treated as no issue.
+        pr_files: List of file paths changed in the PR. None treated as empty.
+        pr_merge_sha: SHA of the PR merge commit. None if not merged.
+        pr_parent_sha: SHA of the parent commit. None if not merged.
+
+    Returns:
+        List of ValidationFinding. Empty = all checks pass.
+    """
+    findings: list[ValidationFinding] = []
+
+    # Normalise inputs
+    body = (issue_body or "").strip()
+    files: set[str] = set(pr_files or [])
+
+    # ── R1: No-op merge detection ──────────────────────────────────────
+    if pr_merge_sha is not None and pr_parent_sha is not None:
+        if pr_merge_sha == pr_parent_sha:
+            findings.append(ValidationFinding(
+                severity="error",
+                code="NO_OP_MERGE",
+                message="PR merge commit has the same tree SHA as its parent — "
+                        "zero files changed (no-op merge).",
+                detail=f"merge/parent tree SHA: {pr_merge_sha}",
+            ))
+
+    # ── R2: Missing file / directory detection ─────────────────────────
+    issue_paths = extract_issue_paths(body)
+    for path in issue_paths:
+        if path.endswith("/"):
+            # Directory reference: check if any PR file starts with this prefix
+            prefix = path.rstrip("/")
+            if not any(f.startswith(prefix + "/") or f == prefix for f in files):
+                findings.append(ValidationFinding(
+                    severity="error",
+                    code="MISSING_FILE",
+                    message=f"Issue references directory `{path}` but no PR file "
+                            f"falls under this directory.",
+                    detail=path,
+                ))
+        else:
+            # Exact file reference
+            if path not in files:
+                findings.append(ValidationFinding(
+                    severity="error",
+                    code="MISSING_FILE",
+                    message=f"Issue acceptance checklist references `{path}` "
+                            f"but it is not in the PR's changed files.",
+                    detail=path,
+                ))
+
+    return findings
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# gh CLI helpers (side-effecting — isolated for testability)
+# ═══════════════════════════════════════════════════════════════════════════
+
+def _check_gh_available() -> bool:
+    """Return True if gh CLI is available and authenticated."""
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "status"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def _gh_run(args: list[str], timeout: int = 30) -> str:
+    """Run a gh CLI command and return stdout. Raises RuntimeError on failure."""
+    try:
+        result = subprocess.run(
+            ["gh"] + args,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        raise RuntimeError("gh CLI not found. Install GitHub CLI: https://cli.github.com/")
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(f"gh command timed out after {timeout}s: gh {' '.join(args)}")
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"gh command failed (exit {result.returncode}): "
+            f"gh {' '.join(args)}\n{result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+def fetch_issue_body(issue_number: int) -> str:
+    """Fetch issue body via gh CLI.
+
+    Returns:
+        Issue body markdown, or empty string on failure.
+    """
+    try:
+        return _gh_run([
+            "issue", "view", str(issue_number),
+            "--json", "body",
+            "--jq", ".body",
+        ])
+    except RuntimeError as e:
+        print(f"warning: could not fetch issue #{issue_number}: {e}", file=sys.stderr)
+        return ""
+
+
+def fetch_pr_files(pr_number: int) -> list[str]:
+    """Fetch list of files changed in a PR via gh CLI.
+
+    Returns:
+        List of file paths, or empty list on failure.
+    """
+    try:
+        raw = _gh_run([
+            "pr", "view", str(pr_number),
+            "--json", "files",
+            "--jq", ".files[].path",
+        ])
+        if not raw:
+            return []
+        return sorted(line.strip() for line in raw.splitlines() if line.strip())
+    except RuntimeError as e:
+        print(f"warning: could not fetch PR #{pr_number} files: {e}", file=sys.stderr)
+        return []
+
+
+def fetch_pr_merge_sha(pr_number: int) -> tuple[Optional[str], Optional[str]]:
+    """Fetch merge commit SHA and parent commit SHA for a merged PR.
+
+    Returns:
+        (merge_sha, parent_sha) or (None, None) if PR not merged / unavailable.
+    """
+    try:
+        raw = _gh_run([
+            "pr", "view", str(pr_number),
+            "--json", "mergeCommit",
+            "--jq", ".mergeCommit.oid",
+        ])
+        if not raw:
+            return None, None  # not merged
+        merge_sha = raw.strip()
+    except RuntimeError:
+        return None, None
+
+    # Get tree of merge commit via git plumbing
+    try:
+        tree_result = subprocess.run(
+            ["git", "rev-parse", f"{merge_sha}^{{tree}}"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if tree_result.returncode != 0:
+            return None, None
+        merge_tree = tree_result.stdout.strip()
+
+        # Get tree of first parent
+        parent_result = subprocess.run(
+            ["git", "rev-parse", f"{merge_sha}^1^{{tree}}"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if parent_result.returncode != 0:
+            return merge_tree, None
+        parent_tree = parent_result.stdout.strip()
+
+        # Return tree SHAs (not commit SHAs) for comparison
+        return merge_tree, parent_tree
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None, None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# CLI
+# ═══════════════════════════════════════════════════════════════════════════
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate PR-issue acceptance consistency",
+    )
+    parser.add_argument(
+        "issue_number", type=int,
+        help="GitHub issue number",
+    )
+    parser.add_argument(
+        "pr_number", type=int,
+        help="GitHub PR number",
+    )
+    parser.add_argument(
+        "--no-fetch", action="store_true",
+        help="Skip gh CLI fetching (for testing with pre-supplied data)",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if not _check_gh_available():
+        print(
+            "warning: gh CLI is not available or not authenticated. "
+            "Skipping validation. Install gh: https://cli.github.com/",
+            file=sys.stderr,
+        )
+        return EXIT_PASS
+
+    # Fetch data
+    issue_body = fetch_issue_body(args.issue_number)
+    pr_files = fetch_pr_files(args.pr_number)
+    merge_sha, parent_sha = fetch_pr_merge_sha(args.pr_number)
+
+    if not issue_body and not pr_files:
+        print(
+            "warning: could not fetch issue body or PR files — skipping validation.",
+            file=sys.stderr,
+        )
+        return EXIT_PASS
+
+    # Run validation
+    findings = core_validate(
+        issue_body=issue_body,
+        pr_files=pr_files,
+        pr_merge_sha=merge_sha,
+        pr_parent_sha=parent_sha,
+    )
+
+    if not findings:
+        print("All PR-issue acceptance checks pass.")
+        return EXIT_PASS
+
+    # Report findings
+    errors = [f for f in findings if f.severity == "error"]
+    warnings = [f for f in findings if f.severity == "warning"]
+
+    for f in findings:
+        tag = "ERROR" if f.severity == "error" else "WARN"
+        print(f"[{tag}] [{f.code}] {f.message}")
+        if f.detail:
+            print(f"       detail: {f.detail}")
+
+    if errors:
+        print(f"\n{len(errors)} error(s) found.", file=sys.stderr)
+        return EXIT_BLOCKING
+    if warnings:
+        print(f"\n{len(warnings)} warning(s) found.", file=sys.stderr)
+        return EXIT_WARNINGS
+
+    return EXIT_PASS
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Add a validation script and CI integration to prevent false issue-close claims, no-op merge commits, and untracked acceptance criteria.

Closes #326.

## What changed

### New: `scripts/validate_issue_pr_acceptance.py`
- Pure-function `core_validate()` — no external deps, fully testable
- CLI wrapper using `gh` to fetch issue body, PR files, and merge tree SHAs
- Graceful fallback if `gh` is unavailable (warning + skip, exit 0)

### New: `scripts/test_issue_pr_acceptance.py`
- 18 property-based contract tests covering 6 contract families (C1–C6)
- Regression fixture for #320/#324 (hardcoded real data)
- Runs in CI (`quick` job)

### Updated: `.github/pull_request_template.md`
- Added `Issue acceptance mapping` table for traceability

### Updated: `.github/workflows/ci.yml`
- Added `python3 scripts/test_issue_pr_acceptance.py` to `quick` job

## Detection rules

| Code | Triggers on |
|------|-------------|
| `NO_OP_MERGE` | Merge commit tree SHA == parent tree SHA (zero diff) |
| `MISSING_FILE` | Issue checklist/bullet path not in PR diff (also supports directory prefix `dir/`) |

## Verification

```
$ python3 scripts/validate_issue_pr_acceptance.py 320 324
→ 7 errors found (NO_OP_MERGE + 6 MISSING_FILE)
```

## Issue acceptance mapping

| Acceptance item | Implementation file | Verification command |
|---|---|---|
| Validation script | `scripts/validate_issue_pr_acceptance.py` | `python3 scripts/test_issue_pr_acceptance.py` |
| PR template update | `.github/pull_request_template.md` | visual review |
| CI integration | `.github/workflows/ci.yml` | runs on PR push |
| #320/#324 regression fixture | `scripts/test_issue_pr_acceptance.py` | `python3 scripts/test_issue_pr_acceptance.py` |

## Risks

- `gh` CLI required for live runs; gracefully skips when unavailable
- Only checks backtick-enclosed paths in checklist/bullet items (not prose)
- No auto-blocking in CI yet (advisory only; see #326 discussion)