### PR TITLE
feat(#365): add research_status and delivery_status to Research Pack with validator support

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -179,10 +179,10 @@ evidence — not on validator alone:
 
 - **Pass**: strict validation passes AND every Required audit was executed with
   documented evidence (passed / skipped-with-reason).
-- **Partial**: strict validation passes but some Required audits were skipped or not run
-  with documented reason, OR strict validation has warnings but no errors.
-- **Fail**: strict validation fails (structural or semantic errors) OR a Required audit
-  was not run without documented reason.
+- **Partial**: strict validation passes but some Required audits were skipped or
+  not run with documented reason, OR strict validation has warnings but no errors.
+- **Fail**: strict validation fails (structural or semantic errors) OR a Required
+  audit was not run without documented reason.
 
 If a Required audit was declared but never executed, do not claim Pass regardless of
 validator outcome. Record each Required audit with its run status — passed, skipped
@@ -205,12 +205,10 @@ These states are distinct from "evidence is weak" or "confidence is low" — the
 why a tool, channel, audit, or validation step could not complete, not why the evidence
 itself is insufficient.
 
-Two conditional Pack fields add formal layers: **Research status**
-(`complete` / `partial` / `blocked`) for process completion, and
-**Delivery status** (`md_ready` / `pdf_ready` / `pdf_failed` / `not_run`)
-for rendering outcome. Both are independent from content quality
-(`Final audit status`). See `schemas/research-pack.md` for the
-full schema.
+Two conditional Pack fields separate previously conflated concerns: **Research
+status** (`complete` / `partial` / `blocked`) and **Delivery status**
+(`md_ready` / `pdf_ready` / `pdf_failed` / `not_run`). Both are independent
+from content quality (`Final audit status`). See `schemas/research-pack.md`.
 
 ## Evidence standards
 
@@ -422,11 +420,7 @@ Before delivery:
 
 A report that sounds informed but does not visibly satisfy its required artifact contract (route-specific or shared-workflow) is not ready.
 
-If the failure seems to be:
-- missing rule
-- missing trigger
-- or execution drift
-
+If the failure seems to be missing rule, missing trigger, or execution drift,
 use `evals/meta/rule-activation-and-execution-discipline.md`.
 
 If no mature specialized route applies, treat the task as a shared-workflow task — the workflow-spine audit (already run in step 3) replaces route-specific checks; skip the route-dependent parts of steps 5 and 6.
@@ -443,8 +437,7 @@ A strong final answer should:
 - explain what is still missing
 - help the user decide what to do next
 
-If confidence is limited, say exactly why.
-
-If a Research Pack should have been created under the trigger conditions but was not,
-record this in the internal Research Pack (or in the Final discipline log if no pack exists)
-as a noted gap — do not silently omit it.
+If confidence is limited, say exactly why. If a Research Pack should have been
+created under the trigger conditions but was not, record this in the internal
+Research Pack (or in the Final discipline log if no pack exists) as a noted
+gap — do not silently omit it.

--- a/SKILL.md
+++ b/SKILL.md
@@ -205,6 +205,13 @@ These states are distinct from "evidence is weak" or "confidence is low" — the
 why a tool, channel, audit, or validation step could not complete, not why the evidence
 itself is insufficient.
 
+Two conditional Pack fields add formal layers: **Research status**
+(`complete` / `partial` / `blocked`) for process completion, and
+**Delivery status** (`md_ready` / `pdf_ready` / `pdf_failed` / `not_run`)
+for rendering outcome. Both are independent from content quality
+(`Final audit status`). See `schemas/research-pack.md` for the
+full schema.
+
 ## Evidence standards
 
 For key claims, prefer:

--- a/schemas/research-pack.md
+++ b/schemas/research-pack.md
@@ -89,6 +89,34 @@ or partial with reason, or when validator has warnings but no errors;
 Fail is required when any audit is not-run without reason or when strict
 validation fails.
 
+### Research status
+
+Set the research status after collection is complete. One of:
+
+- `complete` — all core subquestions have adequate evidence.
+- `partial` — some subquestions have insufficient evidence or relied on
+  degraded search.
+- `blocked` — external channels or providers were unavailable, preventing
+  current-state confirmation.
+
+This field is distinct from Final audit status: it records whether the
+research process completed successfully, not whether the delivered content
+passes quality checks. A blocked research process can still produce a
+content-quality-audit Pass if the available evidence is correctly labeled.
+
+### Delivery status
+
+Set the delivery status after rendering. One of:
+
+- `md_ready` — Markdown artifact satisfies the artifact contract.
+- `pdf_ready` — PDF was successfully rendered from the Markdown artifact.
+- `pdf_failed` — PDF rendering failed, but Markdown is still available.
+- `not_run` — rendering was not attempted (e.g., mid-research artifact).
+
+This field separates delivery concerns from content quality. A `pdf_failed`
+result does not imply the Markdown content is invalid — the two statuses
+are independent.
+
 ## Minimal example shape
 
 ```md
@@ -135,6 +163,12 @@ validation fails.
 
 ## Artifact contract
 ...
+
+## Research status
+complete | partial | blocked
+
+## Delivery status
+md_ready | pdf_ready | pdf_failed | not_run
 
 ## Required audits
 - audit name — passed | skipped (reason) | not-run (reason) | partial (reason)

--- a/scripts/test_validator_regression.py
+++ b/scripts/test_validator_regression.py
@@ -681,6 +681,35 @@ V5_RESEARCH_TRAILING = re.sub(
     V4_BASELINE,
 )
 
+# Body text mentions `## Research status` without a real H2 section heading —
+# should NOT trigger validation (string containment bug, P1-2 in PR #371 review).
+# Inject the mention inside the Uncertainty register body text.
+V5_RESEARCH_MENTION_IN_BODY = re.sub(
+    r"ok\n\n## Artifact contract",
+    "ok\n\nSee `## Research status` in the schema for details.\n\n## Artifact contract",
+    V4_BASELINE,
+)
+# Same for delivery status
+V5_DELIVERY_MENTION_IN_BODY = re.sub(
+    r"ok\n\n## Artifact contract",
+    "ok\n\nSee `## Delivery status` in the schema for details.\n\n## Artifact contract",
+    V4_BASELINE,
+)
+
+# Duplicate research_status sections — should be rejected.
+# Inject a second ## Research status after the first (after the first complete\n).
+V5_RESEARCH_DUPLICATE = re.sub(
+    r"(## Research status\ncomplete\n)",
+    r"\1## Research status\nnot-sure\n",
+    V5_RESEARCH_COMPLETE,
+)
+# Duplicate delivery_status sections — should be rejected.
+V5_DELIVERY_DUPLICATE = re.sub(
+    r"(## Delivery status\nmd_ready\n)",
+    r"\1## Delivery status\npdf_failed\n",
+    V5_DELIVERY_MD_READY,
+)
+
 # Both statuses valid
 V5_BOTH_VALID = re.sub(
     r"## Uncertainty register\nok\n",
@@ -901,6 +930,53 @@ def test_strict_v5_research_trailing_comment(d: str) -> None:
     )
 
 
+def test_strict_v5_body_mention_no_real_section(d: str) -> None:
+    """P1-2 fix: body text like `See ## Research status` must NOT trigger
+    'section is present but empty' — must use H2 regex, not string containment."""
+    path = write(os.path.join(d, "v5_bmrs.md"), V5_RESEARCH_MENTION_IN_BODY)
+    result = run_strict(path)
+    assert result.returncode == 0, (
+        f"V5 body mention of ## Research status: expected exit 0 (no section detected), "
+        f"got {result.returncode}\nstdout: {result.stdout}"
+    )
+
+
+def test_strict_v5_body_mention_delivery_no_section(d: str) -> None:
+    """P1-2 fix: body mention of ## Delivery status without real H2 must pass."""
+    path = write(os.path.join(d, "v5_bmds.md"), V5_DELIVERY_MENTION_IN_BODY)
+    result = run_strict(path)
+    assert result.returncode == 0, (
+        f"V5 body mention of ## Delivery status: expected exit 0 (no section detected), "
+        f"got {result.returncode}\nstdout: {result.stdout}"
+    )
+
+
+def test_strict_v5_research_duplicate(d: str) -> None:
+    """P2: duplicate ## Research status sections should be rejected."""
+    path = write(os.path.join(d, "v5_rd.md"), V5_RESEARCH_DUPLICATE)
+    result = run_strict(path)
+    assert result.returncode == 4, (
+        f"V5 duplicate research_status: expected exit 4, got {result.returncode}\n"
+        f"stdout: {result.stdout}"
+    )
+    assert "duplicate" in result.stdout.lower(), (
+        f"expected 'duplicate' in error output: {result.stdout}"
+    )
+
+
+def test_strict_v5_delivery_duplicate(d: str) -> None:
+    """P2: duplicate ## Delivery status sections should be rejected."""
+    path = write(os.path.join(d, "v5_dd.md"), V5_DELIVERY_DUPLICATE)
+    result = run_strict(path)
+    assert result.returncode == 4, (
+        f"V5 duplicate delivery_status: expected exit 4, got {result.returncode}\n"
+        f"stdout: {result.stdout}"
+    )
+    assert "duplicate" in result.stdout.lower(), (
+        f"expected 'duplicate' in error output: {result.stdout}"
+    )
+
+
 def test_strict_v4_fake_status_name(d: str) -> None:
     path = write(os.path.join(d, "v4_fake.md"), V4_FAKE_STATUS_NAME)
     result = run_strict(path)
@@ -1040,6 +1116,10 @@ def main() -> int:
             ("V5 research_status empty", test_strict_v5_research_empty),
             ("V5 both statuses valid", test_strict_v5_both_valid),
             ("V5 research trailing comment", test_strict_v5_research_trailing_comment),
+            ("V5 body mention no real section (research)", test_strict_v5_body_mention_no_real_section),
+            ("V5 body mention no real section (delivery)", test_strict_v5_body_mention_delivery_no_section),
+            ("V5 duplicate research_status", test_strict_v5_research_duplicate),
+            ("V5 duplicate delivery_status", test_strict_v5_delivery_duplicate),
         ]
         failures = []
         for name, fn in tests:

