### PR TITLE
feat(#376): contract 引用完整性 — audit registry 接线 / required audits / 混淆边界 / artifact ID / pack 交叉校验

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is intentionally lightweight. Use concise entries that explain:
 ## Unreleased
 
 ### Changed
+- `references/markdown-delivery-contract.md`, `scripts/validate_markdown_delivery.py`, and `tests/test_markdown_delivery_contract.py`: added a standalone Markdown-first reader contract and presentation lint. It keeps the judgment, evidence, route/audit, and Source Register layers readable in `.md` without coupling them to PDF cover/page layout.
 - `SKILL.md`: Phase 1 progressive-disclosure refactoring — extracted environment-specific degraded-search fallback policy, execution discipline, evidence log format, and tool capability mapping (100+ lines) to `references/search-provider-fallback.md`; moved PDF delivery trigger keywords and pipeline steps to `references/delivery-operator-note.md`; added `references/route-index.md` as a compact route selection index (34 lines, all 12 routes from `schemas/route-manifest.json`, ≤80 line limit) for one-read route identification before deep-diving into `ROUTING-MATRIX.md`; SKILL.md reduced from 542 to ~443 lines while retaining all workflow spine, Research Pack lifecycle, evidence standards, current-state verification, mid-research review, counter-evidence, synthesis, parallelization, final discipline, and output quality bar sections. Updated cross-references in `external-channel-preflight.md`, `ARCHITECTURE.md`, `SYSTEM-MAP.md`, and `README.md` (#361).
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ python -m playwright install chromium
 ├── SYSTEM-MAP.md           # 全仓库结构地图 / 问题域地图
 ├── references/
 │   ├── route-index.md      # 紧凑路由选择索引 (读 ROUTING-MATRIX 前先读此)
+│   ├── markdown-delivery-contract.md # Markdown-first 阅读交付契约
 │   ├── search-provider-fallback.md  # 降级搜索 fallback 策略和执行纪律
 │   └── ...                 # 可复用研究方法、模板、纪律说明
 ├── checklists/             # 交付前审计门槛
@@ -147,10 +148,11 @@ python -m playwright install chromium
 4. **`references/`** 提供方法、模板、claim discipline 与研究约束
 5. **`checklists/`** 检查最终产物是否真的达到交付标准
 6. **`evals/`** 把真实失败沉淀成可复盘、可回归的资产
-7. **`scripts/`** 负责 markdown → PDF 等交付层问题
+7. **`scripts/`** 负责 Markdown → PDF 等交付层问题；其中
+   `validate_markdown_delivery.py` 单独检查 Markdown 阅读层的结构与密度
 
 一句话概括：
-**route 决定你该怎么研究，checklist 决定你能不能交付，eval 决定你会不会重复犯错。**
+**route 决定你该怎么研究，Markdown 交付契约决定读者能否快速读懂，checklist 决定你能不能交付，eval 决定你会不会重复犯错。**
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -329,6 +329,11 @@ Never treat the first plausible story as the final one.
 
 Use `references/report-template.md` by default.
 
+For default Markdown/text delivery, read
+`references/markdown-delivery-contract.md` and run
+`python3 scripts/validate_markdown_delivery.py <report>.md`; it supplements
+this template with reader-facing format rules.
+
 Use `references/decision-report-template.md` when the task needs:
 
 - recommendation
@@ -361,7 +366,7 @@ For most tasks, include:
 
 ## Delivery rule
 
-Default delivery stays as text or markdown. Produce a PDF artifact only when the user's request shows explicit file-delivery intent (e.g. "生成 PDF", "导出 PDF", "作为附件给我").
+Default delivery stays as text or markdown. Markdown is the reader-facing source of truth; apply `references/markdown-delivery-contract.md`. Produce a PDF artifact only when the user's request shows explicit file-delivery intent (e.g. "生成 PDF", "导出 PDF", "作为附件给我").
 
 For the complete PDF delivery trigger keywords, negation guard list, and pipeline steps, read `references/delivery-operator-note.md`.
 
@@ -412,6 +417,8 @@ Before delivery:
    - if no specialized route applies (shared-workflow path), list at least `workflow-spine-audit.md` and `final-audit.md`
    - for each listed audit, confirm one of these statuses: **已通过** (passed, with evidence visible in the standardized route-and-audit-status block in the artifact — see `references/report-template.md` §Route and audit status — or in the process log), **已跳过（附理由）** (skipped, with documented reason), or **未运行（附理由）** (not run, with documented reason)
    - if any required audit is missing or not run, run it before proceeding, or document the reason (skipped / not run / not applicable)
+
+For Markdown/text delivery, run `python3 scripts/validate_markdown_delivery.py <report>.md`; if PDF was requested, run the separate checks in `references/delivery-operator-note.md`.
 
 A report that sounds informed but does not visibly satisfy its required artifact contract (route-specific or shared-workflow) is not ready.
 

--- a/references/delivery-operator-note.md
+++ b/references/delivery-operator-note.md
@@ -61,6 +61,8 @@ The pipeline should not be treated as a black box. If the markdown is clean but 
 - `scripts/render_pdf.py` — the PDF renderer; supports `--landscape`, `--media`, `--margin-top`, `--margin-right`, `--margin-bottom`, `--margin-left`, and `--title` for print control
 - `scripts/md_to_pdf.py` — the one-shot pipeline; forwards all print controls
 - `references/failure-taxonomy.md` — documents recurring delivery failure families
+- `references/markdown-delivery-contract.md` — defines the reader-facing
+  Markdown shape and its lightweight presentation lint
 
 ## When to change the rendering layer
 

--- a/references/markdown-delivery-contract.md
+++ b/references/markdown-delivery-contract.md
@@ -1,0 +1,289 @@
+# Markdown-first Delivery Contract
+
+Use this contract when the reader will primarily consume the final `.md` file.
+It is a reader-facing layer, separate from the research/content requirements in
+`references/report-template.md` and the HTML/PDF pipeline in
+`references/delivery-operator-note.md`.
+
+The goal is not to make every report look identical. The goal is to make the
+answer easy to locate, scan, verify, and revisit in plain Markdown, Obsidian,
+GitHub, or a similar reader.
+
+## Activation and boundaries
+
+- Markdown/text delivery is the default, so apply this contract before drafting
+  the final report.
+- If the user explicitly requests PDF, apply this contract first, then run the
+  separate PDF/HTML delivery checks. Page breaks, cover pages, and CSS do not
+  belong in the Markdown contract.
+- `references/report-template.md` still controls research content, evidence,
+  route, and audit requirements. This file controls reading order, density,
+  heading shape, and reader-visible scaffolding.
+- A Research Pack remains a process artifact. Do not paste the complete pack,
+  search log, tool trace, or internal deliberation into the reader-facing body.
+- Route/audit status and the structured Source Register remain required when
+  the applicable validator or route contract requires them; place them after
+  the narrative as appendices so they remain discoverable without taking over
+  the opening.
+
+## Reader goals
+
+A reader opening the file should be able to answer these questions quickly:
+
+1. What is the current judgment?
+2. What are the two to five variables that drive it?
+3. Which parts are confirmed, inferred, or still unknown?
+4. What evidence supports the judgment, and what could overturn it?
+5. What should happen next?
+
+## Document shape
+
+### 1. Metadata and title
+
+Use one H1 and, when the file is stored or indexed in a Markdown vault,
+prefer lightweight YAML frontmatter:
+
+```yaml
+---
+title: "报告标题"
+date: 2026-07-23
+type: decision-report
+route: shared-workflow
+status: final
+---
+```
+
+Keep frontmatter short. Put the actual thesis in the body rather than hiding
+it in metadata. Do not add PDF-only cover instructions, page numbers, or CSS
+classes to the Markdown.
+
+### 2. Judgment card before background
+
+Immediately after the title, show a compact, portable blockquote. It should
+contain no more than four lines:
+
+```markdown
+> **核心判断**：一句话回答用户真正要判断的问题。
+>
+> **置信度**：中；限制来自……
+>
+> **结论范围**：本判断只适用于……
+>
+> **改变条件**：如果……，结论将转向……
+```
+
+For English reports, use `Core thesis`, `Confidence`, `Scope`, and
+`What would change this view`. Keep this block before the first background
+paragraph or market/company history section.
+
+### 3. Executive summary
+
+Use a heading that preserves a stable English alias for tooling when useful:
+
+```markdown
+## 执行摘要（Executive summary）
+```
+
+Use four to eight short bullets. Each bullet should carry one idea and, when
+it is load-bearing, one evidence label and source ID:
+
+```markdown
+- [确认] 已发生的事实，以及它对判断的直接影响。[S01]
+- [推断] 基于两项证据得出的方向性判断。[S02][S04]
+- [未知] 公开资料仍无法确认的变量，以及它为什么重要。
+```
+
+For English reports, use `[CONF]`, `[INFER]`, and `[UNKN]`. For Chinese
+reports, prefer `[确认]`, `[推断]`, and `[未知]`; do not mix the two label
+systems within one report. Labels belong on load-bearing claims, not every
+sentence.
+
+### 4. Main narrative
+
+Use H2 headings for the major decision path and H3 headings for its parts.
+The opening 20–30% should already contain the answer, not only methodology or
+background. A normal Markdown-first sequence is:
+
+1. `执行摘要（Executive summary）`
+2. `最关键变量（What matters most）`
+3. `关键发现（Key findings）`
+4. `详细分析（Detailed analysis）`
+5. `风险与反证（Risks and counter-evidence）`
+6. `不确定性与缺失证据（Uncertainty and missing evidence）`
+7. `结论（Bottom line）`
+8. `建议的下一步（Recommended next steps）`
+9. `附录：路由与审计状态（Route and audit status）`
+10. `附录：来源登记（Source Register）`
+
+Adapt or remove sections when the route does not need them, but do not move
+background ahead of the judgment merely to fill the template. For reports
+longer than roughly six major sections, add a short `阅读导航` block near the
+top or rely on the reader's outline view; do not create a manually maintained
+table of contents if it is likely to become stale.
+
+### 5. Section takeaway block
+
+For each major H2 section, put the section judgment before the supporting
+detail. A compact portable pattern is:
+
+```markdown
+> **本节判断**：这一节改变或强化了什么结论？
+>
+> **主要驱动**：最重要的证据或变量是什么？
+>
+> **主要风险 / 关键未知**：什么限制了结论？
+```
+
+Use this on major sections, not every small H3. Keep it to two or three
+sentences/lines so it remains a reading aid rather than another summary layer.
+
+## Markdown readability rules
+
+### Paragraphs and lists
+
+- Keep one main judgment per paragraph; use the first sentence as the point.
+- Prefer two to five sentences per paragraph. Break longer reasoning into a
+  short judgment, evidence bullets, and a limitation.
+- Use bullets for risks, unknowns, counter-evidence, change conditions, and
+  next steps. Avoid a single bullet containing a mini-essay.
+- Use bold for labels or the key phrase, not for whole paragraphs.
+- Leave a blank line around headings, lists, blockquotes, tables, and fenced
+  code blocks. Do not use HTML/CSS merely to create visual spacing.
+
+### Tables
+
+Use a table only when the reader needs row/column comparison. For normal body
+tables:
+
+- target six columns or fewer; split a wide table by decision dimension;
+- put units and time scope in the header or immediately above the table;
+- keep one fact or one judgment in each cell;
+- after the table, write one or two sentences explaining what matters;
+- use bullets or compact cards for narrative evidence, risks, and unknowns;
+- keep the seven-column Source Register as the explicit appendix exception.
+
+Do not end a major section with an unexplained data dump. Do not mix observed
+numbers, proxies, assumptions, and model outputs without a visible numeric-role
+label at row, column, or table level.
+
+### Evidence and links
+
+- Keep the existing `[S01]`-style source IDs so body claims map to the Source
+  Register. When a direct source link improves reading, use `[S01](URL)`;
+  otherwise keep `[S01]` and make the register entry clickable.
+- Put the evidence label next to the claim it qualifies: `[确认] [S01]`,
+  `[推断] [S02]`, or `[未知]`.
+- Use descriptive Markdown link text in the Source Register instead of long
+  raw URLs when the renderer supports it.
+- Do not put retrieval traces, tool names, raw search snippets, or internal
+  citation placeholders in the final body.
+
+### Appendices and internal scaffolding
+
+Keep the narrative clean while preserving auditability:
+
+```markdown
+## 附录：路由与审计状态（Route and audit status）
+
+...标准化审计状态表...
+
+## 附录：来源登记（Source Register）
+
+...七列表格...
+```
+
+The stable English aliases in parentheses are intentional: they keep the
+reader-friendly Chinese headings compatible with existing validators and
+cross-report tooling. Do not rename an audit to a prose description only.
+
+## Delivery acceptance checklist
+
+Before delivering a Markdown report, confirm:
+
+- [ ] exactly one H1; heading levels do not skip from H2 to H4;
+- [ ] the first screen contains the title, judgment card, and executive
+      summary, before detailed background;
+- [ ] the executive summary has four to eight scannable bullets unless the
+      task is genuinely too small for that shape;
+- [ ] major sections use a visible section judgment before evidence detail;
+- [ ] load-bearing claims have an evidence label and `[Sxx]` citation where
+      applicable;
+- [ ] regular tables are narrow, titled or scoped, and interpreted afterward;
+- [ ] route/audit status and Source Register are present in the required
+      stable form, usually as appendices;
+- [ ] no placeholders, retrieval traces, internal deliberation, or parser
+      residue remain in the final body;
+- [ ] `python3 scripts/validate_markdown_delivery.py <report>.md` passes;
+- [ ] if PDF was requested, the separate PDF pipeline and visual check also
+      pass.
+
+## Minimal Markdown-first skeleton
+
+```markdown
+---
+title: "……"
+date: YYYY-MM-DD
+type: decision-report
+route: …
+status: final
+---
+
+# ……
+
+> **核心判断**：……
+>
+> **置信度**：……
+>
+> **结论范围**：……
+
+## 执行摘要（Executive summary）
+
+- [确认] …… [S01]
+- [推断] …… [S02]
+- [未知] ……
+- 下一步：……
+
+## 最关键变量（What matters most）
+
+> **本节判断**：……
+>
+> **主要驱动**：……
+>
+> **主要风险 / 关键未知**：……
+
+## 关键发现（Key findings）
+
+……
+
+## 详细分析（Detailed analysis）
+
+### ……
+
+……
+
+## 风险与反证（Risks and counter-evidence）
+
+- ……
+
+## 不确定性与缺失证据（Uncertainty and missing evidence）
+
+- ……
+
+## 结论（Bottom line）
+
+……
+
+## 建议的下一步（Recommended next steps）
+
+1. ……
+
+## 附录：路由与审计状态（Route and audit status）
+
+……
+
+## 附录：来源登记（Source Register）
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|---|---|---|---|---|---|---|
+| S01 | …… | primary | YYYY-MM-DD | [链接](URL) | high | §2 |
+```

--- a/references/report-template.md
+++ b/references/report-template.md
@@ -4,6 +4,11 @@ Use this as the default structure for most deep-research outputs.
 
 Do not force every section if the task does not need it, but keep the report decision-oriented and evidence-aware.
 
+For the reader-facing format of a Markdown-first delivery, also read
+`references/markdown-delivery-contract.md`. This template defines what the
+report must contain; the Markdown contract defines how that content should be
+ordered and presented for scan reading.
+
 ## Front-page discipline
 
 The front page should help the reader grasp the report's main judgment quickly.

--- a/scripts/validate_markdown_delivery.py
+++ b/scripts/validate_markdown_delivery.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Validate the reader-facing shape of a Markdown research report.
+
+This is intentionally narrower than ``validate_report_quality.py``. The
+existing validator checks evidence, route/audit status, and source
+traceability; this validator checks Markdown reading order and density:
+
+* one H1 and a continuous heading hierarchy;
+* a judgment/summary opening before detailed analysis;
+* stable Route and audit status / Source Register headings;
+* obvious placeholder residue;
+* overly wide body tables.
+
+Warnings are advisory by default. ``--strict`` promotes warnings to a failing
+exit status for delivery gates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+FENCE_RE = re.compile(r"^[ ]{0,3}(`{3,}|~{3,})")
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+EXECUTIVE_RE = re.compile(r"(?:执行\s*摘要|executive\s+summary)", re.IGNORECASE)
+THESIS_RE = re.compile(
+    r"(?:\*\*)?(?:核心判断|核心结论|一句话判断|bottom[- ]line|core\s+thesis|"
+    r"recommendation|judgment|结论)(?:\*\*)?\s*[:：]",
+    re.IGNORECASE,
+)
+AUDIT_RE = re.compile(
+    r"(?:route\s+and\s+audit\s+status|路由与审计状态)", re.IGNORECASE
+)
+SOURCE_RE = re.compile(r"(?:source\s+register|来源登记)", re.IGNORECASE)
+PLACEHOLDER_RE = re.compile(
+    r"(?:\[\s*(?:TODO|TBD|XXX|SOURCE|CITATION\s+NEEDED|待填写|待补充)\s*\]"
+    r"|\{\{[^\n{}]+\}\})",
+    re.IGNORECASE,
+)
+TABLE_SEPARATOR_RE = re.compile(
+    r"^\s*\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*$"
+)
+
+
+@dataclass
+class ValidationResult:
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def _without_frontmatter(lines: list[str]) -> list[str]:
+    if not lines or lines[0].strip() != "---":
+        return lines
+    for index in range(1, min(len(lines), 80)):
+        if lines[index].strip() == "---":
+            return lines[index + 1 :]
+    return lines
+
+
+def _visible_lines(lines: list[str]) -> list[tuple[int, str]]:
+    """Return (line number, line) pairs outside fenced code blocks."""
+    visible: list[tuple[int, str]] = []
+    in_fence = False
+    fence_char = ""
+    fence_length = 0
+    for number, line in enumerate(lines, start=1):
+        match = FENCE_RE.match(line)
+        if not in_fence and match:
+            in_fence = True
+            fence_char = match.group(1)[0]
+            fence_length = len(match.group(1))
+            continue
+        if in_fence:
+            if re.match(
+                rf"^[ ]{{0,3}}{re.escape(fence_char)}{{{fence_length},}}\s*$",
+                line.rstrip(),
+            ):
+                in_fence = False
+            continue
+        visible.append((number, line))
+    return visible
+
+
+def _heading_context(visible: list[tuple[int, str]], line_number: int) -> str:
+    context = ""
+    for number, line in visible:
+        if number > line_number:
+            break
+        match = HEADING_RE.match(line.rstrip())
+        if match:
+            context = match.group(2)
+    return context
+
+
+def _table_widths(visible: list[tuple[int, str]]) -> list[tuple[int, int, str]]:
+    tables: list[tuple[int, int, str]] = []
+    index = 0
+    while index < len(visible) - 1:
+        line_number, line = visible[index]
+        _, next_line = visible[index + 1]
+        if "|" not in line or not TABLE_SEPARATOR_RE.match(next_line):
+            index += 1
+            continue
+        width = len(line.strip().strip("|").split("|"))
+        tables.append((line_number, width, _heading_context(visible, line_number)))
+        index += 2
+        while index < len(visible):
+            candidate = visible[index][1]
+            if "|" not in candidate or not candidate.strip():
+                break
+            index += 1
+    return tables
+
+
+def validate_markdown_delivery(text: str) -> ValidationResult:
+    result = ValidationResult()
+    raw_lines = text.splitlines()
+    lines = _without_frontmatter(raw_lines)
+    visible = _visible_lines(lines)
+
+    headings: list[tuple[int, int, str]] = []
+    for number, line in visible:
+        match = HEADING_RE.match(line.rstrip())
+        if match:
+            headings.append((number, len(match.group(1)), match.group(2).strip()))
+
+    h1s = [item for item in headings if item[1] == 1]
+    if len(h1s) != 1:
+        result.errors.append(f"expected exactly one H1, found {len(h1s)}")
+    if headings and headings[0][1] != 1:
+        result.errors.append("the first heading must be H1")
+    for previous, current in zip(headings, headings[1:]):
+        if current[1] > previous[1] + 1:
+            result.errors.append(
+                f"heading level skips from H{previous[1]} to H{current[1]} "
+                f"near line {current[0]}"
+            )
+
+    opening = "\n".join(line for _, line in visible[:45])
+    if not THESIS_RE.search(opening):
+        result.errors.append(
+            "the opening 45 lines must contain a judgment/thesis marker"
+        )
+    if not any(EXECUTIVE_RE.search(title) for _, _, title in headings):
+        result.errors.append("missing Executive summary / 执行摘要 heading")
+
+    audit_heading = next(
+        ((number, title) for number, _, title in headings if AUDIT_RE.search(title)),
+        None,
+    )
+    source_heading = next(
+        ((number, title) for number, _, title in headings if SOURCE_RE.search(title)),
+        None,
+    )
+    if audit_heading is None:
+        result.errors.append("missing Route and audit status / 路由与审计状态 heading")
+    if source_heading is None:
+        result.errors.append("missing Source Register / 来源登记 heading")
+    if audit_heading and source_heading and source_heading[0] < audit_heading[0]:
+        result.errors.append("Source Register must appear after Route and audit status")
+
+    body = "\n".join(line for _, line in visible)
+    for match in PLACEHOLDER_RE.finditer(body):
+        result.errors.append(f"placeholder residue: {match.group(0)!r}")
+
+    for line_number, width, context in _table_widths(visible):
+        source_like = bool(SOURCE_RE.search(context))
+        limit = 7 if source_like else 6
+        if width > limit:
+            result.warnings.append(
+                f"table near line {line_number} has {width} columns; "
+                f"reader-facing body tables should stay at {limit} or fewer"
+            )
+
+    # A summary heading without any top-level bullets is usually a prose wall.
+    executive_index = next(
+        (
+            index
+            for index, (_, _, title) in enumerate(headings)
+            if EXECUTIVE_RE.search(title)
+        ),
+        None,
+    )
+    if executive_index is not None:
+        start_line = headings[executive_index][0]
+        end_line = (
+            headings[executive_index + 1][0]
+            if executive_index + 1 < len(headings)
+            else len(lines) + 1
+        )
+        bullet_count = sum(
+            1
+            for number, line in visible
+            if start_line < number < end_line and re.match(r"^\s*[-*+]\s+", line)
+        )
+        if bullet_count == 0:
+            result.warnings.append(
+                "Executive summary has no bullet list; use bullets unless the task is genuinely small"
+            )
+        elif bullet_count > 10:
+            result.warnings.append(
+                f"Executive summary has {bullet_count} bullets; compress to roughly four to eight"
+            )
+
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate reader-facing Markdown delivery shape"
+    )
+    parser.add_argument("input", type=Path, help="Markdown report to validate")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="treat advisory readability warnings as failures",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.input.exists():
+        print(f"error: file not found: {args.input}", file=sys.stderr)
+        return 2
+    result = validate_markdown_delivery(args.input.read_text(encoding="utf-8"))
+    for message in result.errors:
+        print(f"ERROR: {message}")
+    for message in result.warnings:
+        print(f"WARNING: {message}")
+
+    if result.errors:
+        print(f"Markdown delivery failed: {len(result.errors)} error(s)")
+        return 2
+    if args.strict and result.warnings:
+        print(
+            f"Markdown delivery failed in strict mode: {len(result.warnings)} warning(s)"
+        )
+        return 2
+    print("Markdown delivery shape: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_markdown_delivery_contract.py
+++ b/tests/test_markdown_delivery_contract.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from validate_markdown_delivery import validate_markdown_delivery  # noqa: E402
+
+
+VALID_REPORT = """---
+title: \"Example\"
+date: 2026-07-23
+type: decision-report
+route: shared-workflow
+status: final
+---
+
+# Example decision report
+
+> **核心判断**：当前最稳妥的选择是先做小范围验证。
+>
+> **置信度**：中；关键限制是长期数据不足。
+
+## 执行摘要（Executive summary）
+
+- [确认] 方案 A 已满足当前硬约束。[S01]
+- [推断] 方案 A 的实施风险低于方案 B。[S02]
+- [未知] 长期维护成本尚未被公开资料充分验证。
+- 下一步：先在低风险范围内验证，再决定是否扩大投入。
+
+## 最关键变量（What matters most）
+
+> **本节判断**：可逆性比短期功能差异更重要。
+>
+> **主要驱动**：迁移成本和验证周期。
+>
+> **主要风险 / 关键未知**：真实负载下的性能数据。
+
+## 关键发现（Key findings）
+
+方案 A 目前更符合约束。[推断] [S02]
+
+## 详细分析（Detailed analysis）
+
+### 实施约束
+
+先验证低风险场景，再决定是否扩大范围。
+
+## 风险与反证（Risks and counter-evidence）
+
+- 反证：如果维护团队规模不足，结论会变弱。[S03]
+
+## 不确定性与缺失证据（Uncertainty and missing evidence）
+
+- 尚未确认跨区域部署成本。
+
+## 结论（Bottom line）
+
+先做受控试点，再进行全面承诺。
+
+## 建议的下一步（Recommended next steps）
+
+1. 建立试点验收指标。
+
+## 附录：路由与审计状态（Route and audit status）
+
+| Audit | Status | 证据 |
+|---|---|---|
+| final-audit | ✅ Passed | §1-§8 |
+
+## 附录：来源登记（Source Register）
+
+| ID | Source Name | Source Type | Date | DOI/URL | Reliability | Claims Supported |
+|---|---|---|---|---|---|---|
+| S01 | Official note | primary | 2026-07-23 | [链接](https://example.com/1) | high | §2 |
+| S02 | Independent analysis | secondary | 2026-07-23 | [链接](https://example.com/2) | medium | §3 |
+| S03 | Counter-evidence | secondary | 2026-07-23 | [链接](https://example.com/3) | medium | §6 |
+"""
+
+
+def test_valid_reader_facing_report_passes() -> None:
+    result = validate_markdown_delivery(VALID_REPORT)
+    assert result.errors == []
+
+
+def test_heading_skip_is_blocking() -> None:
+    result = validate_markdown_delivery(
+        VALID_REPORT.replace("### 实施约束", "#### 实施约束")
+    )
+    assert any("heading level skips" in error for error in result.errors)
+
+
+def test_missing_opening_judgment_is_blocking() -> None:
+    without_judgment = VALID_REPORT.replace(
+        "> **核心判断**：当前最稳妥的选择是先做小范围验证。\n>\n"
+        "> **置信度**：中；关键限制是长期数据不足。\n",
+        "",
+    )
+    result = validate_markdown_delivery(without_judgment)
+    assert any("judgment/thesis marker" in error for error in result.errors)
+
+
+def test_placeholder_residue_is_blocking() -> None:
+    result = validate_markdown_delivery(
+        VALID_REPORT.replace("受控试点", "受控试点 [TBD]", 1)
+    )
+    assert any("placeholder residue" in error for error in result.errors)
+
+
+def test_body_table_width_is_advisory() -> None:
+    wide = (
+        "| A | B | C | D | E | F | G |\n"
+        "|---|---|---|---|---|---|---|\n"
+        "| 1 | 2 | 3 | 4 | 5 | 6 | 7 |"
+    )
+    result = validate_markdown_delivery(
+        VALID_REPORT.replace("方案 A 目前更符合约束。[推断] [S02]", wide)
+    )
+    assert result.errors == []
+    assert any("columns" in warning for warning in result.warnings)
+
+
+def test_skill_wires_markdown_contract() -> None:
+    skill = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+    assert "markdown-delivery-contract.md" in skill
+    assert "validate_markdown_delivery.py" in skill


### PR DESCRIPTION
## 背景

#376 是总计划 #373 的第 3 步：建立 Research Pack、activation contract 与最终报告之间的引用完整性。依赖控制面 #374（audit-registry + registry_loader）已在 main 合入，本 PR 在其基础上接线。

## 改动

**`scripts/validate_contract.py`**（核心，改用 `registry_loader` 加载三个 registry）：
1. **audit id 接线**：必须存在于 `schemas/audit-registry.json`，或为已声明 secondary route 的派生 id `<secondary>-secondary-hard-fail`（保留 #363 的 hard-fail 语义）
2. **混淆边界**：`closest_alternative` 必须属于 primary route 的 `often_confused_with`（route-manifest.json v2 已有数据，此前无消费者）
3. **required audits 强制**：primary route 的 `required_audits` 必须全部声明，缺失 → error；重复 audit id 从 warning 升级为 error
4. **unknown fields fail-closed**：顶层与 audit 条目的未知字段 → error（范围 3）
5. **稳定 ID**：`artifact_id` / `contract_version` / `created_at` 缺失 → 默认 warning（兼容旧报告），`--strict` 下 error（范围 9 迁移策略）
6. **pack↔contract 交叉校验**：新增 `--research-pack PATH`，解析 pack 的 `## Primary route`（display name/alias 经 `registry_loader.resolve_route`）与 contract `primary_route` 比对，不一致 → exit 2（验收标准 5）

**schema/文档**：`route-activation-contract.json` 补三个 ID 字段定义与语义说明；`research-pack.md` 增加可选 `## Artifact id` / `## Contract reference` 段；`report-template.md` example contract 补齐 `source-traceability` 与 ID 字段。

**测试**：新增 `tests/test_contract_reference_integrity.py`（16 个：registry 外 audit id、派生 hard-fail id、混淆边界违反、required audits 缺失/重复、unknown fields、ID 警告、pack route mismatch/match）；`scripts/test_validate_contract.py` fixtures 全部对齐新规则（helper `_required_audit_entries`）。

## 验证

```bash
python3 -m pytest -q                     # 1239 passed（基线 1223 + 新增 16）
python3 scripts/validate_contract.py references/report-template.md --require-contract        # exit 0
python3 scripts/validate_contract.py references/report-template.md --require-contract --research-pack examples/research-pack-example.md  # exit 2（route 不一致，符合预期）
python3 scripts/validate_research_pack.py examples/research-pack-example.md --strict          # exit 0
python3 scripts/test_validator_regression.py                                                  # 58 passed
```

## 范围说明（与 issue 的对应）

- 验收标准 1-5 全部覆盖；6 中 research/delivery status 已由 #365 在 main 完成，本 PR 不重做；audit_status 枚举统一（`conditional`/`failed` 加入、`not-run` 别名）牵涉契约语义变更，建议作为独立后续 issue
- 范围 8（source/claim register 引用完整性）的边界：pack 侧 register 已由 `validate_research_pack.py` 校验，contract↔register 交叉留给 #373 第 4 步统一 audit orchestrator
- 未实现任何 route-specific audit（issue 非目标）

toward #376