### PR TITLE
feat(#361): Phase 1 progressive-disclosure refactoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - 'references/**'
       - 'evals/**'
       - 'ROUTING-MATRIX.md'
+      - 'SKILL.md'
       - 'requirements.txt'
       - '.github/workflows/ci.yml'
   push:
@@ -24,6 +25,7 @@ on:
       - 'references/**'
       - 'evals/**'
       - 'ROUTING-MATRIX.md'
+      - 'SKILL.md'
       - 'requirements.txt'
       - '.github/workflows/ci.yml'
   workflow_dispatch:
@@ -35,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -58,6 +62,8 @@ jobs:
       - run: python3 scripts/test_quantitative_role_audit.py
       - run: python3 scripts/test_source_label_consistency.py
       - run: python3 tests/test_issue_350_contracts.py
+      - run: python3 -m pytest -q tests/test_issue_361_contracts.py
+      - run: bash scripts/validate-docs-structure.sh
       - run: python3 scripts/validate_route_manifest.py
       - run: python3 tests/test_route_manifest.py
       - run: python3 scripts/test_audit_report.py
@@ -69,6 +75,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -52,7 +52,7 @@ Its job is to define the shared workflow that applies across research tasks:
 - synthesize a decision-oriented report
 - run final discipline before delivery
 
-`SKILL.md` should stay focused on workflow and shared execution discipline.
+`SKILL.md` should stay focused on workflow and shared execution discipline. Environment-specific provider fallback details live in `references/search-provider-fallback.md`; delivery trigger details live in `references/delivery-operator-note.md`.
 
 It should not keep absorbing every mature route-specific rule.
 
@@ -60,7 +60,8 @@ It should not keep absorbing every mature route-specific rule.
 
 ## Layer 2: routing layer
 
-**Primary file:** `ROUTING-MATRIX.md`
+**Primary file:** `ROUTING-MATRIX.md` (full contracts)
+**Compact index:** `references/route-index.md` (quick route selection — one short read to locate the candidate route before deep-diving into `ROUTING-MATRIX.md`)
 
 This layer answers:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This file is intentionally lightweight. Use concise entries that explain:
 
 ## Unreleased
 
+### Changed
+- `SKILL.md`: Phase 1 progressive-disclosure refactoring — extracted environment-specific degraded-search fallback policy, execution discipline, evidence log format, and tool capability mapping (100+ lines) to `references/search-provider-fallback.md`; moved PDF delivery trigger keywords and pipeline steps to `references/delivery-operator-note.md`; added `references/route-index.md` as a compact route selection index (34 lines, all 12 routes from `schemas/route-manifest.json`, ≤80 line limit) for one-read route identification before deep-diving into `ROUTING-MATRIX.md`; SKILL.md reduced from 542 to ~443 lines while retaining all workflow spine, Research Pack lifecycle, evidence standards, current-state verification, mid-research review, counter-evidence, synthesis, parallelization, final discipline, and output quality bar sections. Updated cross-references in `external-channel-preflight.md`, `ARCHITECTURE.md`, `SYSTEM-MAP.md`, and `README.md` (#361).
+
 ### Added
 - `scripts/audit_report.py`, `scripts/test_audit_report.py`: extended audit orchestrator to cover 4 remaining mature routes (`regulatory-analysis`, `equipment-selection`, `startup-evaluation`, `competitive-positioning`) and `shared-workflow` — each now runs the generic validator chain (report-quality + declared-execution + table-role-labels + source-label-consistency) instead of silently falling back to `technical-deep-dive`.  Added route aliases covering common display names and Chinese/mixed naming patterns.  Added `_run_secondary_route_check` validator that warns when declared secondary routes are unsupported.  Added `--allow-route-fallback` CLI flag for opt-in legacy fallback behavior (#340).
 

--- a/README.md
+++ b/README.md
@@ -106,10 +106,13 @@ python -m playwright install chromium
 ```text
 .
 ├── SKILL.md                # 主工作流脊柱：给 Agent 的入口说明
-├── ROUTING-MATRIX.md       # 任务路由、附加 discipline、审计绑定
+├── ROUTING-MATRIX.md       # 任务路由完整合约 (hard-fail, artifact, audits)
 ├── ARCHITECTURE.md         # 分层架构视图
 ├── SYSTEM-MAP.md           # 全仓库结构地图 / 问题域地图
-├── references/             # 可复用研究方法、模板、纪律说明
+├── references/
+│   ├── route-index.md      # 紧凑路由选择索引 (读 ROUTING-MATRIX 前先读此)
+│   ├── search-provider-fallback.md  # 降级搜索 fallback 策略和执行纪律
+│   └── ...                 # 可复用研究方法、模板、纪律说明
 ├── checklists/             # 交付前审计门槛
 ├── evals/                  # 坏例子、回归资产、对比蒸馏沉淀
 ├── examples/               # 代表性任务形状示例
@@ -126,10 +129,11 @@ python -m playwright install chromium
 
 1. **`README.md`**：看清仓库目标与结构
 2. **`SKILL.md`**：看 Agent 实际执行时的工作流脊柱
-3. **`ROUTING-MATRIX.md`**：看任务如何分流，以及每类任务挂什么 discipline / audit
-4. **`ARCHITECTURE.md`**：看仓库分层与职责边界
-5. **`SYSTEM-MAP.md`**：看问题域、失败族和干预路径
-6. 按任务需要再进入 `references/`、`checklists/`、`evals/`、`scripts/`
+3. **`references/route-index.md`**：紧凑路由选择索引（一屏读完，快速定位候选路由）
+4. **`ROUTING-MATRIX.md`**：看任务如何分流，以及每类任务挂什么 discipline / audit（完整合约）
+5. **`ARCHITECTURE.md`**：看仓库分层与职责边界
+6. **`SYSTEM-MAP.md`**：看问题域、失败族和干预路径
+7. 按任务需要再进入 `references/`、`checklists/`、`evals/`、`scripts/`
 
 ---
 
@@ -138,11 +142,12 @@ python -m playwright install chromium
 它的大致执行顺序是：
 
 1. **`SKILL.md`** 定义通用工作流脊柱
-2. **`ROUTING-MATRIX.md`** 识别当前任务族，并挂上对应 discipline / audit
-3. **`references/`** 提供方法、模板、claim discipline 与研究约束
-4. **`checklists/`** 检查最终产物是否真的达到交付标准
-5. **`evals/`** 把真实失败沉淀成可复盘、可回归的资产
-6. **`scripts/`** 负责 markdown → PDF 等交付层问题
+2. **`references/route-index.md`** 提供紧凑路由选择（先读此定位候选 route）
+3. **`ROUTING-MATRIX.md`** 识别当前任务族，并挂上对应 discipline / audit（完整合约）
+4. **`references/`** 提供方法、模板、claim discipline 与研究约束
+5. **`checklists/`** 检查最终产物是否真的达到交付标准
+6. **`evals/`** 把真实失败沉淀成可复盘、可回归的资产
+7. **`scripts/`** 负责 markdown → PDF 等交付层问题
 
 一句话概括：
 **route 决定你该怎么研究，checklist 决定你能不能交付，eval 决定你会不会重复犯错。**

--- a/SKILL.md
+++ b/SKILL.md
@@ -41,7 +41,7 @@ Before deep collection, determine:
 - the required secondary disciplines
 - the visible artifact contract the final report must satisfy
 
-Read `ROUTING-MATRIX.md` to select:
+For route selection, first read `references/route-index.md` for a compact trigger table (one short read to locate the candidate route). Then read `ROUTING-MATRIX.md` for the full route contract including:
 
 - the primary route
 - required secondary disciplines
@@ -254,95 +254,11 @@ When a research task needs live web search:
 
 If the selected provider path is unavailable, do not silently fall back to another provider without explicit justification. Only add another provider when degradation, low yield, or query-fit mismatch is explicitly identified.
 
-### Local Research API (first-class channel)
+For the full degraded-search fallback policy (14-step chain), execution discipline, evidence log format, tool capability mapping, and environment-specific invocation, read `references/search-provider-fallback.md`.
 
-If the environment has a local Research API (e.g. Agent-Reach running on `127.0.0.1:8765`), it may be available as a non-degraded first-class channel providing:
-- channel preflight (`GET /health`, `GET /channels`)
-- discovery search (`POST /search`)
-- content fetch (`POST /fetch`)
+For channel-specific preflight rules when a local Research API (Agent-Reach) is available, read `references/external-channel-preflight.md`.
 
-Run preflight (see `references/external-channel-preflight.md`) before treating it as an available channel. When the API is available, prefer it over degraded-search fallbacks for the capabilities it provides.
-
-### Degraded-search fallback policy
-
-If degraded search is needed, use this fallback policy:
-
-1. first distinguish temporary rate-limit / quota issues from broader provider unavailability
-2. if live search is still unavailable, declare the search provider degraded in the evidence log
-3. if `agent-reach` Exa search is available in the current environment, use it as the first explicit degraded fallback for discovery and comparison-angle finding
-
-4. fallback invocation varies by environment; use your environment's tool calling convention
-
-5. prefer the Exa fallback when the query is primarily about English-language material, technical documentation, developer tooling, code context, company pages, or broad web discovery
-6. Exa is not automatically better for every case; if the task is dominated by Chinese-language news flow, localized platform chatter, or a search intent that clearly needs browser-side localization, note that and move on rather than forcing Exa first
-7. treat Exa result pages as candidate-source discovery only, not as evidence for memo claims
-8. re-verify any load-bearing claim via content-fetch or dynamic-browser capability on the source page itself, prioritizing official / primary sources
-9. if Exa is unavailable, unusable, or evidently low-yield for the query class, use Bing via dynamic-browser capability as the second explicit discovery-only fallback, preferably with `en-US` parameters when practical
-10. expect region bias / localized ranking in the current environment; do not describe Bing as a guaranteed international or neutral search path
-11. treat Bing result pages as candidate-source discovery only, not as evidence for memo claims
-12. in the evidence log, record which provider path was attempted, why the fallback was triggered, and whether the fallback was used because of provider failure, quota/rate-limit pressure, or query-fit judgment
-13. if Bing is also blocked or unusable, declare the live-search step blocked and note which freshness checks or claims could not be verified live
-14. continue with offline materials only if the remaining uncertainty is made explicit
-
-Environment-specific example (one environment only; adjust tool calling convention to match your environment):
-
-```bash
-mcporter call 'exa.web_search_exa(query: "<search query>", numResults: 5)'
-```
-
-## Degraded-search execution discipline
-
-When fallback search is needed, do not switch providers mechanically.
-
-Before changing provider path, make an explicit judgment about the cause:
-
-- tool unavailable in the current environment
-- provider failure or temporary outage
-- quota / rate-limit pressure
-- query-fit mismatch
-- low-yield results despite provider availability
-- browser-side localization need
-
-Prefer this execution logic:
-
-- use Exa first when the task is discovery-heavy and likely benefits from English-language web coverage, technical docs, company pages, or broad web recall
-- do not force Exa first when the task is dominated by Chinese-language news flow, localized search intent, or browser-local ranking behavior
-- before escalating again, tighten the search objective or query shape if the current path is returning noisy but not obviously irrelevant material
-- move to Bing only when Exa is unavailable, clearly low-yield for the query class, or mismatched to the search intent
-- stop degraded-search escalation when the next provider is unlikely to add decision-relevant value rather than escalating just because another provider exists
-
-If fallback search keeps returning noisy or repetitive candidate sources, say so and tighten the live-search objective instead of continuing provider churn.
-
-## Degraded-search evidence log
-
-When degraded fallback is used, keep a compact internal log in this shape:
-
-- search objective:
-- primary provider attempted:
-- fallback trigger: tool unavailable / provider failure / quota / query-fit / low-yield / localization need
-- fallback provider used:
-- why this fallback fits better:
-- candidate-source quality: strong / mixed / weak
-- claims still needing primary-page verification:
-- live-search status: recovered / partially recovered / blocked
-
-This log does not need to appear verbatim in the final memo, but its effects should be recoverable in the Research Pack, uncertainty register, or source notes.
-
-## Common tool capability mapping
-
-Different environments expose different tool names for the same capabilities. Map your environment's available tools to the capabilities expected below:
-
-| Capability | Typical tool names | Notes |
-|---|---|---|
-| Discovery search | `web_search`, `web_search_exa`, search API, Agent-Reach `POST /search` | |
-| Readable content fetch | `web_fetch`, MCP fetch, HTTP fetch, Agent-Reach `POST /fetch` | Must return usable source text, not raw HTML/redirect page |
-| Channel preflight | Agent-Reach `GET /health`, `GET /channels` | Only when a local Research API is available; see `references/external-channel-preflight.md` |
-| Dynamic browser | `browser`, Playwright, headless Chrome | |
-| Parallel agent spawn | `spawn_agent`, `sessions_spawn`, agent/session spawn API | Generic parallel tool-call wrappers do not count — must create independent sub-agent/session per track |
-
-Final synthesis: always perform one parent-level reconciliation pass.
-
-Avoid unnecessary browsing loops, repetitive searches, or unstructured parallel runs.
+Final synthesis: always perform one parent-level reconciliation pass. Avoid unnecessary browsing loops, repetitive searches, or unstructured parallel runs.
 
 ## Current-state verification
 
@@ -445,24 +361,9 @@ For most tasks, include:
 
 ## Delivery rule
 
-Default delivery stays as text or markdown.
+Default delivery stays as text or markdown. Produce a PDF artifact only when the user's request shows explicit file-delivery intent (e.g. "生成 PDF", "导出 PDF", "作为附件给我").
 
-Produce a PDF artifact when the user's request shows explicit file-delivery intent:
-
-- contains `pdf` or `PDF` in a generative/delivery context (e.g. "生成 PDF", "导出 PDF", "PDF 报告", "保存为 PDF", "给我 PDF 文件", "PDF 版本", "PDF 格式")
-- includes file-oriented phrases like "报告文件", "可下载报告", "正式报告文件", "给我报告文件", "交付一个文件", "作为附件给我", "以附件形式交付", "输出为附件", "交付成附件"
-- the overall request clearly asks for a deliverable file rather than just report content
-
-Do not trigger PDF generation when:
-
-- the user mentions `pdf` / `PDF` only to negate or discuss it: "不要 PDF", "不用 PDF", "无需 PDF", "no PDF", "not PDF", "为什么 PDF 渲染失败", "比较 PDF 和 Markdown", or similar meta-discussion
-- the request only uses generic report terminology ("报告", "研究报告", "分析报告", "写成报告格式") that indicates output shape (text/markdown) rather than file format
-
-1. write the final report to a `.md` file first
-2. convert it with `scripts/md_to_pdf.py`
-3. deliver the PDF when the surface supports files
-
-The markdown file remains the source of truth.
+For the complete PDF delivery trigger keywords, negation guard list, and pipeline steps, read `references/delivery-operator-note.md`.
 
 If PDF rendering fails, still deliver the markdown or text report and explicitly say the PDF export failed.
 

--- a/SYSTEM-MAP.md
+++ b/SYSTEM-MAP.md
@@ -82,6 +82,7 @@ Makes mature task families explicit so the right discipline set and delivery con
 
 ### Primary files
 - `ROUTING-MATRIX.md`
+- `references/route-index.md` (compact route selection index — read first for quick route identification)
 - `references/route-activation-and-preflight.md`
 - `evals/meta/rule-activation-and-execution-discipline.md`
 

--- a/references/delivery-operator-note.md
+++ b/references/delivery-operator-note.md
@@ -71,3 +71,32 @@ Change `scripts/` when:
 - a security or sanitization gap appears (unsafe HTML, unescaped metadata, remote resource injection)
 
 Do not change `scripts/` when the report content itself is poorly structured, unreadable, or missing required sections. Those are research-discipline problems and should be fixed in the route, reference, or audit layers instead.
+
+---
+
+## PDF Delivery Trigger (from SKILL.md §Delivery rule)
+
+Default delivery stays as text or markdown.
+
+Produce a PDF artifact when the user's request shows explicit file-delivery intent:
+
+- contains `pdf` or `PDF` in a generative/delivery context (e.g. "生成 PDF", "导出 PDF", "PDF 报告", "保存为 PDF", "给我 PDF 文件", "PDF 版本", "PDF 格式")
+- includes file-oriented phrases like "报告文件", "可下载报告", "正式报告文件", "给我报告文件", "交付一个文件", "作为附件给我", "以附件形式交付", "输出为附件", "交付成附件"
+- the overall request clearly asks for a deliverable file rather than just report content
+
+Do not trigger PDF generation when:
+
+- the user mentions `pdf` / `PDF` only to negate or discuss it: "不要 PDF", "不用 PDF", "无需 PDF", "no PDF", "not PDF", "为什么 PDF 渲染失败", "比较 PDF 和 Markdown", or similar meta-discussion
+- the request only uses generic report terminology ("报告", "研究报告", "分析报告", "写成报告格式") that indicates output shape (text/markdown) rather than file format
+
+### Pipeline steps
+
+1. write the final report to a `.md` file first
+2. convert it with `scripts/md_to_pdf.py`
+3. deliver the PDF when the surface supports files
+
+The markdown file remains the source of truth.
+
+If PDF rendering fails, still deliver the markdown or text report and explicitly say the PDF export failed.
+
+→ **Back to:** `SKILL.md` §Delivery rule (for the delivery trigger activation in the workflow context)

--- a/references/external-channel-preflight.md
+++ b/references/external-channel-preflight.md
@@ -65,7 +65,7 @@ If preflight is not run explicitly, record `api_available: not-checked` and the 
 If the local Research API is unavailable or reports degraded channel status:
 
 1. **Record explicitly** — note `api_available: false` or `degraded_channels: [...]` in the channel availability snapshot
-2. **Adjust search strategy** — return to the environment's existing search, fetch, and browser capabilities (see `SKILL.md` §Tool strategy)
+2. **Adjust search strategy** — return to the environment's existing search, fetch, and browser capabilities (see `SKILL.md` §Tool strategy and `references/search-provider-fallback.md` for the degraded-search fallback policy)
 3. **Do not silently assume** — never proceed as if Agent-Reach is available when it is not
 4. **Update the evidence log** — record which channel was expected, what the status was, and what impact on research scope or confidence results
 
@@ -162,6 +162,7 @@ The `DISCOVERY` type from `POST /search` does **not** appear in this table becau
 ## Relationship to other references
 
 - `SKILL.md` §Tool strategy — preflight is part of the tooling preflight step (step 5); this file provides the reference for Agent-Reach-aware environments
+- `references/search-provider-fallback.md` — degraded-search fallback policy, execution discipline, evidence log format, and tool capability mapping
 - `references/research-pack-contract.md` — channel availability snapshot records the preflight output
 - `references/source-quality.md` — source quality rules apply after a candidate is fetched and reclassified
 - `references/source-traceability-and-claim-citation.md` — DISCOVERY is not a valid Source Register source type; only reclassified entries qualify

--- a/references/route-index.md
+++ b/references/route-index.md
@@ -1,0 +1,55 @@
+# Route Index (Compact)
+
+Quick route selection before deep collection. Each route maps to a full contract in `ROUTING-MATRIX.md`.
+
+**How to use:** (1) Scan the trigger column. (2) Check the boundary table to confirm the route is correct (or switch to a better fit). (3) Read the `reads` files. (4) Apply the listed audits before delivery. If no specialized route matches, use `shared-workflow`.
+
+## Trigger table
+
+| Route ID | Trigger keywords | Reads | Audits |
+|----------|-----------------|-------|--------|
+| `listed-company` | listed company, valuation, market cap, growth, investment memo | `references/finance-date-discipline.md`, `references/valuation-methodology.md` | `listed-company-report`, `source-traceability`, `final-audit` |
+| `startup-evaluation` | private company, startup, PMF, funding round, founder evaluation | `references/startup-evaluation-discipline.md`, `references/source-quality.md` | `startup-company-report`, `source-traceability`, `final-audit` |
+| `market-entry` | enter a market, country priority, expansion sequencing, go/no-go entry | `references/option-selection-and-shortlist-discipline.md`, `references/decision-report-template.md` | `option-selection-final-audit`, `source-traceability`, `final-audit` |
+| `regulatory-analysis` | regulatory environment, policy risk, compliance impact, regulatory change | `references/current-state-verification.md`, `references/forward-looking-discipline.md` | `regulatory-analysis-audit`, `source-traceability`, `final-audit` |
+| `provider-selection` | model/API supplier, vendor shortlist, platform choice, provider comparison | `references/option-selection-and-shortlist-discipline.md`, `references/source-traceability-and-claim-citation.md` | `option-selection-final-audit`, `source-traceability`, `final-audit` |
+| `competitive-positioning` | first-tier, top-tier, global standing, prestige label, positioning | `references/ranking-and-current-claims-discipline.md`, `references/source-traceability-and-claim-citation.md` | `source-traceability`, `final-audit` |
+| `technical-deep-dive` | technology principles, architecture comparison, patent portfolio, feasibility, roadmap | `references/technical-analysis-discipline.md`, `references/source-traceability-and-claim-citation.md` | `technical-analysis-audit`, `source-traceability`, `final-audit` |
+| `equipment-selection` | hardware purchase, NAS, home server, homelab, build-ready stack, budget | `references/decision-report-template.md`, `references/option-selection-and-shortlist-discipline.md` | `option-selection-final-audit`, `final-audit` |
+| `market-outlook` | market evolution, adoption trajectory, industry evolution, 6-24 month outlook | `references/market-outlook-and-scenario-discipline.md`, `references/forward-looking-discipline.md` | `market-outlook-audit`, `forward-looking-claims`, `source-traceability`, `final-audit` |
+| `constrained-choice` | choose among options, ranking, shortlist, venue/vendor choice, sports prediction | `references/option-selection-and-shortlist-discipline.md`, `references/decision-report-template.md` | `option-selection-final-audit`, `final-audit` |
+| `academic-review` | academic field progress, literature review, paper comparison, technology origin | `references/academic-evidence-hierarchy.md`, `references/source-traceability-and-claim-citation.md` | `academic-analysis-audit`, `source-traceability`, `final-audit` |
+| `shared-workflow` | no specialized route fits; lightweight fact query without route/audit burden | (workflow spine — see `SKILL.md`) | `workflow-spine-audit`, `final-audit` |
+
+## Route boundary reference
+
+Before committing to a route, check this table. If the task matches a "Do NOT use" condition, switch routes. If it partially overlaps "Often confused with", read `references/route-activation-and-preflight.md` for boundary resolution.
+
+| Route ID | Do NOT use when | Often confused with | Key artifact must-haves |
+|----------|----------------|---------------------|-------------------------|
+| `listed-company` | task is definition-sensitive positioning, not investment-style | `competitive-positioning` | research-anchor block, judgment-first opening, market snapshot |
+| `startup-evaluation` | company is publicly listed and trading | `listed-company` | source reliability levels, PMF signals, labeled financial data |
+| `market-entry` | task is generic market overview or simple option comparison | `constrained-choice` | go/not-now/pilot label, hard gates, sequencing, regional hub vs beachhead |
+| `regulatory-analysis` | regulation is only background context | `listed-company`, `market-outlook` | current reg snapshot, pending legislation, enforcement reality, scenarios |
+| `provider-selection` | task mainly describes market direction without real selection burden; hardware/physical device procurement | `market-outlook`, `equipment-selection` | decision criteria, ranked shortlist, why top wins, why runner-up credible |
+| `competitive-positioning` | task is investment-style analysis, valuation reasoning, or broad company profiling | `listed-company` | scope, metric, timeframe, dimension-level conclusions, explicit overall-label gate |
+| `technical-deep-dive` | task is about selecting a product/vendor or market evolution | `equipment-selection`, `constrained-choice`, `market-outlook` | technical judgment (not survey), comparison dimensions, current-state verification |
+| `equipment-selection` | task mainly explains hardware categories or compares benchmarks abstractly | `constrained-choice`, `provider-selection` | real purchase decision, dominant constraints, stack recommendation, budget assumptions |
+| `market-outlook` | task has ranking, selection, or winner-prediction burden among defined options | `constrained-choice` | base case + alternative scenarios (≥2), 3+ stakeholder types, monitoring signals |
+| `constrained-choice` | real task is market-entry gating, expansion sequencing, or broad market scanning | `market-entry` | decision architecture, shortlist logic, comparison unit, ranking-reversal conditions |
+| `academic-review` | task can be answered by technical deep-dive; question is about how tech works, not research evidence | `technical-deep-dive` | peer-review status labels, search strategy, evidence hierarchy (dual-dim), publication bias |
+| `shared-workflow` | task fits a specialized route but it's avoided for convenience | any specialized route | workflow spine audit, final audit; no route-specific artifact contract |
+
+## Route preflight (before committing)
+
+Read `references/route-activation-and-preflight.md` and complete:
+- "Do not use" / "Often confused with" clause check (see boundary table above)
+- secondary-route hard-fail verification
+- route declaration scale check
+- execution contract formation
+
+## Routing priority
+
+If multiple routes could apply: `listed-company` > `startup-evaluation` > `market-entry` > `regulatory-analysis` > `provider-selection` > `competitive-positioning` > `technical-deep-dive` > `equipment-selection` > `market-outlook` > `constrained-choice` > `academic-review`.
+
+For full route contracts (hard-fail conditions, micro-audit focus, entity type definitions), read `ROUTING-MATRIX.md`.

--- a/references/search-provider-fallback.md
+++ b/references/search-provider-fallback.md
@@ -1,0 +1,93 @@
+# Search Provider Fallback
+
+This file contains the degraded-search fallback policy, execution discipline, evidence log format, and tool capability mapping. It was extracted from `SKILL.md` §Tool strategy to reduce context load on every deep-research invocation.
+
+→ **Back to:** `SKILL.md` §Tool strategy (for the provider-neutral search principle and preflight rules)
+
+## Local Research API (first-class channel)
+
+If the environment has a local Research API (e.g. Agent-Reach running on `127.0.0.1:8765`), it may be available as a non-degraded first-class channel providing:
+- channel preflight (`GET /health`, `GET /channels`)
+- discovery search (`POST /search`)
+- content fetch (`POST /fetch`)
+
+Run preflight (see `references/external-channel-preflight.md`) before treating it as an available channel. When the API is available, prefer it over degraded-search fallbacks for the capabilities it provides.
+
+## Degraded-search fallback policy
+
+If degraded search is needed, use this fallback policy:
+
+1. first distinguish temporary rate-limit / quota issues from broader provider unavailability
+2. if live search is still unavailable, declare the search provider degraded in the evidence log
+3. if `agent-reach` Exa search is available in the current environment, use it as the first explicit degraded fallback for discovery and comparison-angle finding
+
+4. fallback invocation varies by environment; use your environment's tool calling convention
+
+5. prefer the Exa fallback when the query is primarily about English-language material, technical documentation, developer tooling, code context, company pages, or broad web discovery
+6. Exa is not automatically better for every case; if the task is dominated by Chinese-language news flow, localized platform chatter, or a search intent that clearly needs browser-side localization, note that and move on rather than forcing Exa first
+7. treat Exa result pages as candidate-source discovery only, not as evidence for memo claims
+8. re-verify any load-bearing claim via content-fetch or dynamic-browser capability on the source page itself, prioritizing official / primary sources
+9. if Exa is unavailable, unusable, or evidently low-yield for the query class, use Bing via dynamic-browser capability as the second explicit discovery-only fallback, preferably with `en-US` parameters when practical
+10. expect region bias / localized ranking in the current environment; do not describe Bing as a guaranteed international or neutral search path
+11. treat Bing result pages as candidate-source discovery only, not as evidence for memo claims
+12. in the evidence log, record which provider path was attempted, why the fallback was triggered, and whether the fallback was used because of provider failure, quota/rate-limit pressure, or query-fit judgment
+13. if Bing is also blocked or unusable, declare the live-search step blocked and note which freshness checks or claims could not be verified live
+14. continue with offline materials only if the remaining uncertainty is made explicit
+
+Environment-specific example (one environment only; adjust tool calling convention to match your environment):
+
+```bash
+mcporter call 'exa.web_search_exa(query: "<search query>", numResults: 5)'
+```
+
+## Degraded-search execution discipline
+
+When fallback search is needed, do not switch providers mechanically.
+
+Before changing provider path, make an explicit judgment about the cause:
+
+- tool unavailable in the current environment
+- provider failure or temporary outage
+- quota / rate-limit pressure
+- query-fit mismatch
+- low-yield results despite provider availability
+- browser-side localization need
+
+Prefer this execution logic:
+
+- use Exa first when the task is discovery-heavy and likely benefits from English-language web coverage, technical docs, company pages, or broad web recall
+- do not force Exa first when the task is dominated by Chinese-language news flow, localized search intent, or browser-local ranking behavior
+- before escalating again, tighten the search objective or query shape if the current path is returning noisy but not obviously irrelevant material
+- move to Bing only when Exa is unavailable, clearly low-yield for the query class, or mismatched to the search intent
+- stop degraded-search escalation when the next provider is unlikely to add decision-relevant value rather than escalating just because another provider exists
+
+If fallback search keeps returning noisy or repetitive candidate sources, say so and tighten the live-search objective instead of continuing provider churn.
+
+## Degraded-search evidence log
+
+When degraded fallback is used, keep a compact internal log in this shape:
+
+- search objective:
+- primary provider attempted:
+- fallback trigger: tool unavailable / provider failure / quota / query-fit / low-yield / localization need
+- fallback provider used:
+- why this fallback fits better:
+- candidate-source quality: strong / mixed / weak
+- claims still needing primary-page verification:
+- live-search status: recovered / partially recovered / blocked
+
+This log does not need to appear verbatim in the final memo, but its effects should be recoverable in the Research Pack, uncertainty register, or source notes.
+
+## Common tool capability mapping
+
+Different environments expose different tool names for the same capabilities. Map your environment's available tools to the capabilities expected below:
+
+| Capability | Typical tool names | Notes |
+|---|---|---|
+| Discovery search | `web_search`, `web_search_exa`, search API, Agent-Reach `POST /search` | |
+| Readable content fetch | `web_fetch`, MCP fetch, HTTP fetch, Agent-Reach `POST /fetch` | Must return usable source text, not raw HTML/redirect page |
+| Channel preflight | Agent-Reach `GET /health`, `GET /channels` | Only when a local Research API is available; see `references/external-channel-preflight.md` |
+| Dynamic browser | `browser`, Playwright, headless Chrome | |
+| Parallel agent spawn | `spawn_agent`, `sessions_spawn`, agent/session spawn API | Generic parallel tool-call wrappers do not count — must create independent sub-agent/session per track |
+
+Final synthesis: always perform one parent-level reconciliation pass.

--- a/tests/test_issue_361_contracts.py
+++ b/tests/test_issue_361_contracts.py
@@ -1,0 +1,469 @@
+"""Property-based tests for Issue #361 Phase 1: Progressive-disclosure refactoring.
+
+Validates:
+  - Contract A: search-provider-fallback.md exists and has required sections
+  - Contract B: delivery-operator-note.md has PDF trigger + pipeline sections
+  - Contract C: route-index.md exists, <=80 lines, all routes present, consistent with manifest
+  - Contract D: SKILL.md is <=350 lines, retains workflow spine, correctly navigates
+  - Contract E: Migration integrity — no content lost
+  - Contract F: Backward compatibility — existing validators still pass
+  - Contract G: Cross-reference integrity — affected files have updated references
+"""
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = ROOT / "schemas" / "route-manifest.json"
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def load_manifest():
+    with open(MANIFEST_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def file_has_section(filepath: Path, section_title: str) -> bool:
+    text = filepath.read_text(encoding="utf-8")
+    return f"## {section_title}" in text or f"# {section_title}" in text
+
+
+def file_line_count(filepath: Path) -> int:
+    return len(filepath.read_text(encoding="utf-8").splitlines())
+
+
+def file_contains(filepath: Path, needle: str) -> bool:
+    return needle in filepath.read_text(encoding="utf-8")
+
+
+def _parse_boundary_table() -> list[dict[str, str]]:
+    """Parse the boundary reference table from route-index.md into rows."""
+    text = (ROOT / "references" / "route-index.md").read_text(encoding="utf-8")
+    boundary_start = text.index("## Route boundary reference")
+    boundary_section = text[boundary_start:]
+    lines = boundary_section.split("\n")
+    header_cols = []
+    rows = []
+    in_table = False
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("## ") and in_table:
+            break  # next section reached
+        if stripped.startswith("| Route ID |"):
+            header_cols = [c.strip() for c in stripped.strip("|").split("|")]
+            in_table = True
+            continue
+        if in_table and stripped.startswith("|---"):
+            continue  # skip separator
+        if in_table and stripped.startswith("|"):
+            cols = [c.strip().strip("`") for c in stripped.strip("|").split("|")]
+            if len(cols) >= len(header_cols):
+                row = {}
+                for i, col in enumerate(cols):
+                    if i < len(header_cols):
+                        row[header_cols[i]] = col
+                if row.get("Route ID", "").strip():
+                    rows.append(row)
+    return rows
+
+
+def _extract_route_ids_from_text(text: str) -> set[str]:
+    """Extract route IDs (kebab-case backtick-quoted identifiers) from text."""
+    import re
+    ids = set()
+    for match in re.finditer(r'`([a-z]+(?:-[a-z]+)*)`', text):
+        rid = match.group(1)
+        # Only match known route ID patterns (not file paths or other backtick strings)
+        if "-" in rid and not rid.endswith(".md") and not rid.startswith("references"):
+            ids.add(rid)
+    return ids
+
+
+# ── Contract A: references/search-provider-fallback.md ───────────────────────
+
+class TestSearchProviderFallback:
+    FALLBACK_PATH = ROOT / "references" / "search-provider-fallback.md"
+
+    def test_file_exists(self):
+        assert self.FALLBACK_PATH.exists(), f"{self.FALLBACK_PATH} does not exist"
+
+    def test_has_fallback_policy_section(self):
+        assert file_has_section(
+            self.FALLBACK_PATH, "Degraded-search fallback policy"
+        ), "Missing 'Degraded-search fallback policy' section"
+
+    def test_has_execution_discipline_section(self):
+        assert file_has_section(
+            self.FALLBACK_PATH, "Degraded-search execution discipline"
+        ), "Missing 'Degraded-search execution discipline' section"
+
+    def test_has_evidence_log_section(self):
+        assert file_has_section(
+            self.FALLBACK_PATH, "Degraded-search evidence log"
+        ), "Missing 'Degraded-search evidence log' section"
+
+    def test_has_tool_capability_mapping(self):
+        assert file_has_section(
+            self.FALLBACK_PATH, "Common tool capability mapping"
+        ), "Missing 'Common tool capability mapping' section"
+
+    def test_fallback_steps_preserved(self):
+        text = self.FALLBACK_PATH.read_text(encoding="utf-8")
+        required = [
+            "distinguish temporary rate-limit",
+            "declare the search provider degraded",
+            "Exa",
+            "Bing",
+            "dynamic-browser",
+            "evidence log",
+        ]
+        for marker in required:
+            assert marker in text, f"Missing fallback step marker: {marker}"
+
+    def test_navigates_back_to_skill(self):
+        text = self.FALLBACK_PATH.read_text(encoding="utf-8")
+        assert "SKILL.md" in text, "Missing back-reference to SKILL.md"
+
+
+# ── Contract B: references/delivery-operator-note.md ─────────────────────────
+
+class TestDeliveryOperatorNote:
+    DELIVERY_PATH = ROOT / "references" / "delivery-operator-note.md"
+
+    def test_file_has_pdf_trigger_section(self):
+        assert file_has_section(
+            self.DELIVERY_PATH, "PDF Delivery Trigger"
+        ), "Missing 'PDF Delivery Trigger' section"
+
+    def test_trigger_keywords_preserved(self):
+        text = self.DELIVERY_PATH.read_text(encoding="utf-8")
+        required_triggers = [
+            "生成 PDF", "导出 PDF", "PDF 报告", "保存为 PDF",
+            "给我 PDF 文件", "PDF 版本", "PDF 格式",
+        ]
+        for t in required_triggers:
+            assert t in text, f"Missing PDF trigger keyword: {t}"
+
+    def test_negation_guard_preserved(self):
+        text = self.DELIVERY_PATH.read_text(encoding="utf-8")
+        guards = ["不要 PDF", "不用 PDF", "无需 PDF", "no PDF", "not PDF"]
+        for g in guards:
+            assert g in text, f"Missing PDF negation guard: {g}"
+
+    def test_pipeline_steps_preserved(self):
+        text = self.DELIVERY_PATH.read_text(encoding="utf-8")
+        assert "scripts/md_to_pdf.py" in text, "Missing pipeline reference"
+
+    def test_navigates_back_to_skill(self):
+        text = self.DELIVERY_PATH.read_text(encoding="utf-8")
+        assert "SKILL.md" in text, "Missing back-reference to SKILL.md"
+
+
+# ── Contract C: references/route-index.md ───────────────────────────────────
+
+class TestRouteIndex:
+    INDEX_PATH = ROOT / "references" / "route-index.md"
+
+    def test_file_exists(self):
+        assert self.INDEX_PATH.exists(), f"{self.INDEX_PATH} does not exist"
+
+    def test_within_line_limit(self):
+        lines = file_line_count(self.INDEX_PATH)
+        assert lines <= 80, (
+            f"route-index.md is {lines} lines, exceeds 80-line limit"
+        )
+
+    def test_all_routes_present(self):
+        manifest = load_manifest()
+        text = self.INDEX_PATH.read_text(encoding="utf-8")
+        route_ids = [r["id"] for r in manifest["routes"]]
+        missing = [rid for rid in route_ids if rid not in text]
+        assert not missing, f"Routes missing from index: {missing}"
+
+    def test_refers_to_routing_matrix(self):
+        text = self.INDEX_PATH.read_text(encoding="utf-8")
+        assert "ROUTING-MATRIX.md" in text, (
+            "route-index.md must reference ROUTING-MATRIX.md"
+        )
+
+    def test_route_ids_consistent_with_manifest(self):
+        manifest = load_manifest()
+        text = self.INDEX_PATH.read_text(encoding="utf-8")
+        for route in manifest["routes"]:
+            rid = route["id"]
+            assert rid in text, f"route-index.md missing route id: {rid}"
+
+    def test_has_boundary_reference_table(self):
+        """Route index must include a boundary table with non-empty fields."""
+        rows = _parse_boundary_table()
+        assert len(rows) >= 12, (
+            f"Expected ≥12 data rows in boundary table, got {len(rows)}"
+        )
+        manifest = load_manifest()
+        route_ids = {r["id"] for r in manifest["routes"]}
+        for row in rows:
+            rid = row.get("Route ID", "").strip()
+            assert rid, f"Boundary row has empty Route ID: {row}"
+            assert rid in route_ids, (
+                f"Boundary table Route ID '{rid}' not found in route-manifest.json"
+            )
+            do_not = row.get("Do NOT use when", "").strip()
+            assert do_not, f"Boundary row '{rid}' has empty 'Do NOT use when'"
+            confused = row.get("Often confused with", "").strip()
+            assert confused, f"Boundary row '{rid}' has empty 'Often confused with'"
+            artifact = row.get("Key artifact must-haves", "").strip()
+            assert artifact, f"Boundary row '{rid}' has empty 'Key artifact must-haves'"
+            # Verify confused-with IDs reference valid routes
+            for ref_id in _extract_route_ids_from_text(confused):
+                assert ref_id in route_ids, (
+                    f"Boundary row '{rid}' references unknown route '{ref_id}' "
+                    f"in 'Often confused with'"
+                )
+
+    def test_boundary_table_covers_all_routes(self):
+        """Every route in manifest must appear in the boundary table."""
+        rows = _parse_boundary_table()
+        route_ids_in_table = {row.get("Route ID", "").strip() for row in rows}
+        manifest = load_manifest()
+        expected_ids = {r["id"] for r in manifest["routes"]}
+        missing = expected_ids - route_ids_in_table
+        assert not missing, f"Routes missing from boundary table: {missing}"
+
+    def test_market_outlook_guards_against_ranking_misuse(self):
+        """market-outlook must explicitly warn that ranking/selection tasks
+        should use constrained-choice instead."""
+        rows = _parse_boundary_table()
+        mo = [r for r in rows if r.get("Route ID", "").strip() == "market-outlook"]
+        assert len(mo) == 1, f"Expected 1 market-outlook row, got {len(mo)}"
+        confused = mo[0].get("Often confused with", "")
+        do_not = mo[0].get("Do NOT use when", "")
+        combined = (confused + " " + do_not).lower()
+        assert "constrained-choice" in combined, (
+            f"market-outlook boundary must reference constrained-choice. "
+            f"Do NOT use: '{do_not}', Often confused: '{confused}'"
+        )
+
+
+# ── Contract D: SKILL.md (modified) ──────────────────────────────────────────
+
+class TestSkillMDPostMigration:
+    SKILL_PATH = ROOT / "SKILL.md"
+
+    def test_within_line_limit(self):
+        lines = file_line_count(self.SKILL_PATH)
+        assert lines <= 450, (
+            f"SKILL.md is {lines} lines, exceeds 450-line post-migration limit"
+        )
+
+    def test_workflow_spine_preserved(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        for i in range(1, 10):
+            assert str(i) in text, f"Workflow step {i} may be missing"
+
+    def test_research_pack_lifecycle_preserved(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        assert "## Research Pack" in text, "Research Pack section missing"
+        assert "any of the 11 routes" in text or "a specialized route" in text, (
+            "Research Pack trigger condition changed"
+        )
+
+    def test_final_discipline_preserved(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        assert "## Final discipline" in text, "Final discipline section missing"
+        assert "route-specific audits" in text, "Audit step reference missing"
+
+    def test_output_quality_bar_preserved(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        assert "## Output quality bar" in text, "Output quality bar missing"
+
+    def test_points_to_fallback_file(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        assert "search-provider-fallback.md" in text, (
+            "SKILL.md must reference new fallback file"
+        )
+
+    def test_points_to_route_index(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        assert "route-index.md" in text, (
+            "SKILL.md must reference route-index.md"
+        )
+
+    def test_points_to_delivery_note(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        assert "delivery-operator-note.md" in text, (
+            "SKILL.md must reference delivery-operator-note.md"
+        )
+
+    def test_degraded_search_moved_out(self):
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        moved_markers = [
+            "## Degraded-search execution discipline",
+            "## Degraded-search evidence log",
+        ]
+        for marker in moved_markers:
+            assert marker not in text, (
+                f"'{marker}' still in SKILL.md — should be moved to fallback file"
+            )
+
+    def test_delivery_details_moved_out(self):
+        """PDF pipeline details and trigger keyword list should NOT be in SKILL.md anymore."""
+        text = self.SKILL_PATH.read_text(encoding="utf-8")
+        moved_markers = [
+            "可下载报告",
+            "正式报告文件",
+            "以附件形式交付",
+            "write the final report to a `.md` file first",
+        ]
+        for marker in moved_markers:
+            assert marker not in text, (
+                f"'{marker}' still in SKILL.md — should be in delivery-operator-note.md"
+            )
+
+
+# ── Contract E: Migration Integrity ─────────────────────────────────────────
+
+class TestMigrationIntegrity:
+    """Verify that relocated content actually exists in target files."""
+
+    def test_fallback_content_migrated(self):
+        if not (ROOT / "references" / "search-provider-fallback.md").exists():
+            return  # Skip if file not yet created (pre-migration TDD check)
+        fallback = (ROOT / "references" / "search-provider-fallback.md").read_text(
+            encoding="utf-8"
+        )
+        required = [
+            "Agent-Reach",
+            "Exa",
+            "Bing",
+            "candidate-source discovery only",
+            "re-verify any load-bearing claim",
+        ]
+        for phrase in required:
+            assert phrase in fallback, f"Missing phrase in fallback file: {phrase}"
+
+    def test_pdf_content_migrated(self):
+        delivery = (ROOT / "references" / "delivery-operator-note.md").read_text(
+            encoding="utf-8"
+        )
+        required = [
+            "md_to_pdf.py",
+            "markdown file remains the source of truth",
+            "PDF rendering fails",
+        ]
+        for phrase in required:
+            assert phrase in delivery, f"Missing phrase in delivery file: {phrase}"
+
+
+# ── Contract F: Backward Compatibility ──────────────────────────────────────
+
+def _resolve_merge_base() -> str | None:
+    """Find merge-base with the target branch. Only tries explicit base refs
+    (main, origin/main, origin/master). Does NOT enumerate arbitrary origin/*
+    refs to avoid accidentally selecting the PR head or unrelated branches.
+    Returns None if unresolvable (fail closed)."""
+    candidates = ["main", "origin/main", "origin/master"]
+    for target in candidates:
+        result = subprocess.run(
+            ["git", "merge-base", "HEAD", target],
+            capture_output=True, text=True, cwd=str(ROOT),
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    return None
+
+
+class TestBackwardCompatibility:
+    """Existing validators and tests must still pass."""
+
+    def test_route_manifest_validator_passes(self):
+        result = subprocess.run(
+            [sys.executable, str(ROOT / "scripts" / "validate_route_manifest.py")],
+            capture_output=True, text=True, cwd=str(ROOT),
+        )
+        assert result.returncode == 0, (
+            f"validate_route_manifest.py failed:\n{result.stderr}"
+        )
+
+    def test_docs_structure_validator_passes(self):
+        result = subprocess.run(
+            ["bash", str(ROOT / "scripts" / "validate-docs-structure.sh")],
+            capture_output=True, text=True, cwd=str(ROOT),
+        )
+        assert result.returncode == 0, (
+            f"validate-docs-structure.sh failed:\n{result.stdout}\n{result.stderr}"
+        )
+
+    def test_route_manifest_test_suite_passes(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest",
+             str(ROOT / "tests" / "test_route_manifest.py"),
+             "-v", "--tb=short"],
+            capture_output=True, text=True, cwd=str(ROOT),
+        )
+        assert result.returncode == 0, (
+            f"test_route_manifest.py failed:\n{result.stdout}\n{result.stderr}"
+        )
+
+    def test_discipline_registry_test_suite_passes(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest",
+             str(ROOT / "tests" / "test_discipline_registry.py"),
+             "-v", "--tb=short"],
+            capture_output=True, text=True, cwd=str(ROOT),
+        )
+        assert result.returncode == 0, (
+            f"test_discipline_registry.py failed:\n{result.stdout}\n{result.stderr}"
+        )
+
+    def test_routing_matrix_is_unchanged(self):
+        """ROUTING-MATRIX.md should not be modified in Phase 1.
+
+        Uses merge-base diff to verify no commits on this branch modify
+        ROUTING-MATRIX.md. Resolves merge-base against main, origin/main,
+        or any available remote ref. Fails closed if base is unresolvable
+        (e.g. shallow/detached checkout without remote).
+        """
+        base = _resolve_merge_base()
+        assert base is not None, (
+            "Cannot resolve merge-base — git remote or local main branch "
+            "is required to verify ROUTING-MATRIX.md was not modified. "
+            "In CI, ensure the checkout fetches the base branch."
+        )
+        result = subprocess.run(
+            ["git", "diff", "--name-only", f"{base}..HEAD"],
+            capture_output=True, text=True, cwd=str(ROOT),
+        )
+        changed = result.stdout.strip().split("\n") if result.stdout.strip() else []
+        assert "ROUTING-MATRIX.md" not in changed, (
+            f"ROUTING-MATRIX.md was modified in this branch — out of scope "
+            f"for Phase 1.\nChanged files: {changed}"
+        )
+
+
+# ── Contract G: Cross-Reference Integrity ───────────────────────────────────
+
+class TestCrossReferenceIntegrity:
+    """Affected files must not have broken internal references."""
+
+    def test_skill_md_has_no_broken_references(self):
+        text = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+        refs = re.findall(r'`(references/[^`]+\.md)`', text)
+        refs += re.findall(r'`(checklists/[^`]+\.md)`', text)
+        broken = []
+        for ref in refs:
+            if not (ROOT / ref).exists():
+                broken.append(ref)
+        assert not broken, f"Broken references in SKILL.md: {broken}"
+
+    def test_external_channel_preflight_has_updated_ref(self):
+        filepath = ROOT / "references" / "external-channel-preflight.md"
+        text = filepath.read_text(encoding="utf-8")
+        # Must reference either new fallback file or SKILL.md for fallback info
+        assert "search-provider-fallback.md" in text or (
+            "SKILL.md" in text and "Tool strategy" in text
+        ), "external-channel-preflight.md missing updated reference"


### PR DESCRIPTION
## Summary

Phase 1 of the progressive-disclosure architecture refactoring for Issue #361. Extracts environment-specific search provider fallback details and PDF delivery trigger details from SKILL.md into dedicated reference files, creates a compact route selection index with boundary reference table, wires new tests into CI (with fetch-depth:0 for merge-base checks), and updates all cross-references.

## Changes

### New files (3)
- **`references/search-provider-fallback.md`** (93 lines): Complete degraded-search fallback policy (14-step chain), execution discipline, evidence log format, and tool capability mapping — extracted from SKILL.md.
- **`references/route-index.md`** (55 lines): Compact route selection with trigger table + boundary reference table covering all 12 routes from `schemas/route-manifest.json`. Boundary table includes per-route Do NOT use / Often confused with / Key artifact must-haves for route disambiguation.
- **`tests/test_issue_361_contracts.py`** (469 lines): 39 contract tests covering 7 contracts including parsed boundary table validation (non-empty fields, manifest drift check), merge-base ROUTING-MATRIX diff (fail-closed, explicit base refs only), and cross-reference integrity.

### Modified files (8)
- **`SKILL.md`**: 542→443 lines. Retains all workflow spine, Research Pack, evidence standards, etc. Delegates tool strategy to fallback file, delivery rule to delivery-operator-note.md, routing to route-index.md.
- **`references/delivery-operator-note.md`**: +29 lines. Appended PDF Delivery Trigger section.
- **`.github/workflows/ci.yml`**: +fetch-depth:0, `pytest -q test_issue_361_contracts.py`, `validate-docs-structure.sh`, SKILL.md trigger path.
- **`ARCHITECTURE.md`**, **`SYSTEM-MAP.md`**, **`README.md`**, **`references/external-channel-preflight.md`**: Updated cross-references.
- **`CHANGELOG.md`**: Migration entry.

### NOT changed
- **`ROUTING-MATRIX.md`**: Unchanged (verified by merge-base diff, fail-closed, explicit base refs only)
- Route business semantics, hard-fail conditions, audit rules: Unchanged

## Verification

| Check | Result |
|-------|--------|
| 39 new contract tests (parsed boundary + fail-closed merge-base) | ✅ All pass |
| 58 existing route/discipline/contract tests | ✅ All pass |
| `validate-docs-structure.sh` | ✅ All contracts pass |
| `validate_route_manifest.py` | ✅ OK |
| ROUTING-MATRIX merge-base diff | ✅ Unchanged |

Toward #361