### PR TITLE
feat(#350): classify financial aggregators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - run: pip install -r requirements.txt
       - run: python3 -m py_compile scripts/*.py
       - run: python3 scripts/validate_research_pack.py examples/research-pack-example.md
       - run: python3 scripts/validate_research_pack.py examples/research-pack-example.md --strict

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'scripts/**'
+      - 'tests/**'
       - 'schemas/**'
       - 'examples/**'
       - 'checklists/**'
@@ -15,6 +16,7 @@ on:
     branches: [$default-branch]
     paths:
       - 'scripts/**'
+      - 'tests/**'
       - 'schemas/**'
       - 'examples/**'
       - 'checklists/**'
@@ -51,6 +53,8 @@ jobs:
       - run: python3 scripts/test_md_to_pdf_preflight.py
       - run: python3 scripts/test_control_plane_architecture_discipline.py
       - run: python3 scripts/test_quantitative_role_audit.py
+      - run: python3 scripts/test_source_label_consistency.py
+      - run: python3 tests/test_issue_350_contracts.py
       - run: python3 scripts/test_audit_report.py
       - run: python3 scripts/test_issue_pr_acceptance.py
 

--- a/checklists/listed-company-report.md
+++ b/checklists/listed-company-report.md
@@ -9,6 +9,8 @@ Run through every item before delivering the final report.
 - [ ] 市场快照表已填入完整数据（对照模板必填列：当前股价/快照日期/市值/PE (TTM)/PE (Forward)/PB/PS/52周区间/股息率）
 - [ ] 每项指标都标注了具体数据来源和快照日期
 - [ ] 数据来源优先使用实时金融数据平台或交易所披露，而非过时或间接来源
+- [ ] 若市场快照/财务快照使用 `FILED_DATA_AGGREGATOR`（Reuters LSEG/Bloomberg/Wind/Choice/StockAnalysis/Macrotrends filed data），正文同句说明其为聚合/非原始披露来源，并标注 snapshot date、TTM/fiscal year、metric basis/口径；否则不得用 confirmed labels
+- [ ] `ANALYST_PORTAL_COMPILATION`（Finviz/Seeking Alpha/Yahoo Finance 等未明确 filed-data 的门户聚合）不得承载 confirmed labels；用于估计、新闻流或方向性参考时标为 secondary-like / 推断
 
 ## Reporting discipline
 

--- a/evals/cases/ai-coding-provider-selection-current-state-conflict-case.md
+++ b/evals/cases/ai-coding-provider-selection-current-state-conflict-case.md
@@ -94,7 +94,7 @@ The unique contributions:
 
 - `evals/cases/ai-coding-tools-provider-selection-traceability-fail-case.md` — same route/topic, unverifiable freshness (vs verified stale)
 - `evals/cases/rag-api-provider-selection-traceability-fail-case.md` — same route, traceability fail
-- `evals/cases/tsmc-listed-company-aggregator-source-and-moat-case.md` — same vendor/manufacturer claim discipline, different route
+- `evals/cases/aaeon-listed-company-label-inflation-case.md` — same label-inflation discipline, different route
 - `evals/cases/dc-power-market-outlook-inflation-and-monitoring-case.md` — same register inflation severity, different route
 
 ## Reviewer checklist

--- a/evals/cases/tsmc-customer-concentration-and-second-source-case.md
+++ b/evals/cases/tsmc-customer-concentration-and-second-source-case.md
@@ -96,7 +96,7 @@ Issue #280 proposes checklist items, template table, and moat linkage rules to c
 This eval is distinct from existing TSMC eval cases:
 - `tsmc-valuation-dcf-and-sensitivity-case.md` — focuses on DCF/reverse DCF and sensitivity matrix
 - `tsmc-valuation-time-horizon-stratification-case.md` — focuses on time-stratified valuation judgment
-- `tsmc-listed-company-aggregator-source-and-moat-case.md` — focuses on aggregator source discipline
+- `lotes-listed-company-moat-snapshot-case.md` — focuses on moat boundary discipline
 - This case focuses on **customer concentration as an independent valuation variable**
 
 ## Current rule verdict
@@ -122,7 +122,7 @@ This eval directly tests the behavioral impact of the rules proposed in issue #2
 
 - `evals/cases/tsmc-valuation-dcf-and-sensitivity-case.md` — same company, DCF/sensitivity focus (issue #278)
 - `evals/cases/tsmc-valuation-time-horizon-stratification-case.md` — same company, time-horizon stratification focus (issue #277)
-- `evals/cases/tsmc-listed-company-aggregator-source-and-moat-case.md` — same company, aggregator source + moat classification focus
+- `evals/cases/lotes-listed-company-moat-snapshot-case.md` — moat boundary discipline
 - `evals/cases/emc-listed-company-strong-claims-moat-case.md` — moat-style claims evidence gates
 - `evals/cases/lotes-listed-company-moat-snapshot-case.md` — moat boundary discipline
 

--- a/evals/cases/tsmc-valuation-dcf-and-sensitivity-case.md
+++ b/evals/cases/tsmc-valuation-dcf-and-sensitivity-case.md
@@ -90,7 +90,7 @@ Issue #278 proposes DCF/reverse DCF trigger rules, assumption table templates, a
 
 This eval is distinct from the existing TSMC eval cases:
 - `evals/cases/tsmc-valuation-time-horizon-stratification-case.md` focuses on time-horizon stratification of the valuation judgment
-- `evals/cases/tsmc-listed-company-aggregator-source-and-moat-case.md` focuses on aggregator source discipline and moat classification
+- `evals/cases/reporting-period-and-ttm-confusion-case.md` focuses on reporting-period and snapshot discipline
 - This case focuses on **valuation methodology completeness**: DCF/sensitivity as structural requirements for any listed-company valuation
 
 ## Current rule verdict
@@ -109,7 +109,7 @@ This eval directly tests the behavioral impact of three new rules proposed in is
 ## Related evals
 
 - `evals/cases/tsmc-valuation-time-horizon-stratification-case.md` — same company, time-horizon stratification focus (issue #277)
-- `evals/cases/tsmc-listed-company-aggregator-source-and-moat-case.md` — same company, aggregator source + moat classification focus
+- `evals/cases/reporting-period-and-ttm-confusion-case.md` — reporting-period and TTM discipline
 - `evals/cases/pop-mart-listed-company-traceability-hard-fail-case.md` — same route, traceability focus
 - `evals/cases/xiaohongshu-startup-evaluation-traceability-benchmark-case.md` — sensitivity analysis requirement for load-bearing assumptions (startup route)
 - `evals/cases/startup-evaluation-route-activation-case.md` — startup route's DCF avoidance rule (inverse of listed-company DCF requirement)

--- a/evals/cases/tsmc-valuation-time-horizon-stratification-case.md
+++ b/evals/cases/tsmc-valuation-time-horizon-stratification-case.md
@@ -80,7 +80,7 @@ The existing TSMC report demonstrated a clear failure mode: a well-structured li
 
 Issue #277 proposes template rules to close this gap. This eval validates that those rules actually produce the behavioral change. Without this eval, the new template rules could be added but never verified to actually fire during report generation.
 
-This eval is distinct from the existing TSMC eval case (`evals/cases/tsmc-listed-company-aggregator-source-and-moat-case.md`), which focuses on aggregator source discipline and moat classification. This case focuses on valuation judgment structure.
+This eval is distinct from related listed-company cases such as `evals/cases/reporting-period-and-ttm-confusion-case.md`, which focuses on reporting-period and snapshot discipline. This case focuses on valuation judgment structure.
 
 ## Current rule verdict
 
@@ -97,7 +97,7 @@ This eval directly tests the behavioral impact of three new rules proposed in is
 
 ## Related evals
 
-- `evals/cases/tsmc-listed-company-aggregator-source-and-moat-case.md` — same company, different discipline (aggregator source + moat)
+- `evals/cases/reporting-period-and-ttm-confusion-case.md` — listed-company reporting-period discipline
 - `evals/cases/pop-mart-listed-company-traceability-hard-fail-case.md` — same route, traceability focus
 - `evals/cases/consensus-and-forward-pe-misuse-case.md` — same route, forward-PE discipline
 - `evals/comparative-distillation/byd-gpt-vs-minimax-comparative-distillation.md` — comparative distillation showing GPT's stronger calibration, which this rule closes

--- a/evals/cases/world-cup-info-advantage-technical-deep-dive-source-strength-case.md
+++ b/evals/cases/world-cup-info-advantage-technical-deep-dive-source-strength-case.md
@@ -86,7 +86,7 @@ The unique contributions:
 - `evals/cases/mcp-technical-deep-dive-timeline-roadmap-case.md` — same route, timeline and roadmap discipline
 - `evals/cases/agentic-rag-technical-deep-dive-compounded-case.md` — same route, compounded vendor/source fail
 - `evals/cases/world-cup-rule-regulatory-route-mismatch-case.md` — same topic domain, route self-declaration error
-- `evals/cases/tsmc-listed-company-aggregator-source-and-moat-case.md` — same aggregator/source strength issue, different route
+- `evals/cases/finance-and-market-share-cambricon-case.md` — same source-strength calibration issue, different route
 - `evals/cases/dc-power-market-outlook-inflation-and-monitoring-case.md` — same Wikipedia source strength issue
 
 ## Reviewer checklist

--- a/evals/cases/world-cup-prediction-constrained-choice-probability-method-case.md
+++ b/evals/cases/world-cup-prediction-constrained-choice-probability-method-case.md
@@ -106,7 +106,7 @@ The unique contributions:
 - `evals/cases/content-platform-constrained-choice-compounded-fail-case.md` — same route, compounded fail with body traceability and numeric roles
 - `evals/cases/indie-dev-constrained-choice-delivery-fail-case.md` — same route, delivery fail with no source register and no roles
 - `evals/cases/world-cup-constrained-choice-wrong-route-case.md` — same topic domain, different failure (wrong route entirely)
-- `evals/cases/tsmc-listed-company-aggregator-source-and-moat-case.md` — same aggregator source discipline pattern, different route
+- `evals/cases/reporting-period-and-ttm-confusion-case.md` — same numeric role/snapshot discipline pattern, different route
 
 ## Reviewer checklist
 

--- a/references/data-conflict-resolution.md
+++ b/references/data-conflict-resolution.md
@@ -34,13 +34,15 @@ This tier hierarchy is a specialized refinement for financial and market data co
 
 When sources conflict, use this hierarchy to determine which source takes precedence:
 
+Tier 2 maps to `FILED_DATA_AGGREGATOR` when the platform re-presents filed/regulatory data. Tier 5 maps to `ANALYST_PORTAL_COMPILATION` when the platform mixes analyst estimates, market data, news, or auto aggregation.
+
 | Tier | Source type | Description | When to prefer |
 |------|------------|-------------|----------------|
 | **1** | Official filing | SEC 10-K/10-Q, CSRC/HKEX filings, audited annual/interim reports | Historical financials, regulatory disclosures, restated figures |
-| **2** | Exchange / regulatory aggregator | Reuters LSEG, Bloomberg filed data, Wind/Choice API filed data | When primary filing is not directly accessible but data is sourced from filings |
+| **2** | Exchange / regulatory aggregator (`FILED_DATA_AGGREGATOR`) | Reuters LSEG filed data, Bloomberg filed data, Wind/Choice API filed data, StockAnalysis/Macrotrends filed data | When primary filing is not directly accessible but data is sourced from filings; cite with snapshot date and metric basis because it is not original disclosure |
 | **3** | Company disclosure (unaudited) | Earnings releases, investor presentations, press releases, management commentary | Latest quarter before full report; forward guidance |
 | **4** | Reputable third-party dataset | IDC, Counterpoint, Canalys, Gartner (when methodology is transparent) | Market size, market share, industry benchmarks |
-| **5** | Secondary media / analyst | Seeking Alpha, Reuters news, broker research, industry media | News flow, interpretation, synthesis |
+| **5** | Secondary media / analyst / portal compilation (`ANALYST_PORTAL_COMPILATION`) | Seeking Alpha, Finviz, Yahoo Finance (unless specifically filed-data), Reuters news, broker research, industry media | News flow, interpretation, synthesis; must not override filed data or carry confirmed labels |
 | **6** | Social / forum | Retail investor forums, social media, anonymous commentary | Discovery only; never as sole evidence for load-bearing claims |
 
 ### Chinese-language source mapping
@@ -50,7 +52,7 @@ When researching Chinese-listed companies, Chinese-market topics, or cross-borde
 | Tier | Chinese-language source | Mainland accessibility | Mapping rationale |
 |------|------------------------|----------------------|-------------------|
 | **1** | 上交所/深交所/港交所 official filings (年报、半年报、季报) | ✅ | Official regulatory filing, equivalent to SEC 10-K/10-Q |
-| **2** | 东方财富 Choice API (filed data), Wind (filed data), 巨潮资讯网 | ✅ | Exchange/regulatory aggregator when data is sourced from filings |
+| **2** | 东方财富 Choice API (filed data), Wind (filed data), 巨潮资讯网 | ✅ | Exchange/regulatory aggregator / `FILED_DATA_AGGREGATOR` when data is sourced from filings；需标注快照日期、TTM/fiscal year、metric basis/口径 |
 | **3** | 公司官网公告、投资者互动平台、业绩说明会 | ✅ | Company disclosure (unaudited), same as earnings releases / investor presentations |
 | **4** | 财新、证券时报、21 经济、第一财经 | ✅ (财新部分内容需付费) | Reputable financial media with editorial standards; stronger than general industry media |
 | **5** | 36 氪、动点科技、半导体行业观察、新浪财经、同花顺 | ✅ | Industry media / news aggregation; useful for news flow and discovery |

--- a/references/quantitative-role-labeling.md
+++ b/references/quantitative-role-labeling.md
@@ -231,6 +231,11 @@ The assumption is named ("assume 15% growth"), but the conditions that must hold
 - 不得标注为 `[已确认事实]`
 - 应使用 `[推断]` 或具体来源角色如 `[彭博 estimate]`
 
+### Filed-data aggregators and analyst portals
+
+- `FILED_DATA_AGGREGATOR`（Reuters LSEG filed data、Bloomberg filed data、Wind/Choice filed data、StockAnalysis/Macrotrends filed data）是 aggregated filed data / 非原始披露。若用于 `[CONF]` financial snapshot，正文同句必须写明 snapshot date、TTM 或 fiscal year、metric basis/口径，避免把平台聚合值误读为 primary filing。
+- `ANALYST_PORTAL_COMPILATION`（Finviz、Seeking Alpha、Yahoo Finance 未明确为 filed-data 时）混合 analyst estimates、market data、news 或自动聚合；不得用 confirmed labels，应用 `[推断]` / `[未知]` 或更具体的估计角色。
+
 ### 何时需要标注
 
 判断标准：如果删除这行内说明后，读者无法区分"独立验证的事实"和"来源主动声称但未独立验证的数字"，就需要标注。
@@ -256,6 +261,8 @@ The assumption is named ("assume 15% growth"), but the conditions that must hold
 | `SECONDARY_MEDIA`（媒体/行业报告） | `[推断]` | 必须标注"（据XX报道）"如 `[推断]（据路透社报道）` |
 | `SECONDARY_ANALYST`（券商研报） | `[推断]` | 必须标注"（据XX分析师）"如 `[推断]（据高盛分析师）` |
 | `SECONDARY_FEED`（RSS 摘要/聚合内容流） | `[推断]` | 必须标注来源名称 |
+| `FILED_DATA_AGGREGATOR`（金融 filed/regulatory 数据聚合） | `[已确认事实]` + 来源/口径说明 | 仅限 financial snapshot；必须同句说明 aggregated filed data / snapshot date / TTM / fiscal year / metric basis / 口径 |
+| `ANALYST_PORTAL_COMPILATION`（分析师/市场/新闻门户聚合） | `[推断]` / `[未知]` | 不得使用 confirmed labels；如证明为 filed-data 口径，应改列 `FILED_DATA_AGGREGATOR` 并加口径说明 |
 | `TRANSCRIPT`（转录/访谈/电话会） | `[已确认事实]` 或 `[推断]` | verbatim（逐字记录，经录音核对）→ `[已确认事实]`；summary/paraphrase → `[推断]`。无论哪种情况，必须标注来源场景（"据公司年报电话会"） |
 | `INFERRED`（报告自身推断） | `[推断]` | 必须附推理链（见 `references/source-traceability-and-claim-citation.md` §Inference documentation） |
 | `UNCONFIRMED`（无法独立验证） | `[未知]` | 必须标注"未经独立验证" |

--- a/references/source-traceability-and-claim-citation.md
+++ b/references/source-traceability-and-claim-citation.md
@@ -283,6 +283,8 @@ Classify every source in the register by type. Use these types consistently:
 - `SECONDARY_MEDIA` — news article, industry report, analyst commentary
 - `SECONDARY_ANALYST` — analyst report, investment bank research
 - `SECONDARY_FEED` — RSS feed, newsletter, curated content stream
+- `FILED_DATA_AGGREGATOR` — financial data platform re-presenting filed/regulatory data (Reuters LSEG filed data, Bloomberg filed data, Wind filed data, Choice filed data, StockAnalysis/Macrotrends filed data). Not a primary filing; may support a financial snapshot only when the body marks both (1) source role/caveat such as aggregated filed data or non-original disclosure, and (2) snapshot / metric basis such as snapshot date, fiscal year/TTM, or metric basis.
+- `ANALYST_PORTAL_COMPILATION` — portal/compilation mixing analyst estimates, market data, news, or auto aggregation (Finviz, Seeking Alpha, Yahoo Finance when not specifically filed-data). Treat as secondary-like; do not use confirmed labels for claims sourced only to these portals.
 - `TRANSCRIPT` — verbatim or near-verbatim transcript of an interview, press conference, earnings call, podcast, tutorial, or presentation
 - `INFERRED` — model inference with explicit reasoning chain documented
 - `CROWDSOURCED` — Wikipedia, crowdsourced compilation, tertiary sources (must not carry confirmed labels)
@@ -313,6 +315,8 @@ Classify every source in the register by type. Use these types consistently:
 | 专家访谈 / 访谈 / 财报电话会 | TRANSCRIPT | [确认事实] or [推断] | verbatim → confirmed; summary → inferred |
 | Primary (multilateral) / Primary (US govt agency) / government agency / regulator / public agency | PRIMARY_INSTITUTION | [确认事实] | 机构/政府来源，非厂商自述，不需 caveat |
 | Primary (vendor) | PRIMARY_COMPANY | [确认事实] + caveat | 厂商自述需 caveat，同其他公司来源处理 |
+| Reuters LSEG filed data / Bloomberg filed data / Wind filed data / Choice filed data / StockAnalysis filed data / Macrotrends filed data | FILED_DATA_AGGREGATOR | [确认事实] only with role + basis note | 非 primary filing；可用于 financial snapshot，但正文同句必须同时标明 filed data / aggregated / 非原始披露等来源角色，以及 snapshot date / TTM / fiscal year / metric basis 等口径 |
+| Finviz / Seeking Alpha / Yahoo Finance | ANALYST_PORTAL_COMPILATION | [推断]/[未知] | 混合 analyst estimates、market data、news 或 auto aggregation；不得承载 confirmed labels，除非另行证明为 filed-data 口径并改列 FILED_DATA_AGGREGATOR |
 | Secondary (crowdsourced) / crowdsourced / Wikipedia / wiki | CROWDSOURCED | [推断]/[未知] | 不可承载 [确认事实] |
 | rumor / leak / 传闻 / unconfirmed | UNCONFIRMED | [未知]/[推断] | 不可承载 [确认事实] |
 
@@ -441,6 +445,8 @@ If a thesis-bearing claim cannot be made auditable in the body without awkwardne
 
 - 当 register 标注某来源为 **厂商自述 / manufacturer self-reported**（如 `PRIMARY_COMPANY`、`PRIMARY_PARTNER`、简化类型的 `vendor-claim`、或 register Notes 列注明"厂商自述"），正文引用该来源的数据时必须附加内联说明，如 `(来源：厂商自述，非独立验证)`，不得单独使用 `[已确认事实]`
 - 当来源为 **媒体估计**（SECONDARY_MEDIA 类型，如彭博、券商研究报告等第三方推断），正文不得标注为 `[已确认事实]`；应使用 `[推断]` 或具体角色如 `[彭博 estimate]`
+- 当来源为 `ANALYST_PORTAL_COMPILATION`（Finviz、Seeking Alpha、Yahoo Finance 等混合门户/自动聚合），正文不得使用 `[CONF]` / `[确认事实]` / `[Confirmed]` / `[确认]` 等 confirmed labels。
+- 当来源为 `FILED_DATA_AGGREGATOR`（Reuters LSEG filed data、Bloomberg filed data、Wind/Choice filed data、StockAnalysis/Macrotrends filed data），它不是 primary filing；若正文使用 confirmed labels，只能确认“该平台 re-presented filed/regulatory data”，且同句必须同时说明两类信息：source role / caveat（如 `filed data`、`aggregated`、`聚合数据`、`非原始披露`）和 snapshot / metric basis（如 `snapshot date`、`TTM`、`fiscal year`、`口径`、`metric basis`）。
 - 核心原则：**正文标签强度 ≤ register 标签强度**。register 标注弱于正文时视为标签通胀，应修正
 
 > 注：正文标签 `[已确认事实]` 通常对应 register 中的 `PRIMARY_FILING` 或等效高可靠性类型；`[推断]` 对应 `SECONDARY_MEDIA`、`SECONDARY_ANALYST`、`INFERRED`；`[未知]` 对应 `UNCONFIRMED`、`WEAK_SIGNAL`。此映射为经验性参考，具体 case 由审计员根据证据强度判断。

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 markdown>=3.5
 playwright>=1.40
 nh3>=0.2
+hypothesis>=6.0

--- a/scripts/test_source_label_consistency.py
+++ b/scripts/test_source_label_consistency.py
@@ -493,6 +493,36 @@ def test_filed_data_aggregator_without_confirmed_label_passes() -> None:
     )
 
 
+def test_filed_data_aggregator_chinese_confirmed_label_fails() -> None:
+    """[已确认事实] without caveat also fails for filed-data aggregator."""
+    expect_fail(
+        "filed data aggregator chinese confirmed label without caveat",
+        "## Source Register\n\n"
+        "| ID | Source Name | Source Type | Date | DOI/URL | Reliability | "
+        "Claims Supported |\n"
+        "|----|-------------|-------------|------|---------|-------------|-"
+        "-----------------|\n"
+        "| S01 | Wind filed data | FILED_DATA_AGGREGATOR | 2026-06-30 | "
+        "https://wind.example | Medium | §1: FY2025 revenue |\n\n"
+        "[已确认事实] S01 报告营收为 100 亿元。\n",
+    )
+
+
+def test_filed_data_aggregator_chinese_confirmed_with_caveat_passes() -> None:
+    """[已确认事实] with role+basis caveat passes for filed-data aggregator."""
+    expect_pass(
+        "filed data aggregator chinese confirmed with caveat",
+        "## Source Register\n\n"
+        "| ID | Source Name | Source Type | Date | DOI/URL | Reliability | "
+        "Claims Supported |\n"
+        "|----|-------------|-------------|------|---------|-------------|-"
+        "-----------------|\n"
+        "| S01 | Wind filed data | FILED_DATA_AGGREGATOR | 2026-06-30 | "
+        "https://wind.example | Medium | §1: FY2025 revenue |\n\n"
+        "[已确认事实] S01 提供聚合数据，快照日期 2026-06-30，口径为 FY2025 营收。\n",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Property-based test: _normalize_source_type idempotency and roundtrip
 # ---------------------------------------------------------------------------
@@ -600,6 +630,8 @@ def main() -> int:
         test_filed_data_aggregator_confirmed_with_metric_only_fails,
         test_filed_data_aggregator_confirmed_with_caveat_passes,
         test_filed_data_aggregator_without_confirmed_label_passes,
+        test_filed_data_aggregator_chinese_confirmed_label_fails,
+        test_filed_data_aggregator_chinese_confirmed_with_caveat_passes,
         test_normalize_source_type_property,
     ]
     failures = []

--- a/scripts/test_source_label_consistency.py
+++ b/scripts/test_source_label_consistency.py
@@ -13,12 +13,16 @@ SCRIPT = str(
 )
 
 
-def run_lint(text: str) -> subprocess.CompletedProcess:
+def run_lint(text: str, *, strict: bool = False) -> subprocess.CompletedProcess:
     with tempfile.TemporaryDirectory() as d:
         path = Path(d) / "fixture.md"
         path.write_text(text, encoding="utf-8")
+        cmd = [sys.executable, SCRIPT]
+        if strict:
+            cmd.append("--strict")
+        cmd.append(str(path))
         return subprocess.run(
-            [sys.executable, SCRIPT, str(path)],
+            cmd,
             capture_output=True,
             text=True,
         )
@@ -37,6 +41,15 @@ def expect_fail(name: str, text: str) -> None:
     result = run_lint(text)
     assert result.returncode == 2, (
         f"{name}: expected lint failure, got {result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    print(f"  PASS  {name}")
+
+
+def expect_strict_pass(name: str, text: str) -> None:
+    result = run_lint(text, strict=True)
+    assert result.returncode == 0, (
+        f"{name}: expected strict pass, got {result.returncode}\n"
         f"stdout: {result.stdout}\nstderr: {result.stderr}"
     )
     print(f"  PASS  {name}")
@@ -385,6 +398,102 @@ def test_unconfirmed_canonical_type_with_confirmed_fails() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Issue #350: financial aggregator source classification
+# ---------------------------------------------------------------------------
+
+
+def test_filed_data_aggregator_is_known_type_in_strict_mode() -> None:
+    """FILED_DATA_AGGREGATOR must be a recognized canonical type."""
+    expect_strict_pass(
+        "FILED_DATA_AGGREGATOR known in strict mode",
+        "## Source Register\n\n"
+        "| ID | Source Name | Source Type | Date | DOI/URL | Reliability | "
+        "Claims Supported |\n"
+        "|----|-------------|-------------|------|---------|-------------|-"
+        "-----------------|\n"
+        "| S01 | Bloomberg filed data | FILED_DATA_AGGREGATOR | 2026-06-30 | "
+        "https://bloomberg.example | Medium | §1: FY revenue snapshot |\n\n"
+        "[INFER] S01 provides a financial snapshot for comparison.\n",
+    )
+
+
+def test_analyst_portal_compilation_with_confirmed_label_fails() -> None:
+    """ANALYST_PORTAL_COMPILATION behaves like secondary evidence."""
+    expect_fail(
+        "analyst portal compilation with confirmed label",
+        "## Source Register\n\n"
+        "| ID | Source Name | Source Type | Date | DOI/URL | Reliability | "
+        "Claims Supported |\n"
+        "|----|-------------|-------------|------|---------|-------------|-"
+        "-----------------|\n"
+        "| S01 | Yahoo Finance profile | ANALYST_PORTAL_COMPILATION | 2026-06-30 | "
+        "https://finance.yahoo.example | Medium | §1: market data snapshot |\n\n"
+        "[Confirmed] According to S01, revenue was $10B.\n",
+    )
+
+
+def test_filed_data_aggregator_confirmed_without_caveat_fails() -> None:
+    """Confirmed filed-data aggregator citations require same-sentence caveat."""
+    expect_fail(
+        "filed data aggregator confirmed without caveat",
+        "## Source Register\n\n"
+        "| ID | Source Name | Source Type | Date | DOI/URL | Reliability | "
+        "Claims Supported |\n"
+        "|----|-------------|-------------|------|---------|-------------|-"
+        "-----------------|\n"
+        "| S01 | Reuters LSEG Data | FILED_DATA_AGGREGATOR | 2026-06-30 | "
+        "https://lseg.example | Medium | §1: TTM revenue |\n\n"
+        "[CONF] S01 reports TSMC revenue at $10B.\n",
+    )
+
+
+def test_filed_data_aggregator_confirmed_with_metric_only_fails() -> None:
+    """Metric words alone do not establish aggregator/non-original role."""
+    expect_fail(
+        "filed data aggregator confirmed with metric only",
+        "## Source Register\n\n"
+        "| ID | Source Name | Source Type | Date | DOI/URL | Reliability | "
+        "Claims Supported |\n"
+        "|----|-------------|-------------|------|---------|-------------|-"
+        "-----------------|\n"
+        "| S01 | Reuters LSEG Data | FILED_DATA_AGGREGATOR | 2026-06-30 | "
+        "https://lseg.example | Medium | §1: TTM revenue |\n\n"
+        "[CONF] S01 reports TTM revenue at $10B.\n",
+    )
+
+
+def test_filed_data_aggregator_confirmed_with_caveat_passes() -> None:
+    """Filed-data aggregator with caveat/role note can support snapshots."""
+    expect_pass(
+        "filed data aggregator confirmed with caveat",
+        "## Source Register\n\n"
+        "| ID | Source Name | Source Type | Date | DOI/URL | Reliability | "
+        "Claims Supported |\n"
+        "|----|-------------|-------------|------|---------|-------------|-"
+        "-----------------|\n"
+        "| S01 | StockAnalysis financials | FILED_DATA_AGGREGATOR | 2026-06-30 | "
+        "https://stockanalysis.example | Medium | §1: market snapshot |\n\n"
+        "[CONF] S01 provides aggregated filed data with snapshot date 2026-06-30 "
+        "and TTM metric basis for the financial snapshot.\n",
+    )
+
+
+def test_filed_data_aggregator_without_confirmed_label_passes() -> None:
+    """Caveat is only mandatory when confirmed labels are used."""
+    expect_pass(
+        "filed data aggregator without confirmed label",
+        "## Source Register\n\n"
+        "| ID | Source Name | Source Type | Date | DOI/URL | Reliability | "
+        "Claims Supported |\n"
+        "|----|-------------|-------------|------|---------|-------------|-"
+        "-----------------|\n"
+        "| S01 | Wind filed data | FILED_DATA_AGGREGATOR | 2026-06-30 | "
+        "https://wind.example | Medium | §1: financial snapshot |\n\n"
+        "[INFER] S01 is used as a directional financial snapshot.\n",
+    )
+
+
+# ---------------------------------------------------------------------------
 # Property-based test: _normalize_source_type idempotency and roundtrip
 # ---------------------------------------------------------------------------
 
@@ -394,7 +503,8 @@ _VALID_CANONICAL_TYPES: frozenset[str] = frozenset({
     "PRIMARY_INSTITUTION", "PRIMARY_DEV", "SECONDARY_MEDIA",
     "SECONDARY_ANALYST", "SECONDARY_FEED", "SECONDARY",
     "TRANSCRIPT", "INFERRED", "UNCONFIRMED", "WEAK_SIGNAL",
-    "CROWDSOURCED", "PRIMARY",
+    "CROWDSOURCED", "PRIMARY", "FILED_DATA_AGGREGATOR",
+    "ANALYST_PORTAL_COMPILATION",
 })
 
 
@@ -420,6 +530,17 @@ _VALID_CANONICAL_TYPES: frozenset[str] = frozenset({
     "CROWDSOURCED",
     "PRIMARY_COMPANY",
     "SECONDARY_MEDIA",
+    "Reuters LSEG filed data",
+    "Bloomberg filed data",
+    "Wind filed data",
+    "Choice filed data",
+    "StockAnalysis filed data",
+    "Macrotrends filed data",
+    "Finviz",
+    "Seeking Alpha",
+    "Yahoo Finance",
+    "ANALYST_PORTAL_COMPILATION",
+    "FILED_DATA_AGGREGATOR",
 ]))
 def test_normalize_source_type_property(source_type: str) -> None:
     """Property: normalized canonical type is idempotent and valid.
@@ -472,6 +593,13 @@ def main() -> int:
         test_multilateral_source_with_confirmed_passes,
         test_crowdsourced_canonical_type_with_confirmed_fails,
         test_unconfirmed_canonical_type_with_confirmed_fails,
+        # Issue #350 tests
+        test_filed_data_aggregator_is_known_type_in_strict_mode,
+        test_analyst_portal_compilation_with_confirmed_label_fails,
+        test_filed_data_aggregator_confirmed_without_caveat_fails,
+        test_filed_data_aggregator_confirmed_with_metric_only_fails,
+        test_filed_data_aggregator_confirmed_with_caveat_passes,
+        test_filed_data_aggregator_without_confirmed_label_passes,
         test_normalize_source_type_property,
     ]
     failures = []

--- a/scripts/validate_source_label_consistency.py
+++ b/scripts/validate_source_label_consistency.py
@@ -27,6 +27,18 @@ CAVEAT_RE = re.compile(
     r"(?:（来源：厂商自述，非独立验证）|\(来源：厂商自述，非独立验证\))"
 )
 
+# Filed-data aggregators cited with confirmed labels need both:
+# 1) source-role language (aggregated / non-original / filed-data platform), and
+# 2) metric or snapshot basis (date, TTM/FY,口径). A bare "TTM" is not enough.
+FILED_DATA_AGGREGATOR_ROLE_RE = re.compile(
+    r"(?:filed data|filed-data|aggregator|aggregated|聚合数据|非原始披露)",
+    re.IGNORECASE,
+)
+FILED_DATA_AGGREGATOR_BASIS_RE = re.compile(
+    r"(?:快照日期|snapshot date|TTM|fiscal year|口径|metric basis)",
+    re.IGNORECASE,
+)
+
 # Heading patterns for Source Register section.
 HEADING_RE = re.compile(
     r"^#{1,6}\s+.*(?:Source Register|来源注册表)", re.IGNORECASE
@@ -39,6 +51,19 @@ _SECONDARY_TYPES: frozenset[str] = frozenset({
     "SECONDARY_ANALYST",
     "SECONDARY_FEED",
     "SECONDARY",
+})
+
+# Financial data platforms that re-present filed/regulatory data. These are not
+# primary filings, but may support financial snapshots when cited with an inline
+# source-role / metric-basis caveat.
+_FILED_DATA_AGGREGATOR_TYPES: frozenset[str] = frozenset({
+    "FILED_DATA_AGGREGATOR",
+})
+
+# Portals/compilations mixing analyst estimates, market data, news, and/or auto
+# aggregation. Treat as secondary-like for confirmed-label checks.
+_ANALYST_PORTAL_COMPILATION_TYPES: frozenset[str] = frozenset({
+    "ANALYST_PORTAL_COMPILATION",
 })
 
 # Primary company source types that need a self-reporting caveat.
@@ -95,6 +120,25 @@ _FREETEXT_TYPE_MAP: dict[str, str] = {
     "招股说明书": "PRIMARY_FILING",
     "年报": "PRIMARY_FILING",
     "年度报告": "PRIMARY_FILING",
+    # Financial filed-data aggregators
+    "reuters lseg filed data": "FILED_DATA_AGGREGATOR",
+    "lseg filed data": "FILED_DATA_AGGREGATOR",
+    "reuters filed data": "FILED_DATA_AGGREGATOR",
+    "bloomberg filed data": "FILED_DATA_AGGREGATOR",
+    "wind filed data": "FILED_DATA_AGGREGATOR",
+    "choice filed data": "FILED_DATA_AGGREGATOR",
+    "东方财富 choice api filed data": "FILED_DATA_AGGREGATOR",
+    "stockanalysis filed data": "FILED_DATA_AGGREGATOR",
+    "macrotrends filed data": "FILED_DATA_AGGREGATOR",
+    "filed data aggregator": "FILED_DATA_AGGREGATOR",
+    "聚合数据": "FILED_DATA_AGGREGATOR",
+    "财务聚合数据": "FILED_DATA_AGGREGATOR",
+    # Analyst/market/news portal compilations
+    "finviz": "ANALYST_PORTAL_COMPILATION",
+    "seeking alpha": "ANALYST_PORTAL_COMPILATION",
+    "yahoo finance": "ANALYST_PORTAL_COMPILATION",
+    "analyst portal compilation": "ANALYST_PORTAL_COMPILATION",
+    "金融门户": "ANALYST_PORTAL_COMPILATION",
     # Blog / media
     "技术博客": "SECONDARY_MEDIA",
     "官方博客": "PRIMARY_COMPANY",
@@ -308,6 +352,24 @@ def _is_unconfirmed_type(source_type: str) -> bool:
     return _is_type_in(source_type, _UNCONFIRMED_TYPES)
 
 
+def _is_filed_data_aggregator_type(source_type: str) -> bool:
+    """Check if a source type is a filed/regulatory data aggregator."""
+    return _is_type_in(source_type, _FILED_DATA_AGGREGATOR_TYPES)
+
+
+def _is_analyst_portal_compilation_type(source_type: str) -> bool:
+    """Check if a source type is an analyst/market/news portal compilation."""
+    return _is_type_in(source_type, _ANALYST_PORTAL_COMPILATION_TYPES)
+
+
+def _has_filed_data_aggregator_caveat(sentence: str) -> bool:
+    """Return True when sentence has both source-role and metric-basis notes."""
+    return bool(
+        FILED_DATA_AGGREGATOR_ROLE_RE.search(sentence)
+        and FILED_DATA_AGGREGATOR_BASIS_RE.search(sentence)
+    )
+
+
 def _source_ref_re(source_id: str) -> re.Pattern:
     """Build a regex to find a source ID reference (word-boundary match)."""
     return re.compile(r"\b" + re.escape(source_id) + r"\b")
@@ -371,7 +433,8 @@ def _is_unknown_type(source_type: str) -> bool:
 
     Returns True if the type is not secondary, not primary-company, and not a
     recognized exempt type (PRIMARY_FILING, PRIMARY_DEV, INFERRED, UNCONFIRMED,
-    WEAK_SIGNAL, TRANSCRIPT).
+    WEAK_SIGNAL, TRANSCRIPT, FILED_DATA_AGGREGATOR,
+    ANALYST_PORTAL_COMPILATION).
 
     Note: _is_secondary_type and _is_primary_company_type are checked first
     by the caller (check_source_consistency's elif chain). The checks here
@@ -386,10 +449,15 @@ def _is_unknown_type(source_type: str) -> bool:
         "PRIMARY_FILING", "PRIMARY_DEV", "INFERRED",
         "UNCONFIRMED", "WEAK_SIGNAL", "TRANSCRIPT",
         "PRIMARY_INSTITUTION", "CROWDSOURCED",
+        "FILED_DATA_AGGREGATOR", "ANALYST_PORTAL_COMPILATION",
     })
     if _is_secondary_type(source_type):
         return False
     if _is_primary_company_type(source_type):
+        return False
+    if _is_filed_data_aggregator_type(source_type):
+        return False
+    if _is_analyst_portal_compilation_type(source_type):
         return False
     if upper in _KNOWN_OTHER_TYPES:
         return False
@@ -405,7 +473,10 @@ def check_source_consistency(text: str, strict: bool = False) -> list[str]:
     3. Primary company sources must have a self-reporting caveat nearby.
     4. Crowdsourced/tertiary sources must not be referenced with confirmed labels.
     5. Unconfirmed/rumor/leak sources must not be referenced with confirmed labels.
-    6. Unknown source types generate a warning (or error in strict mode).
+    6. Analyst portal compilations must not be referenced with confirmed labels.
+    7. Filed-data aggregators require a same-sentence caveat when referenced
+       with confirmed labels.
+    8. Unknown source types generate a warning (or error in strict mode).
 
     When strict=True, unknown source types cause errors (not just warnings).
     """
@@ -488,8 +559,38 @@ def check_source_consistency(text: str, strict: bool = False) -> list[str]:
                         f"but referenced with confirmed label: {sent[:100]}"
                     )
 
+        elif _is_analyst_portal_compilation_type(norm_type):
+            # Check 6: Analyst/market/news portal compilations are secondary-like.
+            for sent in sentences:
+                if not ref_re.search(sent):
+                    continue
+                if CONFIRMED_LABEL_RE.search(sent):
+                    errors.append(
+                        f"source {source_id} ({source_type}) is an analyst "
+                        f"portal compilation but referenced with confirmed "
+                        f"label: {sent[:100]}"
+                    )
+
+        elif _is_filed_data_aggregator_type(norm_type):
+            # Check 7: Filed-data aggregators can support confirmed snapshots only
+            # when the same sentence marks source role or metric/snapshot basis.
+            for sent in sentences:
+                if not ref_re.search(sent):
+                    continue
+                has_confirmed_label = CONFIRMED_LABEL_RE.search(sent)
+                if (
+                    has_confirmed_label
+                    and not _has_filed_data_aggregator_caveat(sent)
+                ):
+                    errors.append(
+                        f"source {source_id} ({source_type}) is a filed-data "
+                        f"aggregator with confirmed label but lacks same-sentence "
+                        f"filed-data/aggregation/snapshot/metric-basis caveat: "
+                        f"{sent[:100]}"
+                    )
+
         elif _is_unknown_type(norm_type):
-            # Check 6: Unknown source type detection.
+            # Check 8: Unknown source type detection.
             msg = (
                 f"source {source_id} has unrecognized source type "
                 f"'{source_type}': map to a canonical type or correct the entry"

--- a/scripts/validate_source_label_consistency.py
+++ b/scripts/validate_source_label_consistency.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 # Confirmed label patterns — these should NOT be used with secondary sources.
 CONFIRMED_LABEL_RE = re.compile(
-    r"\[(?:确认事实|CONF|Confirmed|确认)\]", re.IGNORECASE
+    r"\[(?:已确认事实|确认事实|CONF|Confirmed|确认)\]", re.IGNORECASE
 )
 
 # Self-reporting caveat patterns required for primary company sources.
@@ -31,11 +31,12 @@ CAVEAT_RE = re.compile(
 # 1) source-role language (aggregated / non-original / filed-data platform), and
 # 2) metric or snapshot basis (date, TTM/FY,口径). A bare "TTM" is not enough.
 FILED_DATA_AGGREGATOR_ROLE_RE = re.compile(
-    r"(?:filed data|filed-data|aggregator|aggregated|聚合数据|非原始披露)",
+    r"(?:filed data|filed-data|aggregator|aggregated|aggregation|aggregate|"
+    r"non-original|聚合数据|非原始披露)",
     re.IGNORECASE,
 )
 FILED_DATA_AGGREGATOR_BASIS_RE = re.compile(
-    r"(?:快照日期|snapshot date|TTM|fiscal year|口径|metric basis)",
+    r"(?:快照日期|snapshot date|TTM|fiscal year|FY\d{4}|口径|metric basis)",
     re.IGNORECASE,
 )
 

--- a/tests/test_issue_350_contracts.py
+++ b/tests/test_issue_350_contracts.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Structural contract tests for Issue #350: financial aggregator source taxonomy."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def read(path: str) -> str:
+    with open(os.path.join(REPO_ROOT, path), "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def git_ls_files(pattern: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "ls-files", pattern],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def tracked_file_exists(path: str) -> bool:
+    return path in git_ls_files(path)
+
+
+def test_source_traceability_mentions_new_financial_aggregator_taxonomy() -> None:
+    text = read("references/source-traceability-and-claim-citation.md")
+    required = [
+        "FILED_DATA_AGGREGATOR",
+        "ANALYST_PORTAL_COMPILATION",
+        "Reuters LSEG",
+        "Bloomberg",
+        "Wind",
+        "Choice",
+        "StockAnalysis",
+        "Macrotrends",
+        "Finviz",
+        "Seeking Alpha",
+        "Yahoo Finance",
+        "snapshot date",
+        "metric basis",
+    ]
+    missing = [token for token in required if token not in text]
+    assert not missing, f"source taxonomy missing tokens: {missing}"
+
+
+def test_conflict_resolution_distinguishes_filed_aggregators_from_portals() -> None:
+    text = read("references/data-conflict-resolution.md")
+    assert "FILED_DATA_AGGREGATOR" in text
+    assert "ANALYST_PORTAL_COMPILATION" in text
+    assert re.search(r"Tier\s*2.*FILED_DATA_AGGREGATOR", text, re.DOTALL), (
+        "Tier 2 filed/regulatory aggregators should be mapped explicitly"
+    )
+    assert re.search(r"Tier\s*5.*ANALYST_PORTAL_COMPILATION", text, re.DOTALL), (
+        "Analyst portal compilations should be mapped as secondary-like"
+    )
+
+
+def test_quantitative_role_labeling_requires_aggregator_role_notes() -> None:
+    text = read("references/quantitative-role-labeling.md")
+    required = [
+        "FILED_DATA_AGGREGATOR",
+        "aggregated filed data",
+        "snapshot date",
+        "TTM",
+        "metric basis",
+        "ANALYST_PORTAL_COMPILATION",
+    ]
+    missing = [token for token in required if token not in text]
+    assert not missing, f"quantitative role labeling missing tokens: {missing}"
+
+
+def test_listed_company_checklist_mentions_aggregator_guardrails() -> None:
+    text = read("checklists/listed-company-report.md")
+    required = [
+        "FILED_DATA_AGGREGATOR",
+        "ANALYST_PORTAL_COMPILATION",
+        "snapshot date",
+        "metric basis",
+        "confirmed",
+    ]
+    missing = [token for token in required if token not in text]
+    assert not missing, f"listed-company checklist missing tokens: {missing}"
+
+
+def test_no_tracked_markdown_references_missing_tsmc_aggregator_eval() -> None:
+    # Build the legacy path from parts so this regression test does not itself
+    # contain a literal reference to the missing eval artifact.
+    missing_eval = "/".join([
+        "evals",
+        "cases",
+        "tsmc-listed-company-aggregator-source-and-moat-case.md",
+    ])
+    if tracked_file_exists(missing_eval):
+        return
+
+    offenders: list[str] = []
+    for path in git_ls_files("*.md") + git_ls_files("**/*.md"):
+        full = os.path.join(REPO_ROOT, path)
+        if not os.path.exists(full):
+            continue
+        if missing_eval in read(path):
+            offenders.append(path)
+
+    assert not offenders, (
+        f"tracked markdown references missing eval {missing_eval}: {offenders}"
+    )
+
+
+def main() -> int:
+    tests = [
+        test_source_traceability_mentions_new_financial_aggregator_taxonomy,
+        test_conflict_resolution_distinguishes_filed_aggregators_from_portals,
+        test_quantitative_role_labeling_requires_aggregator_role_notes,
+        test_listed_company_checklist_mentions_aggregator_guardrails,
+        test_no_tracked_markdown_references_missing_tsmc_aggregator_eval,
+    ]
+    failures: list[str] = []
+    for test in tests:
+        try:
+            test()
+            print(f"  PASS  {test.__name__}")
+        except AssertionError as exc:
+            failures.append(test.__name__)
+            print(f"  FAIL  {test.__name__}: {exc}")
+
+    if failures:
+        print(f"\n{len(failures)} test(s) failed: {', '.join(failures)}")
+        return 1
+
+    print(f"\nAll {len(tests)} tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_issue_350_contracts.py
+++ b/tests/test_issue_350_contracts.py
@@ -103,7 +103,7 @@ def test_no_tracked_markdown_references_missing_tsmc_aggregator_eval() -> None:
         return
 
     offenders: list[str] = []
-    for path in git_ls_files("*.md") + git_ls_files("**/*.md"):
+    for path in git_ls_files("*.md"):
         full = os.path.join(REPO_ROOT, path)
         if not os.path.exists(full):
             continue


### PR DESCRIPTION
## Summary
- Add financial source taxonomy for `FILED_DATA_AGGREGATOR` and `ANALYST_PORTAL_COMPILATION` across source-traceability, data-conflict, quantitative-role, and listed-company checklist docs.
- Extend `validate_source_label_consistency.py` so filed-data aggregators require same-sentence role + metric/snapshot basis for confirmed labels, while analyst/portal compilations are secondary-like.
- Add Issue #350 contract tests, CI wiring for `tests/**`, and remove references to the missing TSMC aggregator eval artifact.

## Test Plan
- [x] `python3 scripts/test_source_label_consistency.py`
- [x] `python3 tests/test_issue_350_contracts.py`
- [x] `python3 -m py_compile scripts/*.py`
- [x] `python3 scripts/test_eval_index.py`
- [x] Full CI quick-job command chain from `.github/workflows/ci.yml`
- [x] Smoke subset: `python3 scripts/test_remote_block.py`, `python3 scripts/test_cjk_pdf_pipeline.py`, HTML sanitization check

Toward #350