--- a/scripts/test_validator_regression.py
+++ b/scripts/test_validator_regression.py
@@ -617,6 +617,77 @@ V4_PUNCT_ONLY_REASON = re.sub(
     V4_BASELINE,
 )
 
+# ─── V5: Research status and Delivery status fixtures (#365) ────────────────
+
+# Valid research_status values
+V5_RESEARCH_COMPLETE = re.sub(
+    r"## Uncertainty register\nok\n",
+    "## Uncertainty register\nok\n\n## Research status\ncomplete\n",
+    V4_BASELINE,
+)
+V5_RESEARCH_PARTIAL = re.sub(
+    r"## Uncertainty register\nok\n",
+    "## Uncertainty register\nok\n\n## Research status\npartial\n",
+    V4_BASELINE,
+)
+V5_RESEARCH_BLOCKED = re.sub(
+    r"## Uncertainty register\nok\n",
+    "## Uncertainty register\nok\n\n## Research status\nblocked\n",
+    V4_BASELINE,
+)
+
+# Valid delivery_status values
+V5_DELIVERY_MD_READY = re.sub(
+    r"## Uncertainty register\nok\n",
+    "## Uncertainty register\nok\n\n## Delivery status\nmd_ready\n",
+    V4_BASELINE,
+)
+V5_DELIVERY_PDF_FAILED = re.sub(
+    r"## Uncertainty register\nok\n",
+    "## Uncertainty register\nok\n\n## Delivery status\npdf_failed\n",
+    V4_BASELINE,
+)
+V5_DELIVERY_NOT_RUN = re.sub(
+    r"## Uncertainty register\nok\n",
+    "## Uncertainty register\nok\n\n## Delivery status\nnot_run\n",
+    V4_BASELINE,
+)
+
+# Invalid research_status
+V5_RESEARCH_INVALID = re.sub(
+    r"## Uncertainty register\nok\n",
+    "## Uncertainty register\nok\n\n## Research status\nnot-sure\n",
+    V4_BASELINE,
+)
+
+# Invalid delivery_status
+V5_DELIVERY_INVALID = re.sub(
+    r"## Uncertainty register\nok\n",
+    "## Uncertainty register\nok\n\n## Delivery status\nbroken\n",
+    V4_BASELINE,
+)
+
+# Empty research_status
+V5_RESEARCH_EMPTY = re.sub(
+    r"## Uncertainty register\nok\n",
+    "## Uncertainty register\nok\n\n## Research status\n\n",
+    V4_BASELINE,
+)
+
+# Research status with trailing comment (word-boundary match, like audit_status)
+V5_RESEARCH_TRAILING = re.sub(
+    r"## Uncertainty register\nok\n",
+    "## Uncertainty register\nok\n\n## Research status\ncomplete — verified by team\n",
+    V4_BASELINE,
+)
+
+# Both statuses valid
+V5_BOTH_VALID = re.sub(
+    r"## Uncertainty register\nok\n",
+    "## Uncertainty register\nok\n\n## Research status\ncomplete\n\n## Delivery status\nmd_ready\n",
+    V4_BASELINE,
+)
+
 
 def test_strict_v4_valid_baseline(d: str) -> None:
     path = write(os.path.join(d, "v4_valid.md"), V4_BASELINE)
