### PR TITLE
feat(#362): add route manifest as single source of truth with drift detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
       - run: python3 scripts/test_quantitative_role_audit.py
       - run: python3 scripts/test_source_label_consistency.py
       - run: python3 tests/test_issue_350_contracts.py
+      - run: python3 scripts/validate_route_manifest.py
+      - run: python3 tests/test_route_manifest.py
       - run: python3 scripts/test_audit_report.py
       - run: python3 scripts/test_issue_pr_acceptance.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
       - 'checklists/**'
       - 'references/**'
       - 'evals/**'
+      - 'ROUTING-MATRIX.md'
       - 'requirements.txt'
       - '.github/workflows/ci.yml'
   push:
@@ -22,6 +23,7 @@ on:
       - 'checklists/**'
       - 'references/**'
       - 'evals/**'
+      - 'ROUTING-MATRIX.md'
       - 'requirements.txt'
       - '.github/workflows/ci.yml'
   workflow_dispatch:

--- a/schemas/route-manifest.json
+++ b/schemas/route-manifest.json
@@ -1,0 +1,103 @@
+{
+  "version": 1,
+  "description": "Single source of truth for deep-research route identity and execution bindings. Each route maps to a ROUTING-MATRIX.md section, _ROUTE_ALIASES entries, and ROUTE_VALIDATORS keys. DO NOT edit without syncing code and docs.",
+  "last_reviewed": "2026-07-22",
+  "routes": [
+    {
+      "id": "provider-selection",
+      "display_name": "Provider / Vendor Selection",
+      "category": "specialized",
+      "aliases": ["provider selection", "vendor selection", "provider / vendor selection"],
+      "required_audits": ["option-selection-final-audit", "source-traceability", "final-audit"],
+      "hard_fail_keywords": ["stale anchor products", "accessibility as side note", "vendor overview instead of choice memo"]
+    },
+    {
+      "id": "market-entry",
+      "display_name": "Market Entry / Regional Expansion",
+      "category": "specialized",
+      "aliases": ["market entry", "regional expansion", "market entry / regional expansion"],
+      "required_audits": ["option-selection-final-audit", "source-traceability", "final-audit"],
+      "hard_fail_keywords": ["generic market overview", "country notes without unified comparison", "expansion without hard gates", "hub/beachhead/expansion collapsed", "skips country-competition stage", "inconsistent country diligence", "recommendation-constraint mismatch"]
+    },
+    {
+      "id": "market-outlook",
+      "display_name": "Market Outlook / Industry Evolution",
+      "category": "specialized",
+      "aliases": ["market outlook", "industry evolution", "market outlook / industry evolution"],
+      "required_audits": ["market-outlook-audit", "forward-looking-claims", "source-traceability", "final-audit"],
+      "hard_fail_keywords": ["industry overview instead of outlook", "mixed facts and scenario assumptions", "forecasts without scenario structure", "hidden stakeholder implications", "wrong route for ranking/selection tasks"]
+    },
+    {
+      "id": "competitive-positioning",
+      "display_name": "First-tier / Top-tier / Competitive Positioning",
+      "category": "specialized",
+      "aliases": ["first-tier", "top-tier", "competitive positioning", "first-tier / top-tier / competitive positioning"],
+      "required_audits": ["source-traceability", "final-audit"],
+      "hard_fail_keywords": ["loose tier labels", "dimensions collapsed into prestige", "unequally treated evidence types"]
+    },
+    {
+      "id": "constrained-choice",
+      "display_name": "Constrained Choice / Shortlist / Option Selection",
+      "category": "specialized",
+      "aliases": ["constrained choice", "constrained choice / shortlist", "shortlist", "option selection", "constrained choice / shortlist / option selection"],
+      "required_audits": ["option-selection-final-audit", "final-audit"],
+      "hard_fail_keywords": ["recommendation without shortlist", "unlabeled numbers", "descriptive blurbs instead of choice memo", "background-first drift"]
+    },
+    {
+      "id": "regulatory-analysis",
+      "display_name": "Regulatory / Policy Impact Analysis",
+      "category": "specialized",
+      "aliases": ["regulatory analysis", "regulatory / policy impact", "regulatory / policy impact analysis"],
+      "required_audits": ["regulatory-analysis-audit", "source-traceability", "final-audit"],
+      "hard_fail_keywords": ["regulations without business impact", "regulatory text confused with media", "false precision on timing", "ignored enforcement reality", "jurisdictions treated as equivalent", "binary risk instead of graduated"]
+    },
+    {
+      "id": "equipment-selection",
+      "display_name": "Equipment Selection / Procurement / Home-server Planning",
+      "category": "specialized",
+      "aliases": ["equipment selection", "equipment selection / procurement", "equipment selection / procurement / home-server planning", "procurement", "home-server planning", "nas", "nas / home server", "homelab"],
+      "required_audits": ["option-selection-final-audit", "final-audit"],
+      "hard_fail_keywords": ["hardware overview instead of procurement", "budget without inclusion assumptions", "hardware and system not bound", "operating costs as side notes", "missing workload segmentation", "benchmark performance without method disclosure"]
+    },
+    {
+      "id": "technical-deep-dive",
+      "display_name": "Technical Deep-dive / Architecture Analysis",
+      "category": "specialized",
+      "aliases": ["technical deep-dive", "architecture analysis", "technical-deep-dive"],
+      "required_audits": ["technical-analysis-audit", "source-traceability", "final-audit"],
+      "hard_fail_keywords": ["technical survey without judgment", "compares architectures without dimensions", "stale technical state", "vendor claims as confirmed facts", "feasibility without viability evidence", "roadmaps without announced vs shipped separation"]
+    },
+    {
+      "id": "listed-company",
+      "display_name": "Listed Company / Investment-style Research",
+      "category": "specialized",
+      "aliases": ["listed company", "investment-style research", "listed company / investment-style research"],
+      "required_audits": ["listed-company-report", "source-traceability", "final-audit"],
+      "hard_fail_keywords": ["mixed reported and forward estimates", "undated financial numbers", "missing research anchor", "missing market snapshot", "market-position without scope", "valuation substitutes for business evidence", "strong claims without evidence", "mixed moat/monopoly/scarcity"]
+    },
+    {
+      "id": "startup-evaluation",
+      "display_name": "Private Company / Startup Evaluation",
+      "category": "specialized",
+      "aliases": ["startup", "private company", "startup evaluation", "private company evaluation", "startup / private company evaluation"],
+      "required_audits": ["startup-company-report", "source-traceability", "final-audit"],
+      "hard_fail_keywords": ["listed-company valuation for private", "unverified founder claims", "weak financials as audited", "unlabeled source reliability", "mini listed-company analysis"]
+    },
+    {
+      "id": "academic-review",
+      "display_name": "Academic / Literature Review",
+      "category": "specialized",
+      "aliases": ["academic review", "literature review", "academic / literature review"],
+      "required_audits": ["academic-analysis-audit", "source-traceability", "final-audit"],
+      "hard_fail_keywords": ["preprints as peer-reviewed", "cherry-picked papers", "causation from observation", "p-values without effect sizes", "outdated research", "unlabeled venue status", "ignored publication bias"]
+    },
+    {
+      "id": "shared-workflow",
+      "display_name": "Shared-workflow (no specialized route selected)",
+      "category": "shared-workflow",
+      "aliases": ["shared-workflow", "shared workflow", "shared-workflow (no specialized route selected)"],
+      "required_audits": ["workflow-spine-audit", "final-audit"],
+      "hard_fail_keywords": ["specialized route escape hatch misuse", "missing workflow-spine-audit"]
+    }
+  ]
+}

--- a/schemas/route-manifest.json
+++ b/schemas/route-manifest.json
@@ -17,7 +17,7 @@
       "category": "specialized",
       "aliases": ["market entry", "regional expansion", "market entry / regional expansion"],
       "required_audits": ["option-selection-final-audit", "source-traceability", "final-audit"],
-      "hard_fail_keywords": ["generic market overview", "country notes without unified comparison", "expansion without hard gates", "hub/beachhead/expansion collapsed", "skips country-competition stage", "inconsistent country diligence", "recommendation-constraint mismatch"]
+      "hard_fail_keywords": ["generic market overview", "country notes without unified comparison", "expansion without hard gates", "collapses hub beachhead expansion", "skips country-competition stage", "inconsistent country diligence", "recommendation-constraint mismatch"]
     },
     {
       "id": "market-outlook",
@@ -73,7 +73,7 @@
       "category": "specialized",
       "aliases": ["listed company", "investment-style research", "listed company / investment-style research"],
       "required_audits": ["listed-company-report", "source-traceability", "final-audit"],
-      "hard_fail_keywords": ["mixed reported and forward estimates", "undated financial numbers", "missing research anchor", "missing market snapshot", "market-position without scope", "valuation substitutes for business evidence", "strong claims without evidence", "mixed moat/monopoly/scarcity"]
+      "hard_fail_keywords": ["mixed reported and forward estimates", "undated financial numbers", "missing research anchor", "missing market snapshot", "market-position without scope", "valuation substitutes for business evidence", "strong claims without evidence", "mixes monopoly moat scarcity"]
     },
     {
       "id": "startup-evaluation",

--- a/schemas/route-manifest.json
+++ b/schemas/route-manifest.json
@@ -33,7 +33,7 @@
       "category": "specialized",
       "aliases": ["first-tier", "top-tier", "competitive positioning", "first-tier / top-tier / competitive positioning"],
       "required_audits": ["source-traceability", "final-audit"],
-      "hard_fail_keywords": ["loose tier labels", "dimensions collapsed into prestige", "unequally treated evidence types"]
+      "hard_fail_keywords": ["loose tier labels", "dimensions collapsed into prestige", "treats all evidence equally"]
     },
     {
       "id": "constrained-choice",
@@ -57,7 +57,7 @@
       "category": "specialized",
       "aliases": ["equipment selection", "equipment selection / procurement", "equipment selection / procurement / home-server planning", "procurement", "home-server planning", "nas", "nas / home server", "homelab"],
       "required_audits": ["option-selection-final-audit", "final-audit"],
-      "hard_fail_keywords": ["hardware overview instead of procurement", "budget without inclusion assumptions", "hardware and system not bound", "operating costs as side notes", "missing workload segmentation", "benchmark performance without method disclosure"]
+      "hard_fail_keywords": ["hardware overview instead of procurement", "budget without inclusion assumptions", "hardware and system not bound", "operating costs as side notes", "fails to segment workload", "benchmark performance without method disclosure"]
     },
     {
       "id": "technical-deep-dive",

--- a/scripts/audit_report.py
+++ b/scripts/audit_report.py
@@ -89,6 +89,7 @@ ValidatorFn = Callable[..., CheckResult]
 # with whitespace collapsed, so we can match regardless of formatting.
 _ROUTE_ALIASES: dict[str, str] = {
     "technical deep-dive": "technical-deep-dive",
+    "architecture analysis": "technical-deep-dive",
     "listed company / investment-style research": "listed-company",
     "listed company": "listed-company",
     "investment-style research": "listed-company",
@@ -120,6 +121,7 @@ _ROUTE_ALIASES: dict[str, str] = {
     "home-server planning": "equipment-selection",
     "nas / home server": "equipment-selection",
     "homelab": "equipment-selection",
+    "nas": "equipment-selection",
     # ── Startup / Private Company Evaluation ─────────────────
     "startup / private company evaluation": "startup-evaluation",
     "startup evaluation": "startup-evaluation",
@@ -131,6 +133,10 @@ _ROUTE_ALIASES: dict[str, str] = {
     "first-tier": "competitive-positioning",
     "top-tier": "competitive-positioning",
     "competitive positioning": "competitive-positioning",
+    # ── Academic / Literature Review ─────────────────────────
+    "academic / literature review": "academic-review",
+    "academic review": "academic-review",
+    "literature review": "academic-review",
     # ── Shared-workflow (generic fallback) ───────────────────
     "shared-workflow (no specialized route selected)": "shared-workflow",
     "shared-workflow": "shared-workflow",

--- a/scripts/validate_route_manifest.py
+++ b/scripts/validate_route_manifest.py
@@ -4,10 +4,11 @@ Route manifest drift detector.
 
 Validates that schemas/route-manifest.json is consistent with:
 1. _ROUTE_ALIASES canonical targets in scripts/audit_report.py
-2. ROUTE_VALIDATORS keys in scripts/audit_report.py
+2. ROUTE_VALIDATORS keys + non-empty validator lists in scripts/audit_report.py
 3. Required audit checklist files in checklists/
-4. ROUTING-MATRIX.md route headings (count + display name comparison)
+4. ROUTING-MATRIX.md route headings (count, display name, audit lists, hard-fail keywords)
 5. All manifest aliases are resolvable via _normalize_route logic
+6. evals/INDEX.md Primary/Secondary route column values
 
 Exit codes:
     0 = manifest is consistent with code/docs
@@ -130,6 +131,68 @@ def _parse_route_validator_keys(source: str) -> set[str]:
 def _parse_routing_matrix_headings(text: str) -> list[str]:
     """Extract route heading display names from ROUTING-MATRIX.md."""
     return re.findall(r"^## Route: (.+)$", text, re.M)
+
+
+def _parse_routing_matrix_route_sections(text: str) -> dict[str, str]:
+    """Split ROUTING-MATRIX.md into per-route sections by '## Route: ' headings.
+
+    Returns {normalized_heading: section_text}.  Normalized keys use
+    _normalize_alias so they can be joined against manifest display_names.
+    """
+    sections: dict[str, str] = {}
+    parts = re.split(r"^## Route: ", text, flags=re.M)
+    for part in parts[1:]:  # Skip content before first ## Route:
+        heading_end = part.index("\n") if "\n" in part else len(part)
+        heading = part[:heading_end].strip()
+        body = part[heading_end:]
+        sections[_normalize_alias(heading)] = body
+    return sections
+
+
+def _parse_audits_from_matrix_section(section: str) -> list[str]:
+    """Extract audit checklist names from a ROUTING-MATRIX.md route section.
+
+    Looks for the ### Audit block and extracts `checklists/xxx.md` references.
+    """
+    audit_match = re.search(
+        r"### Audit\n((?:\s*-.*\n?)+)",
+        section,
+    )
+    if not audit_match:
+        return []
+    audit_lines = audit_match.group(1).strip().split("\n")
+    audits: list[str] = []
+    for line in audit_lines:
+        m = re.search(r"`checklists/([^`]+)\.md`", line)
+        if m:
+            audits.append(m.group(1).strip())
+    return audits
+
+
+def _parse_matrix_route_name_to_id(headings: list[str], manifest_routes: dict[str, dict]) -> dict[str, str]:
+    """Map normalized ROUTING-MATRIX.md headings to manifest route IDs."""
+    mapping: dict[str, str] = {}
+    for heading in headings:
+        norm = _normalize_alias(heading)
+        for route in manifest_routes.values():
+            if _normalize_alias(route["display_name"]) == norm:
+                mapping[norm] = route["id"]
+                break
+    return mapping
+
+
+# ── Known cross-cutting discipline names (from evals/INDEX.md) ───────────────
+
+_CROSS_CUTTING_DISCIPLINES: set[str] = {
+    "source-traceability", "current-state", "forward-looking",
+    "delivery-cleanliness", "decision-utility", "scope-completeness",
+    "quantitative-role", "finance", "product-ranking", "ranking",
+    "adversarial-input", "pdf-rendering", "pdf-build", "pdf-layout",
+    "listing-status", "company-status", "company-status-boundary",
+    "corporate-status", "valuation-methodology", "reporting-period",
+    "comparative-analysis", "external-channel-preflight",
+    "private-company", "listed-company-report",
+}
 
 
 # ── Validation logic ─────────────────────────────────────────────────────────
@@ -271,7 +334,13 @@ def validate(path: Path | None = None) -> int:
                 )
 
     # ═══ Check 7: ROUTING-MATRIX.md route count + display name comparison ════
-    if ROUTING_MATRIX.is_file():
+    # P1-2a fix: require ROUTING-MATRIX.md, error if missing
+    if not ROUTING_MATRIX.is_file():
+        errors.append(
+            f"ROUTING-MATRIX.md not found at {ROUTING_MATRIX} — "
+            f"cannot verify manifest consistency"
+        )
+    else:
         matrix_text = ROUTING_MATRIX.read_text(encoding="utf-8")
         matrix_headings = _parse_routing_matrix_headings(matrix_text)
         specialized_in_manifest = sum(
@@ -296,14 +365,67 @@ def validate(path: Path | None = None) -> int:
             missing_in_matrix = set(manifest_norms.keys()) - set(matrix_norms.keys())
 
             if missing_in_manifest:
-                warnings.append(
+                errors.append(
                     f"ROUTING-MATRIX.md headings not in manifest: "
                     f"{', '.join(sorted(matrix_norms[h] for h in missing_in_manifest))}"
                 )
             if missing_in_matrix:
-                warnings.append(
+                errors.append(
                     f"Manifest display_names not in ROUTING-MATRIX.md: "
                     f"{', '.join(sorted(manifest_norms[h] for h in missing_in_matrix))}"
+                )
+
+        # ═══ Check 7b (P1-2b): Audit list per route comparison ═══════════════
+        matrix_sections = _parse_routing_matrix_route_sections(matrix_text)
+        name_to_id = _parse_matrix_route_name_to_id(matrix_headings, manifest_routes)
+
+        for heading_norm, route_id in name_to_id.items():
+            section = matrix_sections.get(heading_norm, "")
+            matrix_audits = set(_parse_audits_from_matrix_section(section))
+            manifest_audits = set(manifest_routes[route_id].get("required_audits", []))
+
+            if matrix_audits != manifest_audits:
+                missing = manifest_audits - matrix_audits
+                extra = matrix_audits - manifest_audits
+                parts: list[str] = []
+                if missing:
+                    parts.append(f"manifest has but matrix missing: {sorted(missing)}")
+                if extra:
+                    parts.append(f"matrix has but manifest missing: {sorted(extra)}")
+                errors.append(
+                    f"Route '{route_id}': audit list mismatch between "
+                    f"manifest and ROUTING-MATRIX.md — {'; '.join(parts)}"
+                )
+
+        # ═══ Check 7c (P1-2c): hard_fail_keywords present in matrix section ══
+        for heading_norm, route_id in name_to_id.items():
+            section = matrix_sections.get(heading_norm, "")
+            # Find the Hard fail subsection — capture from "### Hard fail"
+            # to the next "## " or "### " or end of section
+            hf_match = re.search(
+                r"### Hard fail\n(.*?)(?=\n## |\n### |\Z)",
+                section,
+                re.DOTALL,
+            )
+            if not hf_match:
+                warnings.append(
+                    f"Route '{route_id}': no '### Hard fail' section "
+                    f"found in ROUTING-MATRIX.md"
+                )
+                continue
+            hf_text = hf_match.group(1).lower()
+            keywords = manifest_routes[route_id].get("hard_fail_keywords", [])
+            missing_keywords: list[str] = []
+            for kw in keywords:
+                sig_words = [w for w in kw.lower().split() if len(w) > 3]
+                if not sig_words:
+                    continue
+                if not any(w in hf_text for w in sig_words):
+                    missing_keywords.append(kw)
+            if missing_keywords:
+                warnings.append(
+                    f"Route '{route_id}': hard_fail_keywords not found in "
+                    f"ROUTING-MATRIX.md hard-fail section: {missing_keywords}"
                 )
 
     # ═══ Check 8: Manifest required fields per route ══════════════════════════
@@ -329,6 +451,56 @@ def validate(path: Path | None = None) -> int:
                     f"'{all_keywords[kw_lower]}' and '{route['id']}'"
                 )
             all_keywords[kw_lower] = route["id"]
+
+    # ═══ Check 10 (P2-1): evals/INDEX.md Primary/Secondary route columns ═════
+    EVALS_INDEX = ROOT / "evals" / "INDEX.md"
+    if EVALS_INDEX.is_file():
+        index_text = EVALS_INDEX.read_text(encoding="utf-8")
+        known_disciplines = _CROSS_CUTTING_DISCIPLINES | manifest_ids
+        for line in index_text.splitlines():
+            if not line.startswith("| `evals/cases/"):
+                continue
+            cells = [c.strip().strip("`") for c in line.strip("|").split("|")]
+            if len(cells) >= 3:
+                # cells[0] = Path, cells[1] = Primary route, cells[2] = Secondary route
+                for col_idx, col_name in [(1, "Primary"), (2, "Secondary")]:
+                    val = cells[col_idx] if col_idx < len(cells) else ""
+                    if not val or val == "-":
+                        continue
+                    # The value may be a case file path or a discipline name
+                    if "/" in val or val.endswith(".md"):
+                        continue  # file path, not a route name
+                    if val not in known_disciplines:
+                        warnings.append(
+                            f"evals/INDEX.md: '{val}' in {col_name} route column "
+                            f"for {cells[0]} is not a known canonical route or "
+                            f"cross-cutting discipline"
+                        )
+
+    # ═══ Check 11 (P2-2): ROUTE_VALIDATORS entries must be non-empty ═════════
+    # Parse the validator lists to verify each has at least one entry
+    vblock_match = re.search(
+        r"ROUTE_VALIDATORS\s*:\s*dict\[str,\s*list\[ValidatorFn\]\]\s*=\s*\{(.+?)\n\s*\}",
+        audit_source,
+        re.DOTALL,
+    )
+    if vblock_match:
+        vblock = vblock_match.group(1)
+        empty_routes: list[str] = []
+        for route_key in validator_keys:
+            # Each entry looks like: "route-key": [\n  validator_fn,\n],
+            # Check that the list between [ and ] contains at least one entry
+            pattern = rf'"{re.escape(route_key)}"\s*:\s*\[(.*?)\]'
+            m = re.search(pattern, vblock, re.DOTALL)
+            if m:
+                list_body = m.group(1).strip()
+                if not list_body or list_body == "":
+                    empty_routes.append(route_key)
+        if empty_routes:
+            errors.append(
+                f"ROUTE_VALIDATORS entries are empty for: "
+                f"{', '.join(sorted(empty_routes))}"
+            )
 
     # ── Output ──────────────────────────────────────────────────────────────
     if errors:

--- a/scripts/validate_route_manifest.py
+++ b/scripts/validate_route_manifest.py
@@ -420,12 +420,15 @@ def validate(path: Path | None = None) -> int:
                 sig_words = [w for w in kw.lower().split() if len(w) > 3]
                 if not sig_words:
                     continue
-                if not any(w in hf_text for w in sig_words):
+                matched = sum(1 for w in sig_words if w in hf_text)
+                # Require >50% of significant words to match; <50% = probable deletion
+                if matched == 0 or (len(sig_words) >= 3 and matched < len(sig_words) / 2):
                     missing_keywords.append(kw)
             if missing_keywords:
-                warnings.append(
-                    f"Route '{route_id}': hard_fail_keywords not found in "
-                    f"ROUTING-MATRIX.md hard-fail section: {missing_keywords}"
+                errors.append(
+                    f"Route '{route_id}': hard_fail_keywords with insufficient "
+                    f"match in ROUTING-MATRIX.md hard-fail section: "
+                    f"{missing_keywords}"
                 )
 
     # ═══ Check 8: Manifest required fields per route ══════════════════════════
@@ -467,15 +470,21 @@ def validate(path: Path | None = None) -> int:
                     val = cells[col_idx] if col_idx < len(cells) else ""
                     if not val or val == "-":
                         continue
-                    # The value may be a case file path or a discipline name
-                    if "/" in val or val.endswith(".md"):
-                        continue  # file path, not a route name
-                    if val not in known_disciplines:
-                        warnings.append(
-                            f"evals/INDEX.md: '{val}' in {col_name} route column "
-                            f"for {cells[0]} is not a known canonical route or "
-                            f"cross-cutting discipline"
-                        )
+                    # Skip only actual eval case file paths
+                    if val.startswith("evals/cases/") or val.endswith(".md"):
+                        continue
+                    # Split on '/' for multi-discipline values
+                    # (e.g., "current-state/source-traceability")
+                    parts = [p.strip() for p in val.split("/")]
+                    for part in parts:
+                        if not part or part == "-":
+                            continue
+                        if part not in known_disciplines:
+                            warnings.append(
+                                f"evals/INDEX.md: '{part}' in {col_name} route "
+                                f"column for {cells[0]} is not a known canonical "
+                                f"route or cross-cutting discipline"
+                            )
 
     # ═══ Check 11 (P2-2): ROUTE_VALIDATORS entries must be non-empty ═════════
     # Parse the validator lists to verify each has at least one entry

--- a/scripts/validate_route_manifest.py
+++ b/scripts/validate_route_manifest.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""
+Route manifest drift detector.
+
+Validates that schemas/route-manifest.json is consistent with:
+1. _ROUTE_ALIASES canonical targets in scripts/audit_report.py
+2. ROUTE_VALIDATORS keys in scripts/audit_report.py
+3. Required audit checklist files in checklists/
+4. ROUTING-MATRIX.md route headings (count + display name comparison)
+5. All manifest aliases are resolvable via _normalize_route logic
+
+Exit codes:
+    0 = manifest is consistent with code/docs
+    1 = non-blocking warnings
+    2 = blocking drift detected
+
+Usage:
+    python3 scripts/validate_route_manifest.py [--manifest schemas/route-manifest.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = ROOT / "schemas" / "route-manifest.json"
+AUDIT_REPORT = ROOT / "scripts" / "audit_report.py"
+ROUTING_MATRIX = ROOT / "ROUTING-MATRIX.md"
+CHECKLISTS_DIR = ROOT / "checklists"
+
+EXIT_OK = 0
+EXIT_WARN = 1
+EXIT_FAIL = 2
+
+
+# ── Normalization helpers ─────────────────────────────────────────────────────
+
+
+def _normalize_alias(name: str) -> str:
+    """Normalize a display name or alias for comparison.
+
+    Lowercase, collapse whitespace, strip trailing parenthetical notes.
+    Mirrors the behavior of _normalize_route in audit_report.py.
+    """
+    normalized = " ".join(name.strip().lower().split())
+    no_paren = re.sub(r"\s*\([^)]*\)\s*$", "", normalized).strip()
+    return no_paren if no_paren else normalized
+
+
+def _resolve_via_routing(
+    name: str,
+    alias_map: dict[str, str],
+    canonical_ids: set[str],
+) -> tuple[str | None, bool]:
+    """Simulate _normalize_route behavior from audit_report.py.
+
+    Returns (canonical_id, used_fallback).
+    - canonical_id is None if the name cannot resolve to a known canonical ID.
+    - used_fallback is True if the name resolved via space→hyphen fallback
+      (not via explicit _ROUTE_ALIASES entry).
+    """
+    normalized = _normalize_alias(name)
+
+    # 1. Direct alias lookup (exact match in _ROUTE_ALIASES keys)
+    if normalized in alias_map:
+        return alias_map[normalized], False
+
+    # 2. Strip parenthetical notes and retry
+    no_paren = re.sub(r"\s*\([^)]*\)\s*$", "", normalized).strip()
+    if no_paren and no_paren != normalized:
+        if no_paren in alias_map:
+            return alias_map[no_paren], False
+        normalized = no_paren
+
+    # 3. Space→hyphen fallback heuristic
+    fallback = normalized.replace(" ", "-")
+    if fallback in canonical_ids:
+        return fallback, True
+
+    return None, False
+
+
+# ── Parser for audit_report.py source ────────────────────────────────────────
+
+
+def _parse_route_aliases(source: str) -> dict[str, str]:
+    """Extract _ROUTE_ALIASES dict from audit_report.py source.
+
+    Returns {display_name: canonical_id}. Assumes all keys and values are
+    simple string literals (no nested braces in values).
+    """
+    match = re.search(
+        r"_ROUTE_ALIASES\s*:\s*dict\[str,\s*str\]\s*=\s*\{(.+?)\n\s*\}",
+        source,
+        re.DOTALL,
+    )
+    if not match:
+        raise SystemExit(f"ERROR: Cannot find _ROUTE_ALIASES in {AUDIT_REPORT}")
+
+    block = match.group(1)
+    pairs = re.findall(
+        r'"([^"]+)"\s*:\s*"([^"]+)"',
+        block,
+    )
+    if not pairs:
+        raise SystemExit(f"ERROR: No entries found in _ROUTE_ALIASES")
+    return {k.strip(): v.strip() for k, v in pairs}
+
+
+def _parse_route_validator_keys(source: str) -> set[str]:
+    """Extract ROUTE_VALIDATORS keys from audit_report.py source."""
+    match = re.search(
+        r"ROUTE_VALIDATORS\s*:\s*dict\[str,\s*list\[ValidatorFn\]\]\s*=\s*\{(.+?)\n\s*\}",
+        source,
+        re.DOTALL,
+    )
+    if not match:
+        raise SystemExit(f"ERROR: Cannot find ROUTE_VALIDATORS in {AUDIT_REPORT}")
+
+    block = match.group(1)
+    keys = re.findall(r'"([a-z][a-z-]*[a-z])"', block)
+    # Exclude short non-route strings that might accidentally match
+    return {k for k in keys if len(k) > 4}
+
+
+def _parse_routing_matrix_headings(text: str) -> list[str]:
+    """Extract route heading display names from ROUTING-MATRIX.md."""
+    return re.findall(r"^## Route: (.+)$", text, re.M)
+
+
+# ── Validation logic ─────────────────────────────────────────────────────────
+
+
+def _load_manifest(path: Path) -> dict:
+    """Load and validate top-level manifest structure."""
+    try:
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise SystemExit(f"ERROR: Manifest file not found: {path}")
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"ERROR: Invalid JSON in {path}: {e}")
+
+    if "version" not in manifest:
+        raise SystemExit(f"ERROR: Missing 'version' field in {path}")
+    if "routes" not in manifest:
+        raise SystemExit(f"ERROR: Missing 'routes' field in {path}")
+    if not isinstance(manifest["routes"], list):
+        raise SystemExit(f"ERROR: 'routes' must be a list in {path}")
+    return manifest
+
+
+def validate(path: Path | None = None) -> int:
+    """Run full drift validation. Returns exit code."""
+    manifest_path = path or DEFAULT_MANIFEST
+    manifest = _load_manifest(manifest_path)
+
+    if not AUDIT_REPORT.is_file():
+        raise SystemExit(f"ERROR: {AUDIT_REPORT} not found")
+
+    audit_source = AUDIT_REPORT.read_text(encoding="utf-8")
+    alias_map = _parse_route_aliases(audit_source)
+    validator_keys = _parse_route_validator_keys(audit_source)
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    # Extract manifest data
+    manifest_routes: dict[str, dict] = {}
+    manifest_ids: set[str] = set()
+    for route in manifest["routes"]:
+        rid = route["id"]
+        if rid in manifest_routes:
+            errors.append(f"Duplicate route ID in manifest: {rid}")
+        manifest_routes[rid] = route
+        manifest_ids.add(rid)
+
+    # ═══ Check 1: ROUTE_VALIDATORS ↔ manifest bidirectional ═════════════════
+    missing_from_manifest = validator_keys - manifest_ids
+    if missing_from_manifest:
+        errors.append(
+            f"Routes in ROUTE_VALIDATORS but NOT in manifest: "
+            f"{', '.join(sorted(missing_from_manifest))}"
+        )
+
+    missing_from_validators = manifest_ids - validator_keys
+    if missing_from_validators:
+        errors.append(
+            f"Routes in manifest but NOT in ROUTE_VALIDATORS: "
+            f"{', '.join(sorted(missing_from_validators))}"
+        )
+
+    # ═══ Check 2: _ROUTE_ALIASES canonical targets all in manifest ═══════════
+    alias_targets = set(alias_map.values())
+    missing_targets = alias_targets - manifest_ids
+    if missing_targets:
+        errors.append(
+            f"_ROUTE_ALIASES canonical targets not in manifest: "
+            f"{', '.join(sorted(missing_targets))}"
+        )
+
+    # ═══ Check 3: Manifest aliases — no duplicates across routes ═════════════
+    all_aliases_norm: dict[str, str] = {}  # normalized alias → route_id
+    for route in manifest["routes"]:
+        for alias in route.get("aliases", []):
+            norm = _normalize_alias(alias)
+            if norm in all_aliases_norm and all_aliases_norm[norm] != route["id"]:
+                errors.append(
+                    f"Duplicate alias '{alias}' (normalized: '{norm}') "
+                    f"claimed by both '{all_aliases_norm[norm]}' and '{route['id']}'"
+                )
+            all_aliases_norm[norm] = route["id"]
+
+    # ═══ Check 4: Every manifest alias must resolve correctly ════════════════
+    # (This is the strengthened check — catches B1/B2 from code review)
+    for route in manifest["routes"]:
+        route_id = route["id"]
+        has_explicit_match = False
+        for alias in route.get("aliases", []):
+            resolved, used_fallback = _resolve_via_routing(
+                alias, alias_map, manifest_ids
+            )
+            if resolved is None:
+                errors.append(
+                    f"Manifest alias '{alias}' for route '{route_id}' "
+                    f"cannot be resolved via _normalize_route"
+                )
+            elif resolved != route_id:
+                errors.append(
+                    f"Manifest alias '{alias}' for route '{route_id}' "
+                    f"resolves to '{resolved}' — target mismatch"
+                )
+            elif not used_fallback:
+                has_explicit_match = True
+        if not has_explicit_match and route_id != "shared-workflow":
+            warnings.append(
+                f"Route '{route_id}' has no explicit alias in _ROUTE_ALIASES; "
+                f"all aliases rely on space→hyphen fallback"
+            )
+
+    # ═══ Check 5: All _ROUTE_ALIASES keys represented in manifest ════════════
+    manifest_alias_norms: dict[str, str] = {}  # normalized → route_id
+    for route in manifest["routes"]:
+        for alias in route.get("aliases", []):
+            manifest_alias_norms[_normalize_alias(alias)] = route["id"]
+
+    for alias_key, target in alias_map.items():
+        norm = _normalize_alias(alias_key)
+        if norm not in manifest_alias_norms:
+            warnings.append(
+                f"_ROUTE_ALIASES key '{alias_key}' (→{target}) "
+                f"has no corresponding alias in manifest"
+            )
+        elif manifest_alias_norms[norm] != target:
+            warnings.append(
+                f"_ROUTE_ALIASES key '{alias_key}' maps to '{target}' "
+                f"but manifest alias maps to '{manifest_alias_norms[norm]}'"
+            )
+
+    # ═══ Check 6: Required audits reference existing checklist files ═════════
+    existing_checklists = {p.stem for p in CHECKLISTS_DIR.glob("*.md")}
+    for route in manifest["routes"]:
+        for audit in route.get("required_audits", []):
+            if audit not in existing_checklists:
+                errors.append(
+                    f"Route '{route['id']}' requires audit '{audit}' "
+                    f"but checklist file 'checklists/{audit}.md' does not exist"
+                )
+
+    # ═══ Check 7: ROUTING-MATRIX.md route count + display name comparison ════
+    if ROUTING_MATRIX.is_file():
+        matrix_text = ROUTING_MATRIX.read_text(encoding="utf-8")
+        matrix_headings = _parse_routing_matrix_headings(matrix_text)
+        specialized_in_manifest = sum(
+            1 for r in manifest["routes"] if r.get("category") == "specialized"
+        )
+
+        if len(matrix_headings) != specialized_in_manifest:
+            errors.append(
+                f"ROUTING-MATRIX.md has {len(matrix_headings)} route sections, "
+                f"manifest has {specialized_in_manifest} specialized routes — drift detected"
+            )
+        else:
+            # Compare display names (normalized)
+            matrix_norms = {_normalize_alias(h): h for h in matrix_headings}
+            manifest_display_names = [
+                r["display_name"] for r in manifest["routes"]
+                if r.get("category") == "specialized"
+            ]
+            manifest_norms = {_normalize_alias(d): d for d in manifest_display_names}
+
+            missing_in_manifest = set(matrix_norms.keys()) - set(manifest_norms.keys())
+            missing_in_matrix = set(manifest_norms.keys()) - set(matrix_norms.keys())
+
+            if missing_in_manifest:
+                warnings.append(
+                    f"ROUTING-MATRIX.md headings not in manifest: "
+                    f"{', '.join(sorted(matrix_norms[h] for h in missing_in_manifest))}"
+                )
+            if missing_in_matrix:
+                warnings.append(
+                    f"Manifest display_names not in ROUTING-MATRIX.md: "
+                    f"{', '.join(sorted(manifest_norms[h] for h in missing_in_matrix))}"
+                )
+
+    # ═══ Check 8: Manifest required fields per route ══════════════════════════
+    required_fields = {
+        "id", "display_name", "category", "aliases",
+        "required_audits", "hard_fail_keywords",
+    }
+    for route in manifest["routes"]:
+        missing_fields = required_fields - set(route.keys())
+        if missing_fields:
+            errors.append(
+                f"Route '{route.get('id', '?')}' missing fields: {missing_fields}"
+            )
+
+    # ═══ Check 9: No duplicate hard_fail_keywords across routes ══════════════
+    all_keywords: dict[str, str] = {}  # lowercase keyword → route_id
+    for route in manifest["routes"]:
+        for kw in route.get("hard_fail_keywords", []):
+            kw_lower = kw.lower().strip()
+            if kw_lower in all_keywords and all_keywords[kw_lower] != route["id"]:
+                warnings.append(
+                    f"Hard-fail keyword '{kw}' claimed by both "
+                    f"'{all_keywords[kw_lower]}' and '{route['id']}'"
+                )
+            all_keywords[kw_lower] = route["id"]
+
+    # ── Output ──────────────────────────────────────────────────────────────
+    if errors:
+        print(f"BLOCKING DRIFT DETECTED ({len(errors)} issue(s)):")
+        for err in errors:
+            print(f"  ✗ {err}")
+        if warnings:
+            print(f"\nWarnings ({len(warnings)}):")
+            for warn in warnings:
+                print(f"  ⚠ {warn}")
+        return EXIT_FAIL
+
+    if warnings:
+        print(f"Warnings only ({len(warnings)}):")
+        for warn in warnings:
+            print(f"  ⚠ {warn}")
+        return EXIT_WARN
+
+    print("OK — manifest is consistent with code and docs")
+    return EXIT_OK
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Route manifest drift detector",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=str,
+        default=None,
+        help=f"Path to route manifest JSON (default: {DEFAULT_MANIFEST})",
+    )
+    args = parser.parse_args(argv)
+
+    manifest_path = Path(args.manifest) if args.manifest else DEFAULT_MANIFEST
+    return validate(manifest_path)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_route_manifest.py
+++ b/tests/test_route_manifest.py
@@ -330,8 +330,14 @@ class TestValidatorRejectsDrift:
         finally:
             tmp.unlink(missing_ok=True)
 
-    def test_empty_route_validators_is_detected(self) -> None:
-        """P2-2: Extra route not in ROUTE_VALIDATORS should fail."""
+    def test_extra_route_not_in_route_validators(self) -> None:
+        """A manifest route not in ROUTE_VALIDATORS must fail (Check 1).
+
+        Note: Check 11 (empty ROUTE_VALIDATORS entry) is a structural
+        guard against manually created empty lists in audit_report.py.
+        It cannot be tested via temp manifest — it reads directly from
+        the real ROUTE_VALIDATORS source and would only trigger if
+        someone writes `"route-key": []` with zero validators."""
         routes = [
             {"id": rid, "display_name": rid, "category": "specialized",
              "aliases": [rid], "required_audits": ["final-audit"],

--- a/tests/test_route_manifest.py
+++ b/tests/test_route_manifest.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""
+Property-based and negative tests for route manifest drift detection.
+
+Tests that schemas/route-manifest.json is consistent with:
+1. _ROUTE_ALIASES canonical targets in scripts/audit_report.py
+2. ROUTE_VALIDATORS keys in scripts/audit_report.py
+3. Required audit checklist files in checklists/
+4. ROUTING-MATRIX.md route count
+
+Includes negative tests that deliberately create inconsistency to verify
+the validator catches drift.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = ROOT / "schemas" / "route-manifest.json"
+VALIDATOR_PATH = ROOT / "scripts" / "validate_route_manifest.py"
+
+
+# ── Canonical route data extracted from audit_report.py (source of truth) ────
+EXPECTED_CANONICAL_IDS = {
+    "academic-review",
+    "competitive-positioning",
+    "constrained-choice",
+    "equipment-selection",
+    "listed-company",
+    "market-entry",
+    "market-outlook",
+    "provider-selection",
+    "regulatory-analysis",
+    "shared-workflow",
+    "startup-evaluation",
+    "technical-deep-dive",
+}
+
+REQUIRED_MANIFEST_FIELDS = {
+    "id",
+    "display_name",
+    "category",
+    "aliases",
+    "required_audits",
+    "hard_fail_keywords",
+}
+
+ALLOWED_CATEGORIES = {"specialized", "shared-workflow"}
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _load_manifest(path: Path) -> dict:
+    """Load and validate top-level structure of a manifest file."""
+    text = path.read_text(encoding="utf-8")
+    manifest = json.loads(text)
+    assert "version" in manifest, "Missing 'version' field"
+    assert "routes" in manifest, "Missing 'routes' field"
+    assert isinstance(manifest["routes"], list), "'routes' must be a list"
+    return manifest
+
+
+def _make_temp_manifest(routes: list[dict]) -> Path:
+    """Create a temporary manifest file for testing."""
+    content = json.dumps({"version": 1, "routes": routes}, indent=2)
+    f = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".json", delete=False, encoding="utf-8",
+    )
+    f.write(content)
+    f.close()
+    return Path(f.name)
+
+
+def _run_validator(
+    manifest_path: Path | None = None,
+    extra_args: list[str] | None = None,
+) -> subprocess.CompletedProcess:
+    """Run validate_route_manifest.py on the given manifest path."""
+    cmd = [sys.executable, str(VALIDATOR_PATH)]
+    if manifest_path is not None:
+        cmd.extend(["--manifest", str(manifest_path)])
+    if extra_args:
+        cmd.extend(extra_args)
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=str(ROOT),
+    )
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+
+class TestManifestExistsAndIsValid:
+    """The real manifest file must exist, be parseable, and have valid structure."""
+
+    def test_manifest_file_exists(self) -> None:
+        assert MANIFEST_PATH.is_file(), f"Missing: {MANIFEST_PATH}"
+
+    def test_manifest_is_valid_json(self) -> None:
+        manifest = _load_manifest(MANIFEST_PATH)
+        assert manifest["version"] >= 1
+
+    def test_manifest_has_all_12_routes(self) -> None:
+        manifest = _load_manifest(MANIFEST_PATH)
+        route_ids = {r["id"] for r in manifest["routes"]}
+        missing = EXPECTED_CANONICAL_IDS - route_ids
+        extra = route_ids - EXPECTED_CANONICAL_IDS
+        assert not missing, f"Manifest missing routes: {missing}"
+        assert not extra, f"Manifest has unexpected routes: {extra}"
+
+    def test_every_route_has_required_fields(self) -> None:
+        manifest = _load_manifest(MANIFEST_PATH)
+        for route in manifest["routes"]:
+            missing_fields = REQUIRED_MANIFEST_FIELDS - set(route.keys())
+            assert not missing_fields, (
+                f"Route '{route.get('id', '?')}' missing fields: {missing_fields}"
+            )
+
+    def test_all_route_ids_are_valid_format(self) -> None:
+        """Route IDs must be lowercase-hyphenated, no spaces."""
+        manifest = _load_manifest(MANIFEST_PATH)
+        for route in manifest["routes"]:
+            rid = route["id"]
+            assert rid == rid.lower(), f"Route ID not lowercase: {rid}"
+            assert " " not in rid, f"Route ID contains space: {rid}"
+            assert rid.isascii(), f"Route ID not ASCII: {rid}"
+
+    def test_all_categories_are_valid(self) -> None:
+        manifest = _load_manifest(MANIFEST_PATH)
+        for route in manifest["routes"]:
+            assert route["category"] in ALLOWED_CATEGORIES, (
+                f"Route '{route['id']}' has invalid category: {route['category']}"
+            )
+
+    def test_no_duplicate_route_ids(self) -> None:
+        manifest = _load_manifest(MANIFEST_PATH)
+        ids = [r["id"] for r in manifest["routes"]]
+        assert len(ids) == len(set(ids)), f"Duplicate route IDs: {ids}"
+
+    def test_every_route_has_non_empty_display_name(self) -> None:
+        manifest = _load_manifest(MANIFEST_PATH)
+        for route in manifest["routes"]:
+            assert route["display_name"].strip(), (
+                f"Route '{route['id']}' has empty display_name"
+            )
+
+    def test_every_route_has_at_least_one_alias(self) -> None:
+        manifest = _load_manifest(MANIFEST_PATH)
+        for route in manifest["routes"]:
+            assert len(route["aliases"]) >= 1, (
+                f"Route '{route['id']}' has no aliases"
+            )
+
+
+class TestValidatorAgainstRealManifest:
+    """The validator must pass against the real manifest."""
+
+    def test_validator_exit_zero_on_real_manifest(self) -> None:
+        result = _run_validator(MANIFEST_PATH)
+        assert result.returncode == 0, (
+            f"Validator exited {result.returncode} on real manifest\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+    def test_validator_output_contains_ok(self) -> None:
+        result = _run_validator(MANIFEST_PATH)
+        output = result.stdout + result.stderr
+        assert "OK" in output or "pass" in output.lower(), (
+            f"Expected 'OK' or 'pass' in output, got:\n{output}"
+        )
+
+
+class TestValidatorRejectsDrift:
+    """Negative tests: validator must detect inconsistency."""
+
+    def test_missing_route_is_detected(self) -> None:
+        """A manifest missing a canonical route should fail."""
+        routes = [
+            {"id": rid, "display_name": rid, "category": "specialized",
+             "aliases": [rid], "required_audits": ["final-audit"],
+             "hard_fail_keywords": ["test"]}
+            for rid in sorted(EXPECTED_CANONICAL_IDS - {"shared-workflow"})
+        ]
+        tmp = _make_temp_manifest(routes)
+        try:
+            result = _run_validator(tmp)
+            assert result.returncode != 0, (
+                f"Should fail (missing route), got exit {result.returncode}\n"
+                f"stdout:\n{result.stdout}"
+            )
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    def test_extra_unknown_route_is_detected(self) -> None:
+        """A manifest with an unknown route ID should fail."""
+        routes = [
+            {"id": rid, "display_name": rid, "category": "specialized",
+             "aliases": [rid], "required_audits": ["final-audit"],
+             "hard_fail_keywords": ["test"]}
+            for rid in sorted(EXPECTED_CANONICAL_IDS)
+        ] + [
+            {"id": "unknown-fake-route", "display_name": "Fake Route",
+             "category": "specialized", "aliases": ["fake"],
+             "required_audits": ["final-audit"],
+             "hard_fail_keywords": ["test"]}
+        ]
+        tmp = _make_temp_manifest(routes)
+        try:
+            result = _run_validator(tmp)
+            assert result.returncode != 0, (
+                f"Should fail (extra route), got exit {result.returncode}\n"
+                f"stdout:\n{result.stdout}"
+            )
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    def test_wrong_audit_list_is_detected(self) -> None:
+        """A manifest with wrong required_audits should fail."""
+        real = _load_manifest(MANIFEST_PATH)
+        routes = []
+        for r in real["routes"]:
+            r_copy = dict(r)
+            if r_copy["id"] == "technical-deep-dive":
+                r_copy["required_audits"] = ["wrong-audit-name"]
+            routes.append(r_copy)
+        tmp = _make_temp_manifest(routes)
+        try:
+            result = _run_validator(tmp)
+            assert result.returncode != 0, (
+                f"Should fail (wrong audit), got exit {result.returncode}\n"
+                f"stdout:\n{result.stdout}"
+            )
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    def test_duplicate_alias_is_detected(self) -> None:
+        """A manifest where two routes share an alias should fail."""
+        routes = [
+            {
+                "id": "technical-deep-dive",
+                "display_name": "TD",
+                "category": "specialized",
+                "aliases": ["shared-alias", "tech"],
+                "required_audits": ["final-audit"],
+                "hard_fail_keywords": ["test"],
+            },
+            {
+                "id": "constrained-choice",
+                "display_name": "CC",
+                "category": "specialized",
+                "aliases": ["shared-alias", "choice"],
+                "required_audits": ["final-audit"],
+                "hard_fail_keywords": ["test"],
+            },
+        ]
+        tmp = _make_temp_manifest(routes)
+        try:
+            result = _run_validator(tmp)
+            assert result.returncode != 0, (
+                f"Should fail (duplicate alias), got exit {result.returncode}\n"
+                f"stdout:\n{result.stdout}"
+            )
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    def test_alias_not_in_route_aliases_is_detected(self) -> None:
+        """N3: Manifest alias that cannot be resolved via _ROUTE_ALIASES.
+
+        This is the exact B1/B2 scenario from the code review: a manifest
+        declares an alias that has no corresponding entry in _ROUTE_ALIASES
+        and cannot be resolved via space→hyphen fallback to the correct ID.
+        """
+        routes = [
+            {
+                "id": "technical-deep-dive",
+                "display_name": "TD",
+                "category": "specialized",
+                "aliases": ["technical deep-dive", "nonexistent-alias-xyz"],
+                "required_audits": ["technical-analysis-audit",
+                                    "source-traceability", "final-audit"],
+                "hard_fail_keywords": ["test"],
+            },
+        ]
+        tmp = _make_temp_manifest(routes)
+        try:
+            result = _run_validator(tmp)
+            output = result.stdout + result.stderr
+            assert result.returncode != 0, (
+                f"Should fail (unresolvable alias), got exit {result.returncode}\n"
+                f"output:\n{output}"
+            )
+        finally:
+            tmp.unlink(missing_ok=True)
+
+
+class TestValidatorReturnsCorrectExitCodes:
+    """Validator exit codes must be well-defined."""
+
+    def test_exit_0_for_consistent_manifest(self) -> None:
+        result = _run_validator(MANIFEST_PATH)
+        assert result.returncode == 0
+
+    def test_exit_nonzero_for_missing_file(self) -> None:
+        result = _run_validator(Path("/nonexistent/manifest.json"))
+        assert result.returncode != 0, (
+            f"Should fail on missing file, got exit {result.returncode}"
+        )
+
+    def test_exit_nonzero_for_invalid_json(self) -> None:
+        f = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8",
+        )
+        f.write("not valid json {{{")
+        f.close()
+        tmp = Path(f.name)
+        try:
+            result = _run_validator(tmp)
+            assert result.returncode != 0, (
+                f"Should fail on invalid JSON, got exit {result.returncode}"
+            )
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    def test_exit_nonzero_for_missing_version(self) -> None:
+        tmp = _make_temp_manifest([{"id": "test", "display_name": "T",
+                                    "category": "specialized",
+                                    "aliases": ["t"], "required_audits": [],
+                                    "hard_fail_keywords": []}])
+        content = json.dumps({"routes": [{"id": "test"}]})
+        tmp.write_text(content)
+        try:
+            result = _run_validator(tmp)
+            assert result.returncode != 0, (
+                f"Should fail on missing version, got exit {result.returncode}"
+            )
+        finally:
+            tmp.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    passed = 0
+    failed = 0
+    test_classes = [
+        TestManifestExistsAndIsValid,
+        TestValidatorAgainstRealManifest,
+        TestValidatorRejectsDrift,
+        TestValidatorReturnsCorrectExitCodes,
+    ]
+    for cls in test_classes:
+        instance = cls()
+        for name in dir(instance):
+            if name.startswith("test_"):
+                try:
+                    getattr(instance, name)()
+                    print(f"  PASS  {cls.__name__}.{name}")
+                    passed += 1
+                except AssertionError as e:
+                    print(f"  FAIL  {cls.__name__}.{name}: {e}")
+                    failed += 1
+                except Exception as e:
+                    print(f"  ERROR {cls.__name__}.{name}: {e}")
+                    failed += 1
+
+    print(f"\n{passed} passed, {failed} failed")
+    sys.exit(0 if failed == 0 else 1)

--- a/tests/test_route_manifest.py
+++ b/tests/test_route_manifest.py
@@ -300,6 +300,67 @@ class TestValidatorRejectsDrift:
         finally:
             tmp.unlink(missing_ok=True)
 
+    def test_audit_list_drift_is_detected(self) -> None:
+        """P1-2b: Manifest audit list not matching ROUTING-MATRIX.md.
+
+        Uses the real manifest but modifies a route's required_audits
+        to differ from what's in ROUTING-MATRIX.md.
+        """
+        real = _load_manifest(MANIFEST_PATH)
+        routes = []
+        for r in real["routes"]:
+            r_copy = dict(r)
+            if r_copy["id"] == "market-outlook":
+                r_copy["required_audits"] = [
+                    "market-outlook-audit", "source-traceability",
+                    "final-audit",
+                ]
+            routes.append(r_copy)
+        tmp = _make_temp_manifest(routes)
+        try:
+            result = _run_validator(tmp)
+            output = result.stdout + result.stderr
+            assert result.returncode != 0, (
+                f"Should fail (audit drift), got exit {result.returncode}\n"
+                f"output:\n{output}"
+            )
+            assert "audit list mismatch" in output.lower(), (
+                f"Expected audit mismatch message, got:\n{output}"
+            )
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    def test_empty_route_validators_is_detected(self) -> None:
+        """P2-2: Extra route not in ROUTE_VALIDATORS should fail."""
+        routes = [
+            {"id": rid, "display_name": rid, "category": "specialized",
+             "aliases": [rid], "required_audits": ["final-audit"],
+             "hard_fail_keywords": ["test"]}
+            for rid in sorted(EXPECTED_CANONICAL_IDS)
+        ] + [
+            {"id": "empty-validator-route", "display_name": "EVR",
+             "category": "specialized", "aliases": ["empty-validator"],
+             "required_audits": ["final-audit"],
+             "hard_fail_keywords": ["test"]}
+        ]
+        tmp = _make_temp_manifest(routes)
+        try:
+            result = _run_validator(tmp)
+            assert result.returncode != 0, (
+                f"Should fail (extra route not in ROUTE_VALIDATORS), "
+                f"got exit {result.returncode}"
+            )
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    def test_evals_index_check_no_false_positive(self) -> None:
+        """P2-1: evals/INDEX.md check against real manifest must not crash."""
+        result = _run_validator(MANIFEST_PATH)
+        output = result.stdout
+        assert "OK" in output, (
+            f"Validator should pass on real manifest+index:\n{output}"
+        )
+
 
 class TestValidatorReturnsCorrectExitCodes:
     """Validator exit codes must be well-defined."""


### PR DESCRIPTION
## Summary

Implements Issue #362: establishes schemas/route-manifest.json as the single source of truth for route identity, covering all 12 canonical routes. Adds a CI drift detector that catches inconsistencies between manifest, _ROUTE_ALIASES, ROUTE_VALIDATORS, checklists, and ROUTING-MATRIX.md.

## What Changed

### New files
- **schemas/route-manifest.json** — 12 canonical routes with id, display_name, aliases, category, required_audits, hard_fail_keywords
- **scripts/validate_route_manifest.py** — 9 consistency checks: bidirectional ROUTE_VALIDATORS <-> manifest, _ROUTE_ALIASES target coverage, all-manifest-alias resolution, all-_ROUTE_ALIASES-key representation, checklist existence, ROUTING-MATRIX.md count + display name comparison, per-route field completeness, duplicate alias/keyword detection
- **tests/test_route_manifest.py** — 20 tests (5 deliberate drift negative tests)

### Modified files
- **scripts/audit_report.py** — added 4 missing _ROUTE_ALIASES entries: architecture analysis, nas, + 3 academic-review aliases (real drift found and fixed)
- **.github/workflows/ci.yml** — added validate_route_manifest.py + test_route_manifest.py to CI quick job

## Verification
- 20 new tests pass
- 93 existing audit tests pass (no regressions)
- Validator exits 0 on real manifest
- All 5 negative drift tests correctly produce nonzero exit codes

Closes #362