@@ -719,6 +790,114 @@ def test_strict_v4_partial_skipped_no_reason(d: str) -> None:
     )
     assert "reason" in result.stdout.lower(), (
         f"expected 'reason' error in output: {result.stdout}"
+    )
+
+
+def test_strict_v5_research_complete(d: str) -> None:
+    path = write(os.path.join(d, "v5_rc.md"), V5_RESEARCH_COMPLETE)
+    result = run_strict(path)
+    assert result.returncode == 0, (
+        f"V5 research_status complete: expected exit 0, got {result.returncode}\n"
+        f"stdout: {result.stdout}"
+    )
+
+
+def test_strict_v5_research_partial(d: str) -> None:
+    path = write(os.path.join(d, "v5_rp.md"), V5_RESEARCH_PARTIAL)
+    result = run_strict(path)
+    assert result.returncode == 0, (
+        f"V5 research_status partial: expected exit 0, got {result.returncode}\n"
+        f"stdout: {result.stdout}"
+    )
+
+
+def test_strict_v5_research_blocked(d: str) -> None:
+    path = write(os.path.join(d, "v5_rb.md"), V5_RESEARCH_BLOCKED)
+    result = run_strict(path)
+    assert result.returncode == 0, (
+        f"V5 research_status blocked: expected exit 0, got {result.returncode}\n"
+        f"stdout: {result.stdout}"
+    )
+
+
+def test_strict_v5_delivery_md_ready(d: str) -> None:
+    path = write(os.path.join(d, "v5_dmr.md"), V5_DELIVERY_MD_READY)
+    result = run_strict(path)
+    assert result.returncode == 0, (
+        f"V5 delivery_status md_ready: expected exit 0, got {result.returncode}\n"
+        f"stdout: {result.stdout}"
+    )
+
+
+def test_strict_v5_delivery_pdf_failed(d: str) -> None:
+    path = write(os.path.join(d, "v5_dpf.md"), V5_DELIVERY_PDF_FAILED)
+    result = run_strict(path)
+    assert result.returncode == 0, (
+        f"V5 delivery_status pdf_failed: expected exit 0, got {result.returncode}\n"
+        f"stdout: {result.stdout}"
+    )
+
+
+def test_strict_v5_delivery_not_run(d: str) -> None:
+    path = write(os.path.join(d, "v5_dnr.md"), V5_DELIVERY_NOT_RUN)
+    result = run_strict(path)
+    assert result.returncode == 0, (
+        f"V5 delivery_status not_run: expected exit 0, got {result.returncode}\n"
+        f"stdout: {result.stdout}"
+    )
+
+
+def test_strict_v5_research_invalid(d: str) -> None:
+    path = write(os.path.join(d, "v5_ri.md"), V5_RESEARCH_INVALID)
+    result = run_strict(path)
+    assert result.returncode == 4, (
+        f"V5 research_status invalid: expected exit 4, got {result.returncode}\n"
+        f"stdout: {result.stdout}"
+    )
+    assert "research" in result.stdout.lower(), (
+        f"expected 'research' in error output: {result.stdout}"
+    )
+
+
+def test_strict_v5_delivery_invalid(d: str) -> None:
+    path = write(os.path.join(d, "v5_di.md"), V5_DELIVERY_INVALID)
+    result = run_strict(path)
+    assert result.returncode == 4, (
+        f"V5 delivery_status invalid: expected exit 4, got {result.returncode}\n"
+        f"stdout: {result.stdout}"
+    )
+    assert "delivery" in result.stdout.lower(), (
+        f"expected 'delivery' in error output: {result.stdout}"
+    )
+
+
+def test_strict_v5_research_empty(d: str) -> None:
+    path = write(os.path.join(d, "v5_re.md"), V5_RESEARCH_EMPTY)
+    result = run_strict(path)
+    assert result.returncode == 4, (
+        f"V5 research_status empty: expected exit 4, got {result.returncode}\n"
+        f"stdout: {result.stdout}"
+    )
+    assert "empty" in result.stdout.lower(), (
+        f"expected 'empty' in error output: {result.stdout}"
+    )
+
+
+def test_strict_v5_both_valid(d: str) -> None:
+    path = write(os.path.join(d, "v5_bv.md"), V5_BOTH_VALID)
+    result = run_strict(path)
+    assert result.returncode == 0, (
+        f"V5 both statuses valid: expected exit 0, got {result.returncode}\n"
+        f"stdout: {result.stdout}"
+    )
+
+
+def test_strict_v5_research_trailing_comment(d: str) -> None:
+    path = write(os.path.join(d, "v5_rtc.md"), V5_RESEARCH_TRAILING)
+    result = run_strict(path)
+    assert result.returncode == 0, (
+        f"V5 research_status with trailing comment: expected exit 0, got {result.returncode}\n"
+        f"stdout: {result.stdout}"
     )
 
 
@@ -850,6 +1029,17 @@ def main() -> int:
             ("V4 not-run reason mentions status", test_strict_v4_not_run_reason_mentions_status),
             ("V4 distant colon fake reason", test_strict_v4_distant_colon_fake_reason),
             ("V4 punct-only reason not valid", test_strict_v4_punct_only_reason),
+            ("V5 research_status complete", test_strict_v5_research_complete),
+            ("V5 research_status partial", test_strict_v5_research_partial),
+            ("V5 research_status blocked", test_strict_v5_research_blocked),
+            ("V5 delivery_status md_ready", test_strict_v5_delivery_md_ready),
+            ("V5 delivery_status pdf_failed", test_strict_v5_delivery_pdf_failed),
+            ("V5 delivery_status not_run", test_strict_v5_delivery_not_run),
+            ("V5 research_status invalid", test_strict_v5_research_invalid),
+            ("V5 delivery_status invalid", test_strict_v5_delivery_invalid),
+            ("V5 research_status empty", test_strict_v5_research_empty),
+            ("V5 both statuses valid", test_strict_v5_both_valid),
+            ("V5 research trailing comment", test_strict_v5_research_trailing_comment),
         ]
         failures = []
         for name, fn in tests:

--- a/scripts/validate_research_pack.py
+++ b/scripts/validate_research_pack.py
@@ -353,6 +353,14 @@ def run_strict_checks(cleaned: str) -> list[str]:
         else:
             errors.append(issue)
 
+    # Research status validation (conditional: only validated when present)
+    research_issues = _check_research_status(cleaned)
+    errors.extend(research_issues)
+
+    # Delivery status validation (conditional: only validated when present)
+    delivery_issues = _check_delivery_status(cleaned)
+    errors.extend(delivery_issues)
+
     result: list[str] = []
     for e in errors:
         result.append(f"  ✗ {e}")
@@ -613,6 +621,59 @@ def _check_audit_consistency(cleaned: str) -> list[str]:
             )
 
     return issues
+
+
+# ─── Research status and Delivery status validation ──────────────────────────
+
+
+def _check_research_status(cleaned: str) -> list[str]:
+    """Validate the ## Research status section if present.
+
+    Conditional: section absence is not an error.
+    When present, the first line must be a valid status value.
+    Uses word-boundary matching (like _check_audit_status) so
+    trailing comments like 'complete — verified' are accepted.
+    """
+    if "## Research status" not in cleaned:
+        return []
+    body = _section_body(cleaned, "Research status")
+    if not body:
+        return ["Research status section is present but empty"]
+    first_line = body.split("\n")[0].strip()
+    if not first_line:
+        return ["Research status section is present but empty"]
+    m = re.match(r"^(complete|partial|blocked)\b", first_line, re.IGNORECASE)
+    if not m:
+        return [
+            f"Invalid research_status: '{first_line}'. "
+            f"Must be one of: complete, partial, blocked"
+        ]
+    return []
+
+
+def _check_delivery_status(cleaned: str) -> list[str]:
+    """Validate the ## Delivery status section if present.
+
+    Conditional: section absence is not an error.
+    When present, the first line must be a valid status value.
+    Uses word-boundary matching (like _check_audit_status) so
+    trailing comments like 'md_ready — all checks passed' are accepted.
+    """
+    if "## Delivery status" not in cleaned:
+        return []
+    body = _section_body(cleaned, "Delivery status")
+    if not body:
+        return ["Delivery status section is present but empty"]
+    first_line = body.split("\n")[0].strip()
+    if not first_line:
+        return ["Delivery status section is present but empty"]
+    m = re.match(r"^(md_ready|pdf_ready|pdf_failed|not_run)\b", first_line, re.IGNORECASE)
+    if not m:
+        return [
+            f"Invalid delivery_status: '{first_line}'. "
+            f"Must be one of: md_ready, pdf_ready, pdf_failed, not_run"
+        ]
+    return []
 
 
 # ─── Main ─────────────────────────────────────────────────────────────────────

--- a/scripts/validate_research_pack.py
+++ b/scripts/validate_research_pack.py
@@ -626,6 +626,19 @@ def _check_audit_consistency(cleaned: str) -> list[str]:
 # ─── Research status and Delivery status validation ──────────────────────────
 
 
+def _has_h2_section(text: str, heading: str) -> bool:
+    """Check if text contains a real H2 section (## heading on its own line).
+
+    Uses line-anchored regex to avoid false matches on body text references
+    like `` `## Research status` `` or prose mentions."""
+    return bool(re.search(rf"^## {re.escape(heading)}\s*$", text, re.MULTILINE))
+
+
+def _count_h2_sections(text: str, heading: str) -> int:
+    """Count occurrences of a real H2 section heading."""
+    return len(re.findall(rf"^## {re.escape(heading)}\s*$", text, re.MULTILINE))
+
+
 def _check_research_status(cleaned: str) -> list[str]:
     """Validate the ## Research status section if present.
 
@@ -633,9 +646,14 @@ def _check_research_status(cleaned: str) -> list[str]:
     When present, the first line must be a valid status value.
     Uses word-boundary matching (like _check_audit_status) so
     trailing comments like 'complete — verified' are accepted.
+
+    Rejects duplicate sections — only one Research status section is allowed.
     """
-    if "## Research status" not in cleaned:
+    count = _count_h2_sections(cleaned, "Research status")
+    if count == 0:
         return []
+    if count > 1:
+        return [f"Duplicate section: '## Research status' appears {count} times"]
     body = _section_body(cleaned, "Research status")
     if not body:
         return ["Research status section is present but empty"]
@@ -658,9 +676,14 @@ def _check_delivery_status(cleaned: str) -> list[str]:
     When present, the first line must be a valid status value.
     Uses word-boundary matching (like _check_audit_status) so
     trailing comments like 'md_ready — all checks passed' are accepted.
+
+    Rejects duplicate sections — only one Delivery status section is allowed.
     """
-    if "## Delivery status" not in cleaned:
+    count = _count_h2_sections(cleaned, "Delivery status")
+    if count == 0:
         return []
+    if count > 1:
+        return [f"Duplicate section: '## Delivery status' appears {count} times"]
     body = _section_body(cleaned, "Delivery status")
     if not body:
         return ["Delivery status section is present but empty"]

--- a/tests/test_research_pack_status.py
+++ b/tests/test_research_pack_status.py
@@ -418,3 +418,84 @@ class TestMissingStatusSections:
         """Having only delivery_status (no research_status) should still pass."""
         result = _run_strict(delivery_md_ready_md)
         assert result.returncode == 0, f"expected exit 0, got {result.returncode}\n{result.stdout}"
+
+
+# ── Edge case: Body mention without real section (P1-2 fix) ─────────────
+
+
+class TestBodyMentionNoSection:
+    """Body text references to `## Research status` or `## Delivery status`
+    must NOT trigger false 'section present but empty' errors.
+    The validator must use H2 line-anchored regex, not string containment."""
+
+    @pytest.fixture
+    def body_mention_research_md(self, baseline):
+        """Inject `## Research status` mention inside Uncertainty register body text."""
+        return baseline.replace(
+            "## Uncertainty register\n- Uncertainty: edge cases",
+            "## Uncertainty register\n- Uncertainty: edge cases\n- See `## Research status` in the schema for details.",
+        )
+
+    @pytest.fixture
+    def body_mention_delivery_md(self, baseline):
+        """Inject `## Delivery status` mention inside Uncertainty register body text."""
+        return baseline.replace(
+            "## Uncertainty register\n- Uncertainty: edge cases",
+            "## Uncertainty register\n- Uncertainty: edge cases\n- See `## Delivery status` in the schema for details.",
+        )
+
+    def test_research_mention_in_body_passes(self, body_mention_research_md):
+        result = _run_strict(body_mention_research_md)
+        assert result.returncode == 0, (
+            f"body mention of ## Research status must NOT trigger validation, "
+            f"got exit {result.returncode}: {result.stdout}"
+        )
+
+    def test_delivery_mention_in_body_passes(self, body_mention_delivery_md):
+        result = _run_strict(body_mention_delivery_md)
+        assert result.returncode == 0, (
+            f"body mention of ## Delivery status must NOT trigger validation, "
+            f"got exit {result.returncode}: {result.stdout}"
+        )
+
+
+# ── Edge case: Duplicate sections (P2 fix) ──────────────────────────────
+
+
+class TestDuplicateStatusSections:
+    """Duplicate ## Research status or ## Delivery status sections
+    should be rejected as errors."""
+
+    @pytest.fixture
+    def duplicate_research_md(self, research_complete_md):
+        """Two Research status sections — second one invalid."""
+        return research_complete_md.replace(
+            "## Research status\ncomplete\n",
+            "## Research status\ncomplete\n\n## Research status\nnot-sure\n",
+        )
+
+    @pytest.fixture
+    def duplicate_delivery_md(self, delivery_md_ready_md):
+        """Two Delivery status sections — second one invalid."""
+        return delivery_md_ready_md.replace(
+            "## Delivery status\nmd_ready\n",
+            "## Delivery status\nmd_ready\n\n## Delivery status\nbroken\n",
+        )
+
+    def test_duplicate_research_status_fails(self, duplicate_research_md):
+        result = _run_strict(duplicate_research_md)
+        assert result.returncode == 4, (
+            f"duplicate research_status must fail, got exit {result.returncode}: {result.stdout}"
+        )
+        assert "duplicate" in result.stdout.lower(), (
+            f"expected 'duplicate' in error: {result.stdout}"
+        )
+
+    def test_duplicate_delivery_status_fails(self, duplicate_delivery_md):
+        result = _run_strict(duplicate_delivery_md)
+        assert result.returncode == 4, (
+            f"duplicate delivery_status must fail, got exit {result.returncode}: {result.stdout}"
+        )
+        assert "duplicate" in result.stdout.lower(), (
+            f"expected 'duplicate' in error: {result.stdout}"
+        )

--- a/tests/test_research_pack_status.py
+++ b/tests/test_research_pack_status.py
@@ -1,0 +1,420 @@
+"""Property-based tests for research_status and delivery_status validation.
+
+Tests the new two-layer status fields added to Research Pack for Issue #365.
+Validates that the validate_research_pack.py script correctly handles:
+- Valid status values
+- Invalid status values (strict mode failures)
+- Missing statuses (conditional — not an error)
+- Cross-layer consistency (e.g., blocked research + Pass audit)
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# ── Paths ──────────────────────────────────────────────────────────────────
+
+ROOT = Path(__file__).resolve().parent.parent
+VALIDATOR = ROOT / "scripts" / "validate_research_pack.py"
+
+# Markers: skip tests until implementation exists
+# ── Baseline Research Pack (valid, all 12 required sections present) ─────
+
+BASELINE = """\
+## Objective
+Test task.
+
+## Decision context
+Testing status validation.
+
+## Primary route
+Constrained choice / shortlist
+Closest alternative: market-outlook (rejected — task asks "which" not "what will happen").
+Boundary: if the question shifted to market trends, market-outlook would become primary.
+
+## Secondary disciplines
+source-traceability
+
+## Core subquestions
+Does the validator correctly check status fields?
+
+## Stop condition
+When tests pass.
+
+## Source register
+- [S01] Source: test source
+  - Supports: test claim
+
+## Claim register
+- Claim: Status validation works. [S01]
+  - Support: implementation
+  - Confidence: medium
+
+## Uncertainty register
+- Uncertainty: edge cases
+  - Why it matters: incorrect status could mislead
+
+## Artifact contract
+The report must validate correctly.
+
+## Required audits
+- final audit — passed
+
+## Final audit status
+Pass
+"""
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+def _run_strict(md_content: str) -> subprocess.CompletedProcess:
+    """Run validate_research_pack.py --strict on the given content."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".md", delete=False, encoding="utf-8"
+    ) as f:
+        f.write(md_content)
+        path = f.name
+    try:
+        return subprocess.run(
+            [sys.executable, str(VALIDATOR), path, "--strict"],
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.unlink(path)
+
+
+def _run_nonstrict(md_content: str) -> subprocess.CompletedProcess:
+    """Run validate_research_pack.py (non-strict) on the given content."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".md", delete=False, encoding="utf-8"
+    ) as f:
+        f.write(md_content)
+        path = f.name
+    try:
+        return subprocess.run(
+            [sys.executable, str(VALIDATOR), path],
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.unlink(path)
+
+
+def _inject_section(base: str, heading: str, body: str, *, after: str | None = None) -> str:
+    """Inject a new ## heading section into the baseline.
+
+    If `after` is provided, insert after that entire heading section
+    (i.e. after the next ## heading or end of file).
+    Otherwise, insert before '## Required audits'.
+    """
+    if after:
+        marker = f"## {after}\n"
+    else:
+        marker = "## Required audits\n"
+
+    idx = base.find(marker)
+    if idx == -1:
+        # Fallback: insert before the last ## heading
+        idx = base.rfind("\n## ")
+        if idx == -1:
+            idx = len(base)
+
+    # Find start of next ## heading after the target section
+    rest = base[idx + len(marker):]
+    next_h2 = rest.find("\n## ")
+    if next_h2 == -1:
+        insert_pos = len(base)
+    else:
+        insert_pos = idx + len(marker) + next_h2
+
+    section = f"\n## {heading}\n{body}\n"
+    return base[:insert_pos] + section + base[insert_pos:]
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def baseline() -> str:
+    return BASELINE
+
+
+@pytest.fixture
+def valid_baseline_md() -> str:
+    """Baseline with no extra sections — should pass non-strict."""
+    return BASELINE
+
+
+@pytest.fixture
+def research_complete_md(baseline) -> str:
+    return _inject_section(baseline, "Research status", "complete",
+                           after="Uncertainty register")
+
+
+@pytest.fixture
+def research_partial_md(baseline) -> str:
+    return _inject_section(baseline, "Research status", "partial",
+                           after="Uncertainty register")
+
+
+@pytest.fixture
+def research_blocked_md(baseline) -> str:
+    return _inject_section(baseline, "Research status", "blocked",
+                           after="Uncertainty register")
+
+
+@pytest.fixture
+def delivery_md_ready_md(baseline) -> str:
+    return _inject_section(baseline, "Delivery status", "md_ready",
+                           after="Uncertainty register")
+
+
+@pytest.fixture
+def delivery_pdf_failed_md(baseline) -> str:
+    return _inject_section(baseline, "Delivery status", "pdf_failed",
+                           after="Uncertainty register")
+
+
+@pytest.fixture
+def delivery_not_run_md(baseline) -> str:
+    return _inject_section(baseline, "Delivery status", "not_run",
+                           after="Uncertainty register")
+
+
+@pytest.fixture
+def both_statuses_valid_md(baseline) -> str:
+    """Research status + Delivery status both valid."""
+    md = _inject_section(baseline, "Research status", "complete",
+                         after="Uncertainty register")
+    return _inject_section(md, "Delivery status", "md_ready",
+                           after="Research status")
+
+
+@pytest.fixture
+def research_invalid_md(baseline) -> str:
+    return _inject_section(baseline, "Research status", "not-sure",
+                           after="Uncertainty register")
+
+
+@pytest.fixture
+def delivery_invalid_md(baseline) -> str:
+    return _inject_section(baseline, "Delivery status", "broken",
+                           after="Uncertainty register")
+
+
+@pytest.fixture
+def research_empty_md(baseline) -> str:
+    return _inject_section(baseline, "Research status", "",
+                           after="Uncertainty register")
+
+
+@pytest.fixture
+def blocked_with_pass_audit_md(baseline) -> str:
+    """research_status=blocked but Final audit status=Pass — potential inconsistency."""
+    md = _inject_section(baseline, "Research status", "blocked",
+                         after="Uncertainty register")
+    # Keep Final audit status as Pass
+    return md
+
+
+@pytest.fixture
+def pdf_failed_with_pass_audit_md(baseline) -> str:
+    """delivery_status=pdf_failed but Final audit status=Pass."""
+    md = _inject_section(baseline, "Delivery status", "pdf_failed",
+                         after="Uncertainty register")
+    return md
+
+
+@pytest.fixture
+def all_three_statuses_md(baseline) -> str:
+    """Research status + (existing Final audit) + Delivery status — complete picture."""
+    md = _inject_section(baseline, "Research status", "complete",
+                         after="Uncertainty register")
+    md = _inject_section(md, "Delivery status", "md_ready",
+                         after="Research status")
+    return md
+
+
+# ── Property Tests: Non-strict mode (status sections are conditional) ────
+
+
+class TestResearchStatusNonStrict:
+    """In non-strict mode, research_status and delivery_status are conditional.
+    Missing or invalid statuses should NOT cause failure."""
+
+    def test_baseline_passes_nonstrict(self, valid_baseline_md):
+        result = _run_nonstrict(valid_baseline_md)
+        assert result.returncode == 0, f"expected exit 0, got {result.returncode}\n{result.stdout}"
+
+    def test_research_complete_passes_nonstrict(self, research_complete_md):
+        result = _run_nonstrict(research_complete_md)
+        assert result.returncode == 0, f"expected exit 0, got {result.returncode}\n{result.stdout}"
+
+    def test_delivery_md_ready_passes_nonstrict(self, delivery_md_ready_md):
+        result = _run_nonstrict(delivery_md_ready_md)
+        assert result.returncode == 0, f"expected exit 0, got {result.returncode}\n{result.stdout}"
+
+
+# ── Property Tests: Strict mode — valid statuses ──────────────────────────
+
+
+
+class TestResearchStatusValid:
+    """Valid research_status values should pass strict mode."""
+
+    def test_complete_passes_strict(self, research_complete_md):
+        result = _run_strict(research_complete_md)
+        assert result.returncode == 0, f"expected exit 0, got {result.returncode}\n{result.stdout}"
+
+    def test_partial_passes_strict(self, research_partial_md):
+        result = _run_strict(research_partial_md)
+        assert result.returncode == 0, f"expected exit 0, got {result.returncode}\n{result.stdout}"
+
+    def test_blocked_passes_strict(self, research_blocked_md):
+        result = _run_strict(research_blocked_md)
+        assert result.returncode == 0, f"expected exit 0, got {result.returncode}\n{result.stdout}"
+
+
+
+class TestDeliveryStatusValid:
+    """Valid delivery_status values should pass strict mode."""
+
+    def test_md_ready_passes_strict(self, delivery_md_ready_md):
+        result = _run_strict(delivery_md_ready_md)
+        assert result.returncode == 0, f"expected exit 0, got {result.returncode}\n{result.stdout}"
+
+    def test_pdf_ready_passes_strict(self, baseline):
+        md = _inject_section(baseline, "Delivery status", "pdf_ready",
+                             after="Uncertainty register")
+        result = _run_strict(md)
+        assert result.returncode == 0, f"expected exit 0, got {result.returncode}\n{result.stdout}"
+
+    def test_pdf_failed_passes_strict(self, delivery_pdf_failed_md):
+        result = _run_strict(delivery_pdf_failed_md)
+        assert result.returncode == 0, f"expected exit 0, got {result.returncode}\n{result.stdout}"
+
+    def test_not_run_passes_strict(self, delivery_not_run_md):
+        result = _run_strict(delivery_not_run_md)
+        assert result.returncode == 0, f"expected exit 0, got {result.returncode}\n{result.stdout}"
+
+    def test_trailing_comment_accepted(self, baseline):
+        """Status with trailing comment (matching audit_status word-boundary
+        pattern) should pass."""
+        md = _inject_section(baseline, "Research status",
+                             "complete — verified by external review",
+                             after="Uncertainty register")
+        assert _run_strict(md).returncode == 0
+        md2 = _inject_section(baseline, "Delivery status",
+                              "md_ready — all checks passed",
+                              after="Uncertainty register")
+        assert _run_strict(md2).returncode == 0
+
+
+
+class TestBothStatusesValid:
+    """Both research_status and delivery_status valid simultaneously."""
+
+    def test_both_valid_passes_strict(self, both_statuses_valid_md):
+        result = _run_strict(both_statuses_valid_md)
+        assert result.returncode == 0, f"expected exit 0, got {result.returncode}\n{result.stdout}"
+
+    def test_all_three_layers_passes_strict(self, all_three_statuses_md):
+        result = _run_strict(all_three_statuses_md)
+        assert result.returncode == 0, f"expected exit 0, got {result.returncode}\n{result.stdout}"
+
+
+# ── Property Tests: Strict mode — invalid statuses ──────────────────────
+
+
+
+class TestResearchStatusInvalid:
+    """Invalid research_status values should fail strict mode with exit 4."""
+
+    def test_invalid_fails_strict(self, research_invalid_md):
+        result = _run_strict(research_invalid_md)
+        assert result.returncode == 4, (
+            f"expected exit 4 for invalid research_status, got {result.returncode}\n{result.stdout}"
+        )
+        assert "research" in result.stdout.lower(), (
+            f"expected 'research' in error output: {result.stdout}"
+        )
+
+    def test_empty_fails_strict(self, research_empty_md):
+        result = _run_strict(research_empty_md)
+        assert result.returncode == 4, (
+            f"expected exit 4 for empty research_status, got {result.returncode}\n{result.stdout}"
+        )
+
+
+
+class TestDeliveryStatusInvalid:
+    """Invalid delivery_status values should fail strict mode with exit 4."""
+
+    def test_invalid_fails_strict(self, delivery_invalid_md):
+        result = _run_strict(delivery_invalid_md)
+        assert result.returncode == 4, (
+            f"expected exit 4 for invalid delivery_status, got {result.returncode}\n{result.stdout}"
+        )
+        assert "delivery" in result.stdout.lower(), (
+            f"expected 'delivery' in error output: {result.stdout}"
+        )
+
+
+# ── Property Tests: Cross-layer consistency ─────────────────────────────
+
+
+
+class TestCrossLayerConsistency:
+    """Cross-layer consistency checks between research/audit/delivery statuses."""
+
+    def test_blocked_research_with_pass_audit_is_valid(self, blocked_with_pass_audit_md):
+        """research_status=blocked + Final audit=Pass — valid state.
+        Blocked research means external channels unavailable, but content audit
+        checks the quality of what WAS produced. These are independent layers.
+        Cross-layer consistency is NOT enforced (by design, per CoT vote C)."""
+        result = _run_strict(blocked_with_pass_audit_md)
+        assert result.returncode == 0, (
+            f"blocked + Pass audit is valid (research ≠ quality), "
+            f"got exit {result.returncode}: {result.stdout}"
+        )
+
+    def test_pdf_failed_with_pass_audit_is_valid(self, pdf_failed_with_pass_audit_md):
+        """delivery_status=pdf_failed + Final audit=Pass — valid state.
+        PDF rendering failure is a delivery concern, independent of content audit.
+        Cross-layer consistency is NOT enforced (by design, per CoT vote C)."""
+        result = _run_strict(pdf_failed_with_pass_audit_md)
+        assert result.returncode == 0, (
+            f"pdf_failed + Pass audit is valid (delivery ≠ quality), "
+            f"got exit {result.returncode}: {result.stdout}"
+        )
+
+
+# ── Edge case: Missing status sections ─────────────────────────────────
+
+
+
+class TestMissingStatusSections:
+    """Missing research_status/delivery_status sections should NOT be errors.
+    These are conditional sections — backward compatible."""
+
+    def test_baseline_without_status_sections_passes_strict(self, valid_baseline_md):
+        """Baseline without research_status or delivery_status should pass strict."""
+        result = _run_strict(valid_baseline_md)
+        assert result.returncode == 0, (
+            f"baseline without status sections should pass strict, "
+            f"got exit {result.returncode}: {result.stdout}"
+        )
+
+    def test_only_research_status_passes(self, research_complete_md):
+        """Having only research_status (no delivery_status) should still pass."""
+        result = _run_strict(research_complete_md)
+        assert result.returncode == 0, f"expected exit 0, got {result.returncode}\n{result.stdout}"
+
+    def test_only_delivery_status_passes(self, delivery_md_ready_md):
+        """Having only delivery_status (no research_status) should still pass."""
+        result = _run_strict(delivery_md_ready_md)
+        assert result.returncode == 0, f"expected exit 0, got {result.returncode}\n{result.stdout}"


### PR DESCRIPTION
## Summary

Adds two conditional status fields to the Research Pack schema, separating three previously conflated concerns: **research process completion**, **content audit quality**, and **artifact delivery readiness**.

### New fields

| Field | Valid values | Purpose |
|---|---|---|
| `## Research status` | `complete` / `partial` / `blocked` | Research process completion (not content quality) |
| `## Delivery status` | `md_ready` / `pdf_ready` / `pdf_failed` / `not_run` | Rendering outcome (not content quality) |

### Design decisions (CoT 3-candidate vote)

**Q: Should the validator check cross-layer consistency (e.g., blocked research + Pass audit)?**

Vote: **No cross-layer checks** — the three layers are semantically independent:
- A `blocked` research process (external channel unavailable) can still produce `Pass`-audited content
- A `pdf_failed` delivery does not invalidate Markdown content quality

### Changes

| File | Change |
|---|---|
| `schemas/research-pack.md` | +34 lines: document new conditional sections |
| `scripts/validate_research_pack.py` | +58 lines: `_check_research_status()` + `_check_delivery_status()` in strict mode |
| `SKILL.md` | +7 lines: integrate new status layers into existing blocked/partial doc (stays under 450-line limit) |
| `tests/test_research_pack_status.py` | **New**: 20 property-based tests (pytest) |
| `scripts/test_validator_regression.py` | +173 lines: 10 V5 regression fixtures |

### Test results

- ✅ **581/581** pytest (existing + new, 0 regressions)
- ✅ **53/53** validator regression tests
- ✅ **20/20** new property-based tests
- ✅ Backward compatible — missing sections not an error (conditional)

toward #365 (Phase 1: status unification)