### PR TITLE
Harden manual audit evidence provenance (#390)

### DIFF
--- a/checklists/final-audit.md
+++ b/checklists/final-audit.md
@@ -6,6 +6,7 @@ This is the last gate before the report goes to the user. If any item fails, rev
 
 ## Core question answered
 
+<!-- audit-item: FA-001 -->
 - [ ] the report answers the user's actual question, not just the general topic
 - [ ] the most important 2-3 variables are clearly stated and supported
 - [ ] the bottom line is clear and actionable

--- a/examples/research-pack-example.md
+++ b/examples/research-pack-example.md
@@ -86,8 +86,8 @@ Stop when the top choice, runner-up logic, and ranking-change conditions are sup
 The final memo should visibly show the comparison unit, top choice, runner-up logic, ranking-change conditions, and uncertainty that can move the decision.
 
 ## Required audits
-- final audit — passed
-- quantitative role audit — passed
+- final audit — passed — pack-section:Artifact contract
+- quantitative role audit — passed — pack-section:Artifact contract
 
 ## Final audit status
 Pass

--- a/references/report-template.md
+++ b/references/report-template.md
@@ -247,6 +247,7 @@ This symmetry matters because asymmetric structure signals to the reader that on
 - **一致性要求**：区块中每个声称已通过的审计（✅ Passed 或等效表达/emoji）必须在正文或交付物结构中有对应的执行证据（如 source-traceability ✅ 需要正文存在 `[SN]` 引用，workflow-spine-audit ✅ 需要交付物有清晰的工作流结构）；无对应执行证据的 ✅ Passed 视为自评不准确，由 final-audit 门控标记为未通过
 - **证据列要求**：每项审计的「证据」列必须填写具体的正文引用，不得为空或仅写"是"、"通过"等无明确引用内容：
   - ✅ **已通过 (Passed)** — 使用 typed reference：`report-section:<heading>`、`report-table:<heading>`、`checklist-item:<path>#<id>` 或 `audit-record:<path>#<id>@<ISO-8601>`
+    Checklist item IDs are declared by stable markers such as `<!-- audit-item: FA-001 -->` in the referenced checklist.
   - ⚠️ **已跳过 (Skipped)** — 引用正文中说明跳过理由的章节位置，或说明"§X 已在正文覆盖，未独立运行"
   - ❌ **未运行 (Not run)** — 引用正文中说明未运行原因的章节位置
   「证据」列与 Status 列的自评状态共同构成可审计记录——评审者无需全文扫描即可定位每项审计的执行证据或决定理由。裸 `§3`、`§999` 和任意自由文本不属于可验证 evidence。

--- a/references/report-template.md
+++ b/references/report-template.md
@@ -213,11 +213,11 @@ This symmetry matters because asymmetric structure signals to the reader that on
 
 | Audit | Status | 证据 |
 |-------|--------|------|
-| route-activation-audit | ✅ Passed | §3-§5 路由选择正确，无 Do-not-use 违规 |
-| option-selection-final-audit | ✅ Passed | §4 短名单、反转条件、次优选项均已执行 |
-| source-traceability | ✅ Passed | 正文使用 [S01]-[S12] 引用，附录为 7 列 Source Register |
-| final-audit | ✅ Passed | 各核心关卡在正文可追溯（§2-§6, §8） |
-| regulatory secondary hard-fail | ✅ Passed | §6 逐项验证 4 项 hard-fail 条件：3 项不适用（非监管主题），1 项已验证（§6.2 合规影响分析） |
+| route-activation-audit | ✅ Passed | report-section:Route selection visibility |
+| option-selection-final-audit | ✅ Passed | report-section:Comparison |
+| source-traceability | ✅ Passed | report-section:Sources |
+| final-audit | ✅ Passed | report-section:Bottom line |
+| regulatory secondary hard-fail | ✅ Passed | report-section:Regulatory impact |
 ```
 
 **格式模板（shared-workflow 路径）：**
@@ -229,8 +229,8 @@ This symmetry matters because asymmetric structure signals to the reader that on
 
 | Audit | Status | 证据 |
 |-------|--------|------|
-| workflow-spine-audit | ✅ Passed | 各工作流关卡在正文可追溯（§2-§6） |
-| final-audit | ✅ Passed | 各核心关卡在正文有对应检查标记 |
+| workflow-spine-audit | ✅ Passed | report-section:Findings |
+| final-audit | ✅ Passed | report-section:Bottom line |
 ```
 
 **规则：**
@@ -246,12 +246,14 @@ This symmetry matters because asymmetric structure signals to the reader that on
 - 该区块不追求详尽审计记录，只追求评审者可见——证明审计已运行
 - **一致性要求**：区块中每个声称已通过的审计（✅ Passed 或等效表达/emoji）必须在正文或交付物结构中有对应的执行证据（如 source-traceability ✅ 需要正文存在 `[SN]` 引用，workflow-spine-audit ✅ 需要交付物有清晰的工作流结构）；无对应执行证据的 ✅ Passed 视为自评不准确，由 final-audit 门控标记为未通过
 - **证据列要求**：每项审计的「证据」列必须填写具体的正文引用，不得为空或仅写"是"、"通过"等无明确引用内容：
-  - ✅ **已通过 (Passed)** — 引用执行证据的具体位置（章节号、检查项编号、或 Source Register 条目）
+  - ✅ **已通过 (Passed)** — 使用 typed reference：`report-section:<heading>`、`report-table:<heading>`、`checklist-item:<path>#<id>` 或 `audit-record:<path>#<id>@<ISO-8601>`
   - ⚠️ **已跳过 (Skipped)** — 引用正文中说明跳过理由的章节位置，或说明"§X 已在正文覆盖，未独立运行"
   - ❌ **未运行 (Not run)** — 引用正文中说明未运行原因的章节位置
-  「证据」列与 Status 列的自评状态共同构成可审计记录——评审者无需全文扫描即可定位每项审计的执行证据或决定理由
+  「证据」列与 Status 列的自评状态共同构成可审计记录——评审者无需全文扫描即可定位每项审计的执行证据或决定理由。裸 `§3`、`§999` 和任意自由文本不属于可验证 evidence。
 - 如果路由未选择（shared-workflow 路径），列出 `workflow-spine-audit.md` 和 `final-audit.md` 的运行状态
 - **审计状态应由 validator 输出驱动**：技术类报告交付前，应使用 `scripts/audit_report.py`（route-aware 审计编排器）对报告运行一次 consolidated audit。该工具的 verdict 输出应作为最终 Route and Audit Status 区块的客观依据。如果未运行 audit wrapper，不得将任意状态默认为 ✅ Passed；必须标注为 ⚠️ Manual 或 ❌ Not Run，并附理由。
+
+  JSON 中的 `execution_source` 必须区分 `automated_validator`、`manual_checklist_attestation`、`process_node_evidence` 和兼容模式的 `legacy_self_attested`。
 
 #### 类型化实体说明
 
@@ -288,10 +290,10 @@ Status block 中涉及四类实体，使用统一的 canonical id：
       "secondary_routes": ["regulatory-analysis"],
       "disciplines": ["current-state", "source-traceability", "forward-looking"],
       "audits": [
-        {"id": "option-selection-final-audit", "status": "passed", "evidence": "§4 短名单、反转条件、次优选项均已执行"},
-        {"id": "source-traceability", "status": "passed", "evidence": "[S01]-[S15]"},
-        {"id": "regulatory-analysis-secondary-hard-fail", "status": "passed", "evidence": "§6 verified 4 hard-fail conditions; 2 inapplicable"},
-        {"id": "final-audit", "status": "passed", "evidence": "§2-§8"}
+        {"id": "option-selection-final-audit", "status": "passed", "evidence": "report-section:Comparison"},
+        {"id": "source-traceability", "status": "passed", "evidence": "report-section:Sources"},
+        {"id": "regulatory-analysis-secondary-hard-fail", "status": "passed", "evidence": "report-section:Regulatory impact"},
+        {"id": "final-audit", "status": "passed", "evidence": "report-section:Bottom line"}
       ]
     }
    ```

--- a/references/research-pack-contract.md
+++ b/references/research-pack-contract.md
@@ -126,8 +126,14 @@ What the final report must visibly contain.
 ### Required audits
 Which audits should run before delivery. For each audit, record its run
 status — one of: passed, skipped (with reason), not-run (with reason), or
-partial (with reason for incomplete execution). The run status documents
-whether the audit was actually executed, not just listed.
+partial (with reason for incomplete execution). A `passed` line must include
+a typed evidence reference such as `pack-section:Artifact contract` or
+`checklist-item:checklists/final-audit.md#FA-001`; arbitrary prose is
+`legacy_self_attested` and is not accepted by strict validation. The run
+status documents whether the audit was actually executed, not just listed.
+
+Use the compact form `audit-id — passed — pack-section:Artifact contract`.
+For `skipped`, `not-run`, and `partial`, put the reason after the status.
 
 ### Final audit status
 Whether the report passed, partially passed, or failed audit readiness.
@@ -136,6 +142,10 @@ Required audits: Pass requires all audits to be passed or skipped (with
 reason); Partial is for not-run/partial with reason, or validator warnings
 without errors; Fail is required when any audit is not-run without reason,
 or when strict validation fails.
+
+The report status block and audit JSON use the same provenance labels:
+`automated_validator`, `manual_checklist_attestation`,
+`process_node_evidence`, and compatibility-only `legacy_self_attested`.
 
 ## Scope
 

--- a/references/route-activation-and-preflight.md
+++ b/references/route-activation-and-preflight.md
@@ -100,7 +100,7 @@ In the execution contract (Step 4), add the following requirement: the final del
 This block makes the route selection and audit run status visible to anyone reading the final report, without requiring access to the process log.
 
 - list all required audits for the declared route(s) from `ROUTING-MATRIX.md` `### Audit` sections, along with `route-activation-audit` status and (if a secondary route is declared) the secondary route's hard-fail verification status
-- for each audit, record its status (**已通过** / **已跳过（附理由）** / **未运行（附理由）**) and a concrete evidence citation in the standardized 「证据」column (chapter reference, checklist item number, or Source Register entry — see `references/report-template.md` §证据列要求)
+- for each audit, record its status (**已通过** / **已跳过（附理由）** / **未运行（附理由）**) and a typed evidence reference in the standardized 「证据」column (`report-section:<heading>`, `report-table:<heading>`, `checklist-item:<path>#<id>`, or `audit-record:<path>#<id>@<ISO-8601>` — see `references/report-template.md` §证据列要求)
 - if no specialized route applies (shared-workflow path), list at least `workflow-spine-audit.md` and `final-audit.md` with their run statuses
 
 Do not treat this block as optional or as a process-log-only concern. If the reader cannot see which audits ran, the audit framework has not been delivered.

--- a/schemas/research-pack.md
+++ b/schemas/research-pack.md
@@ -121,7 +121,8 @@ reason), or partial (with reason for incomplete execution). A passed audit
 must carry a typed evidence reference, for example
 `pack-section:Artifact contract` or
 `checklist-item:checklists/final-audit.md#FA-001`; free-form text is legacy
-self-attestation and cannot pass strict validation.
+self-attestation and cannot pass strict validation. Checklist IDs are stable
+markers such as `<!-- audit-item: FA-001 -->` immediately before the item.
 
 The compact Markdown form is:
 

--- a/schemas/research-pack.md
+++ b/schemas/research-pack.md
@@ -117,7 +117,18 @@ State what the final report must visibly contain.
 ### Required audits
 List the audits that should run before delivery. For each audit, record
 its run status — one of: passed, skipped (with reason), not-run (with
-reason), or partial (with reason for incomplete execution).
+reason), or partial (with reason for incomplete execution). A passed audit
+must carry a typed evidence reference, for example
+`pack-section:Artifact contract` or
+`checklist-item:checklists/final-audit.md#FA-001`; free-form text is legacy
+self-attestation and cannot pass strict validation.
+
+The compact Markdown form is:
+
+```md
+- final-audit — passed — pack-section:Artifact contract
+- route-activation-audit — not-run: no route activation record was created
+```
 
 ### Final audit status
 Mark Pass, Partial, or Fail with a short reason. The status must be
@@ -127,6 +138,13 @@ documented reason); Partial is appropriate when some audits are not-run
 or partial with reason, or when validator has warnings but no errors;
 Fail is required when any audit is not-run without reason or when strict
 validation fails.
+
+The same evidence/provenance semantics are used by the report status block
+and the JSON verdict. Automated results are labelled
+`automated_validator`; manual checklist results are labelled
+`manual_checklist_attestation`; process-node results are labelled
+`process_node_evidence`; old free-form entries are labelled
+`legacy_self_attested` in compatibility mode.
 
 ### Research status
 

--- a/schemas/route-activation-contract.json
+++ b/schemas/route-activation-contract.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://deep-research-skill/schemas/route-activation-contract.json",
   "title": "Route Activation Contract",
-  "description": "Typed, verifiable contract that separates primary route, secondary routes, cross-cutting disciplines, and audits. Generated at preflight, re-verified at delivery. Designed for embedding in Markdown ```contract fenced blocks.",
+  "description": "Typed, verifiable contract that separates primary route, secondary routes, cross-cutting disciplines, and audits. Audit evidence uses the shared typed-reference vocabulary and is re-verified at delivery. Designed for embedding in Markdown ```contract fenced blocks.",
   "version": 1,
   "type": "object",
   "required": ["primary_route", "secondary_routes", "disciplines", "audits"],
@@ -75,12 +75,41 @@
           },
           "status": {
             "type": "string",
-            "enum": ["passed", "skipped", "not_run"],
+            "enum": ["passed", "skipped", "not_run", "partial"],
             "description": "Execution status of this audit"
           },
           "evidence": {
+            "description": "Typed reference to a concrete evidence location. Legacy free-form strings are compatibility-only and cannot pass strict validation.",
+            "oneOf": [
+              {
+                "type": "string",
+                "pattern": "^(report-section|report-table|pack-section|pack-table|checklist-item|audit-record|validator):.+$"
+              },
+              {
+                "type": "object",
+                "required": ["kind", "locator"],
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": ["report_section", "report_table", "pack_section", "pack_table", "checklist_item", "audit_record", "automated_validator"]
+                  },
+                  "locator": {"type": "string", "minLength": 1},
+                  "record_path": {"type": "string"},
+                  "record_id": {"type": "string"},
+                  "recorded_at": {"type": "string"},
+                  "validator_binding": {"type": "string"}
+                },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "reason": {
             "type": "string",
-            "description": "Concrete reference to evidence location in artifact. Must be non-empty when status=passed."
+            "description": "Required for skipped, not_run, or partial audits."
+          },
+          "execution_source": {
+            "type": "string",
+            "enum": ["automated_validator", "manual_checklist_attestation", "process_node_evidence", "legacy_self_attested"]
           }
         }
       }
@@ -101,10 +130,10 @@
       "secondary_routes": ["regulatory-analysis"],
       "disciplines": ["current-state", "source-traceability", "forward-looking"],
       "audits": [
-        {"id": "listed-company-report", "status": "passed", "evidence": "§2-§6"},
-        {"id": "source-traceability", "status": "passed", "evidence": "[S01]-[S15]"},
-        {"id": "final-audit", "status": "passed", "evidence": "§2-§8"},
-        {"id": "regulatory-analysis-secondary-hard-fail", "status": "passed", "evidence": "§6 verified 4 hard-fail conditions; 2 inapplicable"}
+        {"id": "listed-company-report", "status": "passed", "evidence": "report-section:Research anchor"},
+        {"id": "source-traceability", "status": "passed", "evidence": "report-section:Sources"},
+        {"id": "final-audit", "status": "passed", "evidence": "report-section:Bottom line"},
+        {"id": "regulatory-analysis-secondary-hard-fail", "status": "passed", "evidence": "report-section:Regulatory impact"}
       ]
     }
   ]

--- a/scripts/audit_evidence.py
+++ b/scripts/audit_evidence.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""Shared, fail-closed validation for audit evidence references.
+
+Audit status is not execution evidence by itself.  This module defines the
+small wire format shared by report status blocks, Research Packs, contracts,
+and the JSON verdict emitted by ``audit_report.py``.
+
+Typed references use one of these prefixes::
+
+    report-section:<exact visible heading>
+    report-table:<exact visible heading>
+    pack-section:<exact visible heading>
+    pack-table:<exact visible heading>
+    checklist-item:<relative checklist path>#<item id>
+    audit-record:<relative record path>#<record id>@<ISO-8601 timestamp>
+    validator:<validator binding id>
+
+Legacy free-form strings are accepted only outside strict mode and are
+explicitly labelled ``legacy_self_attested`` by callers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import re
+from pathlib import Path
+
+
+EXECUTION_SOURCES = frozenset(
+    {
+        "automated_validator",
+        "manual_checklist_attestation",
+        "process_node_evidence",
+        "legacy_self_attested",
+    }
+)
+
+_PREFIX_TO_KIND = {
+    "report-section": "report_section",
+    "report-table": "report_table",
+    "pack-section": "pack_section",
+    "pack-table": "pack_table",
+    "checklist-item": "checklist_item",
+    "audit-record": "audit_record",
+    "validator": "automated_validator",
+}
+_KIND_TO_PREFIX = {value: key for key, value in _PREFIX_TO_KIND.items()}
+_REFERENCE_RE = re.compile(r"^([a-z][a-z-]*):(.*)$", re.IGNORECASE)
+_ITEM_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_RECORD_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]*$")
+_HEADING_RE = re.compile(r"^(#{1,6})[ \t]+(.+?)[ \t]*$")
+
+
+@dataclass(frozen=True)
+class EvidenceValidation:
+    """Result of validating one evidence reference."""
+
+    provenance: dict[str, object] | None = None
+    errors: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+    legacy: bool = False
+
+    @property
+    def is_valid(self) -> bool:
+        return not self.errors
+
+
+def _normalise_heading(value: str) -> str:
+    return " ".join(value.strip().split()).casefold()
+
+
+def _normalise_kind(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip().lower()
+    if value in _PREFIX_TO_KIND:
+        return _PREFIX_TO_KIND[value]
+    if value in _KIND_TO_PREFIX:
+        return value
+    return None
+
+
+def is_typed_reference(value: object) -> bool:
+    """Return whether *value* uses a recognised typed-reference prefix."""
+    if isinstance(value, dict):
+        return _normalise_kind(value.get("kind")) is not None
+    if not isinstance(value, str):
+        return False
+    match = _REFERENCE_RE.match(value.strip())
+    return bool(match and match.group(1).lower() in _PREFIX_TO_KIND)
+
+
+def _safe_path(path_value: str, base_dir: Path) -> tuple[Path | None, str | None]:
+    """Resolve a relative evidence path without allowing path traversal."""
+    candidate = Path(path_value)
+    if candidate.is_absolute():
+        return None, "evidence path must be relative"
+    root = base_dir.resolve()
+    resolved = (root / candidate).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError:
+        return None, "evidence path escapes the artifact directory"
+    return resolved, None
+
+
+def _headings(text: str) -> list[tuple[int, str, int]]:
+    result: list[tuple[int, str, int]] = []
+    for line_number, line in enumerate(text.splitlines(), 1):
+        match = _HEADING_RE.match(line)
+        if match:
+            result.append((len(match.group(1)), match.group(2), line_number))
+    return result
+
+
+def _section_lines(text: str, heading_line: int) -> list[str]:
+    lines = text.splitlines()
+    start = heading_line
+    for index in range(start, len(lines)):
+        if index > start and _HEADING_RE.match(lines[index]):
+            return lines[start:index]
+    return lines[start:]
+
+
+def _validate_artifact_heading(
+    kind: str,
+    locator: str,
+    artifact_text: str | None,
+    artifact_label: str,
+) -> EvidenceValidation:
+    if not locator.strip():
+        return EvidenceValidation(errors=(f"{kind} evidence locator is empty",))
+
+    if artifact_text is None:
+        return EvidenceValidation(
+            provenance={
+                "kind": kind,
+                "locator": locator,
+                "verified": False,
+            }
+        )
+
+    matches = [
+        (level, title, line)
+        for level, title, line in _headings(artifact_text)
+        if _normalise_heading(title) == _normalise_heading(locator)
+    ]
+    if not matches:
+        return EvidenceValidation(
+            errors=(
+                f"{kind} evidence locator {locator!r} was not found in "
+                f"the visible {artifact_label}",
+            )
+        )
+    if len(matches) > 1:
+        return EvidenceValidation(
+            errors=(
+                f"{kind} evidence locator {locator!r} is ambiguous in "
+                f"the visible {artifact_label} ({len(matches)} matches)",
+            )
+        )
+
+    _, _, line = matches[0]
+    return EvidenceValidation(
+        provenance={
+            "kind": kind,
+            "locator": locator,
+            "verified": True,
+            "line": line,
+        }
+    )
+
+
+def _validate_artifact_table(
+    kind: str,
+    locator: str,
+    artifact_text: str | None,
+    artifact_label: str,
+) -> EvidenceValidation:
+    heading_result = _validate_artifact_heading(
+        kind,
+        locator,
+        artifact_text,
+        artifact_label,
+    )
+    if heading_result.errors or artifact_text is None:
+        if artifact_text is None and heading_result.provenance:
+            heading_result = EvidenceValidation(
+                provenance={
+                    **heading_result.provenance,
+                    "kind": kind,
+                },
+                errors=heading_result.errors,
+                warnings=heading_result.warnings,
+                legacy=heading_result.legacy,
+            )
+        return heading_result
+
+    line = int(heading_result.provenance["line"])
+    section = _section_lines(artifact_text, line)
+    has_row = any("|" in current for current in section)
+    has_separator = any(
+        "|" in current and re.search(r"-{3,}", current)
+        for current in section
+    )
+    if not has_row or not has_separator:
+        return EvidenceValidation(
+            errors=(
+                f"{kind} evidence locator {locator!r} does not point "
+                "to a visible Markdown table",
+            )
+        )
+    return EvidenceValidation(
+        provenance={
+            **heading_result.provenance,
+            "kind": kind,
+        }
+    )
+
+
+def _validate_checklist_item(
+    locator: str,
+    base_dir: Path | None,
+) -> EvidenceValidation:
+    if "#" not in locator:
+        return EvidenceValidation(
+            errors=(
+                "checklist-item evidence must use "
+                "<relative checklist path>#<item id>",
+            )
+        )
+    path_value, item_id = locator.rsplit("#", 1)
+    if not path_value or not _ITEM_ID_RE.fullmatch(item_id):
+        return EvidenceValidation(
+            errors=(
+                "checklist-item evidence has an invalid path or item id",
+            )
+        )
+
+    provenance: dict[str, object] = {
+        "kind": "checklist_item",
+        "locator": locator,
+        "checklist": path_value,
+        "item_id": item_id,
+        "verified": False,
+    }
+    if base_dir is None:
+        return EvidenceValidation(provenance=provenance)
+
+    path, path_error = _safe_path(path_value, base_dir)
+    if path_error:
+        return EvidenceValidation(errors=(path_error,))
+    assert path is not None
+    if not path.is_file():
+        return EvidenceValidation(
+            errors=(f"checklist file does not exist: {path_value}",)
+        )
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return EvidenceValidation(
+            errors=(f"cannot read checklist file {path_value}: {exc}",)
+        )
+
+    marker_patterns = (
+        rf"<!--\s*audit-item\s*:\s*{re.escape(item_id)}\s*-->",
+        rf"\{{#{re.escape(item_id)}\}}",
+        rf"^\s*-\s*\[[ xX]\]\s+\*\*{re.escape(item_id)}\*\*",
+    )
+    if not any(re.search(pattern, text, re.MULTILINE) for pattern in marker_patterns):
+        return EvidenceValidation(
+            errors=(
+                f"checklist item {item_id!r} was not found in {path_value}",
+            )
+        )
+    provenance["verified"] = True
+    return EvidenceValidation(provenance=provenance)
+
+
+def _validate_audit_record(
+    locator: str,
+    base_dir: Path | None,
+) -> EvidenceValidation:
+    match = re.fullmatch(r"([^#]+)#([^@]+)@(.+)", locator)
+    if not match:
+        return EvidenceValidation(
+            errors=(
+                "audit-record evidence must use "
+                "<relative path>#<record id>@<ISO-8601 timestamp>",
+            )
+        )
+    path_value, record_id, timestamp = match.groups()
+    if not _RECORD_ID_RE.fullmatch(record_id):
+        return EvidenceValidation(errors=("audit-record has an invalid record id",))
+    try:
+        datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        return EvidenceValidation(
+            errors=(f"audit-record timestamp is not ISO-8601: {timestamp!r}",)
+        )
+
+    provenance: dict[str, object] = {
+        "kind": "audit_record",
+        "locator": locator,
+        "record_path": path_value,
+        "record_id": record_id,
+        "recorded_at": timestamp,
+        "verified": False,
+    }
+    if base_dir is None:
+        return EvidenceValidation(provenance=provenance)
+    path, path_error = _safe_path(path_value, base_dir)
+    if path_error:
+        return EvidenceValidation(errors=(path_error,))
+    assert path is not None
+    if not path.is_file():
+        return EvidenceValidation(
+            errors=(f"audit record file does not exist: {path_value}",)
+        )
+    provenance["verified"] = True
+    return EvidenceValidation(provenance=provenance)
+
+
+def validate_evidence_reference(
+    reference: object,
+    *,
+    artifact_text: str | None = None,
+    base_dir: Path | None = None,
+    strict: bool = False,
+    artifact_label: str = "report",
+) -> EvidenceValidation:
+    """Validate one typed evidence reference.
+
+    ``artifact_text`` is optional because standalone contract/pack validators
+    may only have the process artifact, not the final report.  When supplied,
+    section/table references are resolved against visible content.  Legacy
+    free-form strings are warnings outside strict mode and errors in strict
+    mode; callers can still expose their provenance explicitly.
+    """
+    kind: str | None = None
+    locator: str | None = None
+    if isinstance(reference, dict):
+        kind = _normalise_kind(reference.get("kind"))
+        raw_locator = reference.get("locator")
+        if isinstance(raw_locator, str):
+            locator = raw_locator.strip()
+    elif isinstance(reference, str):
+        raw = reference.strip()
+        match = _REFERENCE_RE.match(raw)
+        if match:
+            kind = _PREFIX_TO_KIND.get(match.group(1).lower())
+            if kind is not None:
+                locator = match.group(2).strip()
+        if kind is None:
+            provenance = {
+                "kind": "legacy_self_attested",
+                "locator": raw,
+                "verified": False,
+            }
+            if strict:
+                return EvidenceValidation(
+                    provenance=provenance,
+                    errors=(
+                        "evidence must use a typed reference; free-form "
+                        "evidence is legacy_self_attested",
+                    ),
+                    legacy=True,
+                )
+            return EvidenceValidation(
+                provenance=provenance,
+                warnings=(
+                    "free-form evidence is legacy_self_attested and was "
+                    "not independently verified",
+                ),
+                legacy=True,
+            )
+    else:
+        return EvidenceValidation(
+            errors=(
+                "evidence must be a typed reference string or object",
+            )
+        )
+
+    if kind is None:
+        return EvidenceValidation(
+            errors=(
+                "evidence kind is unknown; use report-section, report-table, "
+                "pack-section, pack-table, checklist-item, audit-record, "
+                "or validator",
+            )
+        )
+    if locator is None or not locator:
+        return EvidenceValidation(errors=(f"{kind} evidence locator is empty",))
+
+    if kind in {"report_section", "pack_section"}:
+        label = "pack" if kind == "pack_section" else artifact_label
+        return _validate_artifact_heading(kind, locator, artifact_text, label)
+    if kind in {"report_table", "pack_table"}:
+        label = "pack" if kind == "pack_table" else artifact_label
+        return _validate_artifact_table(kind, locator, artifact_text, label)
+    if kind == "checklist_item":
+        return _validate_checklist_item(locator, base_dir)
+    if kind == "audit_record":
+        return _validate_audit_record(locator, base_dir)
+    if kind == "automated_validator":
+        return EvidenceValidation(
+            provenance={
+                "kind": "automated_validator",
+                "locator": locator,
+                "validator_binding": locator,
+                "verified": True,
+            }
+        )
+    return EvidenceValidation(
+        errors=(f"unsupported evidence kind: {kind}",)
+    )
+
+
+def typed_reference(kind: str, locator: str) -> str:
+    """Render a canonical string reference for fixtures and templates."""
+    prefix = _KIND_TO_PREFIX.get(kind, kind)
+    return f"{prefix}:{locator}"

--- a/scripts/audit_evidence.py
+++ b/scripts/audit_evidence.py
@@ -398,6 +398,7 @@ def validate_evidence_reference(
     strict: bool = False,
     artifact_label: str = "report",
     known_validator_bindings: Collection[str] | None = None,
+    execution_type: str | None = None,
 ) -> EvidenceValidation:
     """Validate one typed evidence reference.
 
@@ -473,6 +474,19 @@ def validate_evidence_reference(
     if kind == "audit_record":
         return _validate_audit_record(locator, base_dir)
     if kind == "automated_validator":
+        if execution_type in {"manual", "process"}:
+            return EvidenceValidation(
+                provenance={
+                    "kind": "automated_validator",
+                    "locator": locator,
+                    "validator_binding": locator,
+                    "verified": False,
+                },
+                errors=(
+                    f"{execution_type} audits cannot use validator evidence; "
+                    "use a checklist, artifact, or audit-record reference",
+                ),
+            )
         known_bindings = frozenset(
             known_validator_bindings
             if known_validator_bindings is not None

--- a/scripts/audit_evidence.py
+++ b/scripts/audit_evidence.py
@@ -21,8 +21,10 @@ explicitly labelled ``legacy_self_attested`` by callers.
 
 from __future__ import annotations
 
+import json
+from collections.abc import Collection
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 import re
 from pathlib import Path
 
@@ -318,8 +320,74 @@ def _validate_audit_record(
         return EvidenceValidation(
             errors=(f"audit record file does not exist: {path_value}",)
         )
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        return EvidenceValidation(
+            errors=(
+                f"audit record file must contain JSON records: {path_value} "
+                f"({exc})",
+            )
+        )
+
+    if isinstance(payload, list):
+        records = payload
+    elif isinstance(payload, dict) and isinstance(payload.get("records"), list):
+        records = payload["records"]
+    elif isinstance(payload, dict):
+        records = [payload]
+    else:
+        return EvidenceValidation(
+            errors=(
+                f"audit record file must contain a JSON object, array, or "
+                f"records array: {path_value}",
+            )
+        )
+
+    def _parse_timestamp(value: object) -> datetime | None:
+        if not isinstance(value, str):
+            return None
+        try:
+            parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    expected_time = _parse_timestamp(timestamp)
+    matching_record = None
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        candidate_id = record.get("record_id", record.get("id"))
+        candidate_time = record.get(
+            "recorded_at",
+            record.get("timestamp", record.get("executed_at")),
+        )
+        if candidate_id != record_id or _parse_timestamp(candidate_time) != expected_time:
+            continue
+        matching_record = record
+        break
+    if matching_record is None:
+        return EvidenceValidation(
+            errors=(
+                f"audit record {record_id!r} with timestamp {timestamp!r} "
+                f"was not found in {path_value}",
+            )
+        )
     provenance["verified"] = True
     return EvidenceValidation(provenance=provenance)
+
+
+def _default_validator_bindings() -> frozenset[str]:
+    """Load the canonical validator binding set without importing audit_report."""
+    try:
+        from registry_loader import AUDIT_BINDING_IDS
+    except (ImportError, AttributeError):
+        return frozenset()
+    return frozenset(AUDIT_BINDING_IDS)
 
 
 def validate_evidence_reference(
@@ -329,6 +397,7 @@ def validate_evidence_reference(
     base_dir: Path | None = None,
     strict: bool = False,
     artifact_label: str = "report",
+    known_validator_bindings: Collection[str] | None = None,
 ) -> EvidenceValidation:
     """Validate one typed evidence reference.
 
@@ -404,6 +473,23 @@ def validate_evidence_reference(
     if kind == "audit_record":
         return _validate_audit_record(locator, base_dir)
     if kind == "automated_validator":
+        known_bindings = frozenset(
+            known_validator_bindings
+            if known_validator_bindings is not None
+            else _default_validator_bindings()
+        )
+        if locator not in known_bindings:
+            return EvidenceValidation(
+                provenance={
+                    "kind": "automated_validator",
+                    "locator": locator,
+                    "validator_binding": locator,
+                    "verified": False,
+                },
+                errors=(
+                    f"validator binding {locator!r} is not registered",
+                ),
+            )
         return EvidenceValidation(
             provenance={
                 "kind": "automated_validator",

--- a/scripts/audit_report.py
+++ b/scripts/audit_report.py
@@ -83,6 +83,7 @@ from validate_research_pack import (
     run_strict_checks as vrp_run_strict_checks,
     strip_fenced_code_blocks as vrp_strip_fenced_code_blocks,
 )
+from audit_evidence import validate_evidence_reference
 
 # ── Runtime control-plane registry (issue #374) ─────────────────────────────
 # Route identity, aliases and validator dispatch bindings come from
@@ -561,6 +562,7 @@ def _run_contract_check(path: Path, **kwargs: bool) -> CheckResult:
             name="contract-check",
             errors=[f"{path}: cannot read file — {exc}"],
         )
+    visible_text = vc_strip_fences(text)
 
     # Cardinality checks on user-writable declarations (issue #378): more
     # than one contract block / route status block is structural
@@ -619,6 +621,8 @@ def _run_contract_check(path: Path, **kwargs: bool) -> CheckResult:
         contract,
         report_primary_route=report_route,
         strict=strict,
+        report_text=visible_text,
+        evidence_base_dir=Path(__file__).resolve().parent.parent,
     )
     if result.errors:
         return CheckResult(
@@ -655,6 +659,8 @@ def _run_contract_check(path: Path, **kwargs: bool) -> CheckResult:
             pack_artifact_id=pack_artifact,
             research_pack_provided=True,
             strict=strict,
+            report_text=visible_text,
+            evidence_base_dir=Path(__file__).resolve().parent.parent,
         )
         if cross.errors:
             return CheckResult(
@@ -738,7 +744,20 @@ def _run_research_pack(pack_path: Path | None, **kwargs: bool) -> CheckResult:
     missing = vrp_find_missing_headings(cleaned)
     errors.extend(f"pack missing required heading: {h}" for h in missing)
     try:
-        errors.extend(vrp_run_strict_checks(cleaned))
+        report_path = kwargs.get("report_path")
+        report_text: str | None = None
+        if isinstance(report_path, Path) and report_path.is_file():
+            report_text = vc_strip_fences(
+                report_path.read_text(encoding="utf-8", errors="replace")
+            )
+        errors.extend(
+            vrp_run_strict_checks(
+                cleaned,
+                artifact_text=cleaned,
+                evidence_base_dir=Path(__file__).resolve().parent.parent,
+                report_text=report_text,
+            )
+        )
     except Exception as exc:
         errors.append(f"research-pack strict checks crashed: {exc}")
     return CheckResult(name="research-pack", errors=errors, warnings=[])
@@ -845,15 +864,19 @@ class AuditResult:
 
     status is one of: pass | conditional-pass | fail | not_run | skipped |
     partial.  ``not_run``/``skipped`` mean the audit did not execute and
-    must never aggregate to a Pass verdict.
+    must never aggregate to a Pass verdict. execution_source distinguishes
+    automated validator output, manual checklist attestation, process-node
+    evidence, and legacy self-attestation (issue #390).
     """
 
     audit_id: str
     execution_type: str  # automated | manual | process
     status: str
+    execution_source: str | None = None
     errors: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     evidence: list[str] = field(default_factory=list)
+    evidence_provenance: list[dict[str, object]] = field(default_factory=list)
     validator_binding: str | None = None
     reason: str | None = None
 
@@ -1101,6 +1124,17 @@ def _audit_validator_fn(binding: str) -> ValidatorFn | None:
     return fn
 
 
+def _execution_source(execution_type: str, *, legacy: bool = False) -> str:
+    """Map registry execution type to the public provenance vocabulary."""
+    if legacy:
+        return "legacy_self_attested"
+    if execution_type == "automated":
+        return "automated_validator"
+    if execution_type == "process":
+        return "process_node_evidence"
+    return "manual_checklist_attestation"
+
+
 def _execute_required_audits(
     path: Path,
     route_id: str,
@@ -1119,6 +1153,12 @@ def _execute_required_audits(
     """
     audit_ids = _ROUTE_REGISTRY.required_audits_for(route_id) + list(GLOBAL_AUDITS)
     block_statuses, block_malformed = _parse_audit_block_statuses(path)
+    try:
+        visible_text = vc_strip_fences(
+            path.read_text(encoding="utf-8", errors="replace")
+        )
+    except (OSError, UnicodeError):
+        visible_text = None
     results: list[AuditResult] = []
     blocking: list[str] = []
     warnings: list[str] = []
@@ -1156,14 +1196,50 @@ def _execute_required_audits(
                 status = declared["status"]
                 reason = None
             evidence = [declared["evidence"]] if declared and declared["evidence"] else []
+            execution_source = _execution_source(audit.execution_type)
+            evidence_provenance: list[dict[str, object]] = []
             if status == "pass" and not evidence:
                 status = "partial"
                 reason = "declared Passed but evidence column is empty"
+            elif (
+                declared is not None
+                and not declared.get("duplicate")
+                and status in {"skipped", "not_run", "partial"}
+                and not evidence
+            ):
+                reason = (
+                    f"declared status '{status}' requires a reason or evidence "
+                    "reference"
+                )
+            elif status == "pass":
+                evidence_result = validate_evidence_reference(
+                    evidence[0],
+                    artifact_text=visible_text,
+                    base_dir=Path(__file__).resolve().parent.parent,
+                    strict=strict,
+                    artifact_label="report",
+                )
+                if evidence_result.legacy:
+                    execution_source = _execution_source(
+                        audit.execution_type, legacy=True
+                    )
+                if evidence_result.provenance:
+                    evidence_provenance.append(
+                        {
+                            **evidence_result.provenance,
+                            "execution_source": execution_source,
+                        }
+                    )
+                if evidence_result.errors:
+                    status = "partial"
+                    reason = "; ".join(evidence_result.errors)
             result = AuditResult(
                 audit_id=audit_id,
                 execution_type=audit.execution_type,
                 status=status,
+                execution_source=execution_source,
                 evidence=evidence,
+                evidence_provenance=evidence_provenance,
                 reason=reason,
             )
             results.append(result)
@@ -1209,13 +1285,23 @@ def _execute_required_audits(
                 audit_id=audit_id,
                 execution_type="automated",
                 status=status,
+                execution_source="automated_validator",
                 validator_binding=binding,
+                evidence_provenance=[{
+                    "kind": "automated_validator",
+                    "locator": binding,
+                    "validator_binding": binding,
+                    "verified": False,
+                }],
                 reason=reason,
             ))
             continue
         try:
             target = research_pack if audit_id == "research-pack" else path
-            check = fn(target, strict=strict)
+            audit_kwargs: dict[str, object] = {"strict": strict}
+            if audit_id == "research-pack":
+                audit_kwargs["report_path"] = path
+            check = fn(target, **audit_kwargs)
         except Exception as exc:
             check = CheckResult(
                 name=audit_id,
@@ -1236,14 +1322,23 @@ def _execute_required_audits(
         else:
             # Success carries an evidence location (issue #378 acceptance 8).
             evidence = [f"{target}: no violations found by {binding}"]
+        evidence_provenance = [{
+            "kind": "automated_validator",
+            "locator": binding,
+            "validator_binding": binding,
+            "target": str(target),
+            "verified": True,
+        }]
         results.append(AuditResult(
             audit_id=audit_id,
             execution_type="automated",
             status=status,
+            execution_source="automated_validator",
             errors=list(check.errors),
             warnings=list(check.warnings),
             validator_binding=binding,
             evidence=evidence,
+            evidence_provenance=evidence_provenance,
             reason="advisory outside strict mode" if advisory else None,
         ))
         if not advisory:
@@ -1281,14 +1376,44 @@ def _execute_required_audits(
             status, reason = "pass", None
         else:
             status, reason = str(entry.get("status", "not_run")).lower(), None
-        evidence = [str(entry.get("evidence", "")).strip()] if entry and entry.get("evidence") else []
+        raw_evidence = entry.get("evidence") if entry else None
+        if isinstance(raw_evidence, str) and raw_evidence.strip():
+            evidence = [raw_evidence.strip()]
+        elif isinstance(raw_evidence, dict):
+            evidence = [json.dumps(raw_evidence, ensure_ascii=False, sort_keys=True)]
+        else:
+            evidence = []
+        execution_source = _execution_source("manual")
+        evidence_provenance: list[dict[str, object]] = []
         if status == "pass" and not evidence:
             status, reason = "partial", "hard-fail entry declared Passed but evidence empty"
+        elif status == "pass":
+            evidence_result = validate_evidence_reference(
+                raw_evidence,
+                artifact_text=visible_text,
+                base_dir=Path(__file__).resolve().parent.parent,
+                strict=strict,
+                artifact_label="report",
+            )
+            if evidence_result.legacy:
+                execution_source = _execution_source("manual", legacy=True)
+            if evidence_result.provenance:
+                evidence_provenance.append(
+                    {
+                        **evidence_result.provenance,
+                        "execution_source": execution_source,
+                    }
+                )
+            if evidence_result.errors:
+                status = "partial"
+                reason = "; ".join(evidence_result.errors)
         result = AuditResult(
             audit_id=derived_id,
             execution_type="manual",
             status=status,
+            execution_source=execution_source,
             evidence=evidence,
+            evidence_provenance=evidence_provenance,
             reason=reason,
         )
         results.append(result)
@@ -1418,10 +1543,12 @@ def _verdict_to_json(verdict: AuditVerdict) -> str:
             {
                 "audit_id": a.audit_id,
                 "execution_type": a.execution_type,
+                "execution_source": a.execution_source,
                 "status": a.status,
                 "errors": a.errors,
                 "warnings": a.warnings,
                 "evidence": a.evidence,
+                "evidence_provenance": a.evidence_provenance,
                 "validator_binding": a.validator_binding,
                 "reason": a.reason,
             }

--- a/scripts/audit_report.py
+++ b/scripts/audit_report.py
@@ -623,6 +623,7 @@ def _run_contract_check(path: Path, **kwargs: bool) -> CheckResult:
         strict=strict,
         report_text=visible_text,
         evidence_base_dir=Path(__file__).resolve().parent.parent,
+        known_validator_bindings=_registered_validator_bindings(),
     )
     if result.errors:
         return CheckResult(
@@ -661,6 +662,7 @@ def _run_contract_check(path: Path, **kwargs: bool) -> CheckResult:
             strict=strict,
             report_text=visible_text,
             evidence_base_dir=Path(__file__).resolve().parent.parent,
+            known_validator_bindings=_registered_validator_bindings(),
         )
         if cross.errors:
             return CheckResult(
@@ -756,6 +758,7 @@ def _run_research_pack(pack_path: Path | None, **kwargs: bool) -> CheckResult:
                 artifact_text=cleaned,
                 evidence_base_dir=Path(__file__).resolve().parent.parent,
                 report_text=report_text,
+                known_validator_bindings=_registered_validator_bindings(),
             )
         )
     except Exception as exc:
@@ -1135,6 +1138,11 @@ def _execution_source(execution_type: str, *, legacy: bool = False) -> str:
     return "manual_checklist_attestation"
 
 
+def _registered_validator_bindings() -> set[str]:
+    """Return validator ids with runtime functions in this module."""
+    return set(_VALIDATOR_REGISTRY) | set(_AUDIT_VALIDATOR_REGISTRY)
+
+
 def _execute_required_audits(
     path: Path,
     route_id: str,
@@ -1218,6 +1226,7 @@ def _execute_required_audits(
                     base_dir=Path(__file__).resolve().parent.parent,
                     strict=strict,
                     artifact_label="report",
+                    known_validator_bindings=_registered_validator_bindings(),
                 )
                 if evidence_result.legacy:
                     execution_source = _execution_source(
@@ -1394,6 +1403,7 @@ def _execute_required_audits(
                 base_dir=Path(__file__).resolve().parent.parent,
                 strict=strict,
                 artifact_label="report",
+                known_validator_bindings=_registered_validator_bindings(),
             )
             if evidence_result.legacy:
                 execution_source = _execution_source("manual", legacy=True)

--- a/scripts/audit_report.py
+++ b/scripts/audit_report.py
@@ -1227,6 +1227,7 @@ def _execute_required_audits(
                     strict=strict,
                     artifact_label="report",
                     known_validator_bindings=_registered_validator_bindings(),
+                    execution_type=audit.execution_type,
                 )
                 if evidence_result.legacy:
                     execution_source = _execution_source(
@@ -1404,6 +1405,7 @@ def _execute_required_audits(
                 strict=strict,
                 artifact_label="report",
                 known_validator_bindings=_registered_validator_bindings(),
+                execution_type="manual",
             )
             if evidence_result.legacy:
                 execution_source = _execution_source("manual", legacy=True)

--- a/scripts/test_audit_report.py
+++ b/scripts/test_audit_report.py
@@ -1233,8 +1233,8 @@ Stop when evidence saturated.
 
 ## Required audits
 
-- audit-one — passed — pack-section:Artifact contract
-- audit-two — passed — pack-section:Artifact contract
+- market-outlook-audit — passed — pack-section:Artifact contract
+- final-audit — passed — pack-section:Artifact contract
 
 ## Final audit status
 

--- a/scripts/test_audit_report.py
+++ b/scripts/test_audit_report.py
@@ -45,10 +45,10 @@ def _valid_report() -> str:
 
 | Audit | Status | 证据 |
 |-------|--------|------|
-| source-traceability | ✅ Passed | §3 正文使用 [S01] 与 [S02] 引用 |
-| final-audit | ✅ Passed | §2-§6 各核心关卡可追溯 |
-| quantitative-role-labeling | ✅ Passed | §5 Comparison 表格含数字角色列 |
-| technical-analysis-audit | ✅ Passed | §4 判断与维度结论可追溯 |
+| source-traceability | ✅ Passed | report-section:Findings |
+| final-audit | ✅ Passed | report-section:执行摘要 |
+| quantitative-role-labeling | ✅ Passed | report-table:Comparison Table |
+| technical-analysis-audit | ✅ Passed | report-section:维度结论 |
 
 ## 执行摘要
 
@@ -80,7 +80,7 @@ Each dimension conclusion is backed by [S01] and [S02].
 | S02 | Example B | secondary | 2026-02-01 | https://example.com/b | high | §5 |
 
 ```contract
-{"primary_route": "technical-deep-dive", "secondary_routes": [], "disciplines": [], "audits": [{"id": "technical-analysis-audit", "status": "passed", "evidence": "§4"}, {"id": "source-traceability", "status": "passed", "evidence": "§3"}, {"id": "final-audit", "status": "passed", "evidence": "§2"}], "artifact_id": "fixture-tdd-valid", "contract_version": "1.0.0", "created_at": "2026-08-13"}
+{"primary_route": "technical-deep-dive", "secondary_routes": [], "disciplines": [], "audits": [{"id": "technical-analysis-audit", "status": "passed", "evidence": "report-section:维度结论"}, {"id": "source-traceability", "status": "passed", "evidence": "report-section:Findings"}, {"id": "final-audit", "status": "passed", "evidence": "report-section:执行摘要"}], "artifact_id": "fixture-tdd-valid", "contract_version": "1.0.0", "created_at": "2026-08-13"}
 ```
 """
 
@@ -482,9 +482,9 @@ def _valid_market_outlook_report() -> str:
 
 | Audit | Status | 证据 |
 |-------|--------|------|
-| source-traceability | ✅ Passed | §3 正文使用 [S01] 与 [S02] 引用 |
-| quantitative-role-labeling | ✅ Passed | §5 Comparison 表格含数字角色列 |
-| final-audit | ✅ Passed | §2-§6 各核心关卡可追溯 |
+| source-traceability | ✅ Passed | report-section:市场现状 |
+| quantitative-role-labeling | ✅ Passed | report-table:Comparison Table |
+| final-audit | ✅ Passed | report-section:执行摘要 |
 
 ## 执行摘要
 
@@ -631,11 +631,11 @@ _MO_BODY_PREFIX = """\
 
 | Audit | Status | 证据 |
 |-------|--------|------|
-| source-traceability | ✅ Passed | §3 正文使用 [S01] 与 [S02] 引用 |
-| quantitative-role-labeling | ✅ Passed | §5 Comparison 表格含数字角色列 |
-| final-audit | ✅ Passed | §2-§6 各核心关卡可追溯 |
-| market-outlook-audit | ✅ Passed | §3 监控信号完整 |
-| forward-looking-claims | ✅ Passed | §4 前瞻数字均带标签 |
+| source-traceability | ✅ Passed | report-section:市场现状 |
+| quantitative-role-labeling | ✅ Passed | report-table:Comparison Table |
+| final-audit | ✅ Passed | report-section:执行摘要 |
+| market-outlook-audit | ✅ Passed | report-section:Monitoring Signals |
+| forward-looking-claims | ✅ Passed | report-section:Monitoring Signals |
 
 ## 执行摘要
 
@@ -671,7 +671,7 @@ _MO_SOURCE_REGISTER = """
 | S02 | Example B | secondary | 2026-02-01 | https://example.com/b | high | §5 |
 
 ```contract
-{"primary_route": "market-outlook", "secondary_routes": [], "disciplines": [], "audits": [{"id": "market-outlook-audit", "status": "passed", "evidence": "§3"}, {"id": "forward-looking-claims", "status": "passed", "evidence": "§4"}, {"id": "source-traceability", "status": "passed", "evidence": "§5"}, {"id": "final-audit", "status": "passed", "evidence": "§2"}], "artifact_id": "fixture-mo-monitoring", "contract_version": "1.0.0", "created_at": "2026-08-13"}
+{"primary_route": "market-outlook", "secondary_routes": [], "disciplines": [], "audits": [{"id": "market-outlook-audit", "status": "passed", "evidence": "report-section:Monitoring Signals"}, {"id": "forward-looking-claims", "status": "passed", "evidence": "report-section:Monitoring Signals"}, {"id": "source-traceability", "status": "passed", "evidence": "report-section:市场现状"}, {"id": "final-audit", "status": "passed", "evidence": "report-section:执行摘要"}], "artifact_id": "fixture-mo-monitoring", "contract_version": "1.0.0", "created_at": "2026-08-13"}
 ```
 """
 
@@ -1233,8 +1233,8 @@ Stop when evidence saturated.
 
 ## Required audits
 
-- audit-one — passed: executed by author
-- audit-two — passed: verified
+- audit-one — passed — pack-section:Artifact contract
+- audit-two — passed — pack-section:Artifact contract
 
 ## Final audit status
 

--- a/scripts/test_validate_contract.py
+++ b/scripts/test_validate_contract.py
@@ -44,7 +44,7 @@ def _required_audit_entries(
     )
     extra_ids = {e.get("id") for e in (extra or [])}
     entries = [
-        {"id": aid, "status": "passed", "evidence": "§2"}
+        {"id": aid, "status": "passed", "evidence": "report-section:Executive summary"}
         for aid in required
         if aid not in extra_ids
     ]
@@ -66,10 +66,10 @@ SAMPLE_CONTRACT_MD = """# Test Report
   "secondary_routes": ["regulatory-analysis"],
   "disciplines": ["current-state", "source-traceability"],
   "audits": [
-    {"id": "listed-company-report", "status": "passed", "evidence": "§3"},
-    {"id": "source-traceability", "status": "passed", "evidence": "[S01]-[S12]"},
-    {"id": "regulatory-analysis-secondary-hard-fail", "status": "passed", "evidence": "§6 verified"},
-    {"id": "final-audit", "status": "passed", "evidence": "§2-§8"}
+    {"id": "listed-company-report", "status": "passed", "evidence": "report-section:Research anchor"},
+    {"id": "source-traceability", "status": "passed", "evidence": "report-section:Sources"},
+    {"id": "regulatory-analysis-secondary-hard-fail", "status": "passed", "evidence": "report-section:Regulatory impact"},
+    {"id": "final-audit", "status": "passed", "evidence": "report-section:Bottom line"}
   ]
 }
 ```

--- a/scripts/test_validator_regression.py
+++ b/scripts/test_validator_regression.py
@@ -188,8 +188,8 @@ ok
 ok
 
 ## Required audits
-- final audit — passed
-- quantitative role audit — passed
+- final audit — passed — pack-section:Artifact contract
+- quantitative role audit — passed — pack-section:Artifact contract
 
 ## Final audit status
 Pass
@@ -510,12 +510,17 @@ ok
 ok
 
 ## Required audits
-- final audit — passed
-- quantitative role audit — passed
+- final audit — passed — pack-section:Artifact contract
+- quantitative role audit — passed — pack-section:Artifact contract
 
 ## Final audit status
 Pass
 """
+
+V4_PASS_AUDITS_RE = (
+    r"- final audit — passed — pack-section:Artifact contract\n"
+    r"- quantitative role audit — passed — pack-section:Artifact contract"
+)
 
 V4_NO_ALTERNATIVE = re.sub(
     r"Constrained choice / shortlist\nClosest alternative.*?\n\n",
@@ -525,43 +530,49 @@ V4_NO_ALTERNATIVE = re.sub(
 )
 
 V4_PASS_BUT_NOT_RUN = re.sub(
-    r"- final audit — passed\n- quantitative role audit — passed",
-    "- final audit — not-run\n- quantitative role audit — passed",
+    V4_PASS_AUDITS_RE,
+    "- final audit — not-run\n"
+    "- quantitative role audit — passed — pack-section:Artifact contract",
     V4_BASELINE,
 )
 
 V4_PASS_BUT_PARTIAL = re.sub(
-    r"- final audit — passed\n- quantitative role audit — passed",
-    "- final audit — partial: incomplete execution\n- quantitative role audit — passed",
+    V4_PASS_AUDITS_RE,
+    "- final audit — partial: incomplete execution\n"
+    "- quantitative role audit — passed — pack-section:Artifact contract",
     V4_BASELINE,
 )
 
 V4_PARTIAL_NOT_RUN_NO_REASON = re.sub(
-    r"## Required audits\n- final audit — passed\n- quantitative role audit — passed\n\n## Final audit status\nPass",
-    "## Required audits\n- final audit — not-run\n- quantitative role audit — passed\n\n## Final audit status\nPartial",
+    rf"## Required audits\n{V4_PASS_AUDITS_RE}\n\n## Final audit status\nPass",
+    "## Required audits\n- final audit — not-run\n"
+    "- quantitative role audit — passed — pack-section:Artifact contract\n\n"
+    "## Final audit status\nPartial",
     V4_BASELINE,
 )
 
 V4_PARTIAL_VALID = re.sub(
-    r"## Final audit status\nPass",
-    "## Final audit status\nPartial",
+        r"## Final audit status\nPass",
+        "## Final audit status\nPartial",
     re.sub(
-        r"- final audit — passed\n- quantitative role audit — passed",
+        V4_PASS_AUDITS_RE,
         "- final audit — not-run: task completed before audit available\n"
-        "- quantitative role audit — passed",
+        "- quantitative role audit — passed — pack-section:Artifact contract",
         V4_BASELINE,
     ),
 )
 
 V4_PASS_SKIPPED_NO_REASON = re.sub(
-    r"- final audit — passed\n- quantitative role audit — passed",
-    "- final audit — skipped\n- quantitative role audit — passed",
+    V4_PASS_AUDITS_RE,
+    "- final audit — skipped\n"
+    "- quantitative role audit — passed — pack-section:Artifact contract",
     V4_BASELINE,
 )
 
 V4_PASS_PARTIAL_NO_REASON = re.sub(
-    r"- final audit — passed\n- quantitative role audit — passed",
-    "- final audit — partial\n- quantitative role audit — passed",
+    V4_PASS_AUDITS_RE,
+    "- final audit — partial\n"
+    "- quantitative role audit — passed — pack-section:Artifact contract",
     V4_BASELINE,
 )
 
@@ -572,8 +583,9 @@ V4_PARTIAL_SKIPPED_NO_REASON = re.sub(
 )
 
 V4_FAKE_STATUS_NAME = re.sub(
-    r"- final audit — passed\n- quantitative role audit — passed",
-    "- passed-source audit\n- quantitative role audit — passed",
+    V4_PASS_AUDITS_RE,
+    "- passed-source audit\n"
+    "- quantitative role audit — passed — pack-section:Artifact contract",
     V4_BASELINE,
 )
 
@@ -587,33 +599,33 @@ V4_ALT_NO_IDENTITY = re.sub(
 
 # Reason text contains status keyword — must NOT be confused with a second status
 V4_REASON_CONTAINS_STATUS = re.sub(
-    r"- final audit — passed\n- quantitative role audit — passed",
+    V4_PASS_AUDITS_RE,
     "- final audit — skipped: partial provider outage prevented execution\n"
-    "- quantitative role audit — passed",
+    "- quantitative role audit — passed — pack-section:Artifact contract",
     V4_BASELINE,
 )
 
 # Not-run with reason containing "not-run" in explanation
 V4_NOT_RUN_REASON_MENTIONS_STATUS = re.sub(
-    r"- final audit — passed\n- quantitative role audit — passed",
+    V4_PASS_AUDITS_RE,
     "- final audit — not-run: audit was not-run because task completed early\n"
-    "- quantitative role audit — passed",
+    "- quantitative role audit — passed — pack-section:Artifact contract",
     V4_BASELINE,
 )
 
 # Distant colon must not fake a reason (anchored match)
 V4_DISTANT_COLON_FAKE_REASON = re.sub(
-    r"- final audit — passed\n- quantitative role audit — passed",
+    V4_PASS_AUDITS_RE,
     "- final audit — skipped — no reason; note: none\n"
-    "- quantitative role audit — passed",
+    "- quantitative role audit — passed — pack-section:Artifact contract",
     V4_BASELINE,
 )
 
 # Punctuation-only reason must not count as documented reason
 V4_PUNCT_ONLY_REASON = re.sub(
-    r"- final audit — passed\n- quantitative role audit — passed",
+    V4_PASS_AUDITS_RE,
     "- final audit — skipped: ; note: none\n"
-    "- quantitative role audit — passed",
+    "- quantitative role audit — passed — pack-section:Artifact contract",
     V4_BASELINE,
 )
 

--- a/scripts/validate_contract.py
+++ b/scripts/validate_contract.py
@@ -31,6 +31,7 @@ import argparse
 import json
 import re
 import sys
+from collections.abc import Collection
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -252,6 +253,7 @@ def validate_contract(
     strict: bool = False,
     report_text: str | None = None,
     evidence_base_dir: Path | None = None,
+    known_validator_bindings: Collection[str] | None = None,
 ) -> ContractValidationResult:
     """Validate a route activation contract against the manifest and registry.
 
@@ -295,6 +297,8 @@ def validate_contract(
         report_text: visible report text used to resolve report-section/table
             evidence. When omitted, typed references are syntax-checked only.
         evidence_base_dir: root for checklist-item and audit-record paths.
+        known_validator_bindings: actual validator binding ids available to
+            the caller. Defaults to the canonical registry binding set.
     """
     errors: list[str] = []
     warnings: list[str] = []
@@ -595,6 +599,7 @@ def validate_contract(
                 base_dir=evidence_base_dir,
                 strict=strict,
                 artifact_label="report",
+                known_validator_bindings=known_validator_bindings,
             )
             errors.extend(
                 f"Audit '{audit_id}' evidence: {error}"

--- a/scripts/validate_contract.py
+++ b/scripts/validate_contract.py
@@ -542,6 +542,12 @@ def validate_contract(
                 f"(schemas/audit-registry.json). Valid audit ids: "
                 f"{sorted(audit_ids)}"
             )
+        audit_info = audit_registry.get_audit(audit_id)
+        audit_execution_type = (
+            audit_info.execution_type
+            if audit_info is not None
+            else "manual" if is_derived_hard_fail else None
+        )
 
         status = audit.get("status", "")
         if not isinstance(status, str):
@@ -600,6 +606,7 @@ def validate_contract(
                 strict=strict,
                 artifact_label="report",
                 known_validator_bindings=known_validator_bindings,
+                execution_type=audit_execution_type,
             )
             errors.extend(
                 f"Audit '{audit_id}' evidence: {error}"

--- a/scripts/validate_contract.py
+++ b/scripts/validate_contract.py
@@ -40,6 +40,7 @@ from registry_loader import (
     load_discipline_registry,
     load_route_registry,
 )
+from audit_evidence import validate_evidence_reference
 
 # ── Paths relative to project root ──────────────────────────────────────────
 
@@ -48,7 +49,7 @@ ROUTE_MANIFEST_PATH = PROJECT_ROOT / "schemas" / "route-manifest.json"
 DISCIPLINE_REGISTRY_PATH = PROJECT_ROOT / "schemas" / "discipline-registry.json"
 AUDIT_REGISTRY_PATH = PROJECT_ROOT / "schemas" / "audit-registry.json"
 
-VALID_AUDIT_STATUSES = {"passed", "skipped", "not_run"}
+VALID_AUDIT_STATUSES = {"passed", "skipped", "not_run", "partial"}
 
 # Recommended stable artifact identity fields (issue #376 范围 1).
 ARTIFACT_META_FIELDS = ("artifact_id", "contract_version", "created_at")
@@ -249,6 +250,8 @@ def validate_contract(
     pack_artifact_id: str | None = None,
     research_pack_provided: bool = False,
     strict: bool = False,
+    report_text: str | None = None,
+    evidence_base_dir: Path | None = None,
 ) -> ContractValidationResult:
     """Validate a route activation contract against the manifest and registry.
 
@@ -259,7 +262,7 @@ def validate_contract(
     4. primary_route is not also in secondary_routes
     5. disciplines are valid discipline ids (not route ids)
     6. audits have valid status values
-    7. passed audits have non-empty evidence
+    7. passed audits have non-empty, typed evidence
     8. shared-workflow has minimum required audits
     9. audit ids belong to audit-registry.json (or are derived
        `<secondary>-secondary-hard-fail` entries)
@@ -289,6 +292,9 @@ def validate_contract(
             (without --research-pack there is no pack to trace to).
         strict: when True, missing artifact identity fields are errors
             instead of warnings.
+        report_text: visible report text used to resolve report-section/table
+            evidence. When omitted, typed references are syntax-checked only.
+        evidence_base_dir: root for checklist-item and audit-record paths.
     """
     errors: list[str] = []
     warnings: list[str] = []
@@ -506,7 +512,9 @@ def validate_contract(
             continue
 
         # 6a0. Unknown audit fields fail closed (issue #376 范围 3).
-        known_audit_fields = {"id", "status", "evidence"}
+        known_audit_fields = {
+            "id", "status", "evidence", "reason", "execution_source",
+        }
         for afield in audit:
             if afield not in known_audit_fields:
                 errors.append(
@@ -536,12 +544,32 @@ def validate_contract(
             status = ""
 
         evidence = audit.get("evidence", "")
-        if not isinstance(evidence, str):
+        if not isinstance(evidence, (str, dict)):
             errors.append(
-                f"Audit '{audit_id}' evidence must be a string, "
-                f"got {type(evidence).__name__}"
+                f"Audit '{audit_id}' evidence must be a typed reference "
+                f"string or object, got {type(evidence).__name__}"
             )
             evidence = ""
+
+        reason = audit.get("reason", "")
+        if reason is not None and not isinstance(reason, str):
+            errors.append(
+                f"Audit '{audit_id}' reason must be a string, "
+                f"got {type(reason).__name__}"
+            )
+            reason = ""
+
+        execution_source = audit.get("execution_source")
+        if execution_source is not None and execution_source not in {
+            "automated_validator",
+            "manual_checklist_attestation",
+            "process_node_evidence",
+            "legacy_self_attested",
+        }:
+            errors.append(
+                f"Audit '{audit_id}' has invalid execution_source "
+                f"'{execution_source}'"
+            )
 
         if status not in VALID_AUDIT_STATUSES:
             errors.append(
@@ -549,12 +577,46 @@ def validate_contract(
                 f"Must be one of: {sorted(VALID_AUDIT_STATUSES)}"
             )
 
-        # Passed audits must have non-empty evidence
-        if status == "passed" and (not evidence or not evidence.strip()):
+        # Passed audits must have a typed, locatable evidence reference. A
+        # free-form legacy string remains readable in compatibility mode, but
+        # strict contract validation must not turn it into a trusted Pass.
+        if status == "passed" and (
+            not evidence
+            or (isinstance(evidence, str) and not evidence.strip())
+        ):
             errors.append(
                 f"Audit '{audit_id}' is marked 'passed' but has empty evidence. "
                 f"Evidence must reference a concrete location in the artifact."
             )
+        elif status == "passed":
+            evidence_result = validate_evidence_reference(
+                evidence,
+                artifact_text=report_text if strict else None,
+                base_dir=evidence_base_dir,
+                strict=strict,
+                artifact_label="report",
+            )
+            errors.extend(
+                f"Audit '{audit_id}' evidence: {error}"
+                for error in evidence_result.errors
+            )
+            if not evidence_result.legacy:
+                warnings.extend(
+                    f"Audit '{audit_id}' evidence: {warning}"
+                    for warning in evidence_result.warnings
+                )
+
+        if status in {"skipped", "not_run", "partial"} and (
+            not isinstance(reason, str) or not reason.strip()
+        ):
+            if strict:
+                errors.append(
+                    f"Audit '{audit_id}' status='{status}' requires a non-empty reason"
+                )
+            else:
+                warnings.append(
+                    f"Audit '{audit_id}' status='{status}' has no explicit reason"
+                )
 
     # 6b. Duplicate audit ID detection — duplicate ids are an error
     # (issue #376 验收标准 4).
@@ -822,6 +884,8 @@ def main(argv: list[str] | None = None) -> int:
         pack_artifact_id=pack_artifact_id,
         research_pack_provided=args.research_pack is not None,
         strict=args.strict,
+        report_text=_strip_fences(text) if args.strict else None,
+        evidence_base_dir=PROJECT_ROOT,
     )
     print(result.format())
 

--- a/scripts/validate_research_pack.py
+++ b/scripts/validate_research_pack.py
@@ -5,6 +5,8 @@ import json
 import re
 from pathlib import Path
 
+from audit_evidence import validate_evidence_reference, is_typed_reference
+
 REQUIRED_HEADINGS = [
     "## Objective",
     "## Decision context",
@@ -349,7 +351,13 @@ def _check_malformed_refs(cleaned: str) -> list[str]:
     return issues
 
 
-def run_strict_checks(cleaned: str) -> list[str]:
+def run_strict_checks(
+    cleaned: str,
+    *,
+    artifact_text: str | None = None,
+    evidence_base_dir: Path | None = None,
+    report_text: str | None = None,
+) -> list[str]:
     errors: list[str] = []
     warnings: list[str] = []
 
@@ -442,6 +450,15 @@ def run_strict_checks(cleaned: str) -> list[str]:
     errors.extend(run_errs)
     warnings.extend(run_warns)
 
+    evidence_errors, evidence_warnings = _check_audit_evidence(
+        _parse_audit_statuses(cleaned),
+        artifact_text=artifact_text if artifact_text is not None else cleaned,
+        evidence_base_dir=evidence_base_dir,
+        report_text=report_text,
+    )
+    errors.extend(evidence_errors)
+    warnings.extend(evidence_warnings)
+
     # Audit consistency (Pass vs not-run/partial, Partial vs not-run-no-reason, Fail vs all-ok)
     cons_issues = _check_audit_consistency(cleaned)
     for issue in cons_issues:
@@ -489,6 +506,68 @@ def _check_audit_status(text: str) -> list[str]:
     return []
 
 
+# ─── Strict mode: evidence and status consistency ─────────────────────────────
+
+
+def _check_audit_evidence(
+    records: list[dict],
+    *,
+    artifact_text: str,
+    evidence_base_dir: Path | None,
+    report_text: str | None,
+) -> tuple[list[str], list[str]]:
+    """Require typed, resolvable evidence for every passed pack audit."""
+    errors: list[str] = []
+    warnings: list[str] = []
+    for record in records:
+        status = record.get("status")
+        if status is None:
+            continue
+        audit_line = str(record.get("line", ""))[:100]
+        if status in {"passed", "已通过"}:
+            evidence = record.get("evidence")
+            if not evidence:
+                errors.append(
+                    f"Required audit marked passed without typed evidence: "
+                    f"{audit_line}"
+                )
+                continue
+
+            target_text = artifact_text
+            target_label = "Research Pack"
+            if (
+                isinstance(evidence, str)
+                and evidence.startswith(("report-section:", "report-table:"))
+                and report_text is not None
+            ):
+                target_text = report_text
+                target_label = "report"
+            result = validate_evidence_reference(
+                evidence,
+                artifact_text=target_text,
+                base_dir=evidence_base_dir,
+                strict=True,
+                artifact_label=target_label,
+            )
+            errors.extend(
+                f"Required audit evidence: {error}"
+                for error in result.errors
+            )
+            warnings.extend(
+                f"Required audit evidence: {warning}"
+                for warning in result.warnings
+            )
+        elif status in {
+            "skipped", "not-run", "partial", "已跳过", "未运行", "部分通过",
+        }:
+            if not record.get("has_reason"):
+                errors.append(
+                    f"Required audit status={status} requires a reason: "
+                    f"{audit_line}"
+                )
+    return errors, warnings
+
+
 # ─── Structured audit status parsing ────────────────────────────────────────────
 
 # Extract status after em dash separator (standard format: "audit-name — STATUS")
@@ -503,7 +582,9 @@ _STATUS_EXTRACT_RE = re.compile(
 def _parse_audit_statuses(cleaned: str) -> list[dict]:
     """Parse Required audits into structured status records.
 
-    Each record: {"line": str, "status": str|None, "has_reason": bool}
+    Each record: {"line": str, "status": str|None, "has_reason": bool,
+    "detail": str, "evidence": str|None}.  A typed evidence reference is
+    separated from the free-form reason after the status token.
     Status is extracted from the first em-dash-separated token.
     has_reason is True when the status is followed by colon with content.
     """
@@ -517,17 +598,36 @@ def _parse_audit_statuses(cleaned: str) -> list[dict]:
             continue
         m = _STATUS_EXTRACT_RE.search(line)
         if not m:
-            records.append({"line": line, "status": None, "has_reason": False})
+            records.append({
+                "line": line,
+                "status": None,
+                "has_reason": False,
+                "detail": "",
+                "evidence": None,
+            })
             continue
         status = m.group(1).lower()
-        after = line[m.end():]
-        # Reason must immediately follow the status with non-trivial content.
-        # Anchored match prevents distant colons (e.g. "skipped — no; note: x").
-        # \w + CJK range requires at least one letter/ideograph, not just punctuation.
+        raw_after = line[m.end():]
+        # Preserve the existing reason grammar: a reason must be introduced
+        # immediately by a colon. An em dash is reserved for the typed
+        # evidence separator and must not make distant/punctuation-only text
+        # look like a documented skip reason.
         has_reason = bool(re.match(
-            r"\s*[:：]\s*[a-zA-Z0-9_\u4e00-\u9fff]", after
+            r"\s*[:：]\s*[a-zA-Z0-9_\u4e00-\u9fff]", raw_after
         ))
-        records.append({"line": line, "status": status, "has_reason": has_reason})
+        after = raw_after.strip()
+        if after.startswith(("—", "–")):
+            after = after[1:].strip()
+        if after.startswith((":", "：")):
+            after = after[1:].strip()
+        evidence = after if is_typed_reference(after) else None
+        records.append({
+            "line": line,
+            "status": status,
+            "has_reason": has_reason,
+            "detail": after,
+            "evidence": evidence,
+        })
     return records
 
 
@@ -848,7 +948,11 @@ def main() -> int:
         return EXIT_ARTIFACT
 
     if args.strict:
-        strict_issues = run_strict_checks(cleaned)
+        strict_issues = run_strict_checks(
+            cleaned,
+            artifact_text=cleaned,
+            evidence_base_dir=Path(__file__).resolve().parent.parent,
+        )
         if strict_issues:
             print("Strict mode issues:")
             for issue in strict_issues:

--- a/scripts/validate_research_pack.py
+++ b/scripts/validate_research_pack.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import re
+from collections.abc import Collection
 from pathlib import Path
 
 from audit_evidence import validate_evidence_reference, is_typed_reference
@@ -357,6 +358,7 @@ def run_strict_checks(
     artifact_text: str | None = None,
     evidence_base_dir: Path | None = None,
     report_text: str | None = None,
+    known_validator_bindings: Collection[str] | None = None,
 ) -> list[str]:
     errors: list[str] = []
     warnings: list[str] = []
@@ -455,6 +457,7 @@ def run_strict_checks(
         artifact_text=artifact_text if artifact_text is not None else cleaned,
         evidence_base_dir=evidence_base_dir,
         report_text=report_text,
+        known_validator_bindings=known_validator_bindings,
     )
     errors.extend(evidence_errors)
     warnings.extend(evidence_warnings)
@@ -515,6 +518,7 @@ def _check_audit_evidence(
     artifact_text: str,
     evidence_base_dir: Path | None,
     report_text: str | None,
+    known_validator_bindings: Collection[str] | None,
 ) -> tuple[list[str], list[str]]:
     """Require typed, resolvable evidence for every passed pack audit."""
     errors: list[str] = []
@@ -548,6 +552,7 @@ def _check_audit_evidence(
                 base_dir=evidence_base_dir,
                 strict=True,
                 artifact_label=target_label,
+                known_validator_bindings=known_validator_bindings,
             )
             errors.extend(
                 f"Required audit evidence: {error}"

--- a/scripts/validate_research_pack.py
+++ b/scripts/validate_research_pack.py
@@ -7,7 +7,7 @@ from collections.abc import Collection
 from pathlib import Path
 
 from audit_evidence import validate_evidence_reference, is_typed_reference
-from registry_loader import load_audit_registry
+from registry_loader import load_audit_registry, load_route_registry
 
 REQUIRED_HEADINGS = [
     "## Objective",
@@ -525,6 +525,8 @@ def _check_audit_evidence(
     errors: list[str] = []
     warnings: list[str] = []
     audit_registry = load_audit_registry()
+    route_registry = load_route_registry()
+    route_ids = route_registry.route_ids()
     for record in records:
         status = record.get("status")
         if status is None:
@@ -532,11 +534,21 @@ def _check_audit_evidence(
         audit_line = str(record.get("line", ""))[:100]
         audit_id = record.get("audit_id")
         audit_info = audit_registry.get_audit(str(audit_id))
+        derived_secondary_id = (
+            isinstance(audit_id, str)
+            and audit_id.endswith("-secondary-hard-fail")
+            and audit_id[: -len("-secondary-hard-fail")] in route_ids
+        )
+        if audit_info is None and not derived_secondary_id:
+            errors.append(
+                f"Required audit id {audit_id!r} is not registered in "
+                "schemas/audit-registry.json"
+            )
         execution_type = (
             audit_info.execution_type
             if audit_info is not None
             else "manual"
-            if str(audit_id).endswith("-secondary-hard-fail")
+            if derived_secondary_id
             else None
         )
         if status in {"passed", "已通过"}:

--- a/scripts/validate_research_pack.py
+++ b/scripts/validate_research_pack.py
@@ -7,6 +7,7 @@ from collections.abc import Collection
 from pathlib import Path
 
 from audit_evidence import validate_evidence_reference, is_typed_reference
+from registry_loader import load_audit_registry
 
 REQUIRED_HEADINGS = [
     "## Objective",
@@ -523,11 +524,21 @@ def _check_audit_evidence(
     """Require typed, resolvable evidence for every passed pack audit."""
     errors: list[str] = []
     warnings: list[str] = []
+    audit_registry = load_audit_registry()
     for record in records:
         status = record.get("status")
         if status is None:
             continue
         audit_line = str(record.get("line", ""))[:100]
+        audit_id = record.get("audit_id")
+        audit_info = audit_registry.get_audit(str(audit_id))
+        execution_type = (
+            audit_info.execution_type
+            if audit_info is not None
+            else "manual"
+            if str(audit_id).endswith("-secondary-hard-fail")
+            else None
+        )
         if status in {"passed", "已通过"}:
             evidence = record.get("evidence")
             if not evidence:
@@ -553,6 +564,7 @@ def _check_audit_evidence(
                 strict=True,
                 artifact_label=target_label,
                 known_validator_bindings=known_validator_bindings,
+                execution_type=execution_type,
             )
             errors.extend(
                 f"Required audit evidence: {error}"
@@ -602,9 +614,13 @@ def _parse_audit_statuses(cleaned: str) -> list[dict]:
         if not line or line.startswith("#"):
             continue
         m = _STATUS_EXTRACT_RE.search(line)
+        audit_prefix = re.split(r"\s+[–—]\s+", line, maxsplit=1)[0]
+        audit_id = re.sub(r"^[-*]\s*", "", audit_prefix).strip().lower()
+        audit_id = re.sub(r"\s+", "-", audit_id)
         if not m:
             records.append({
                 "line": line,
+                "audit_id": audit_id,
                 "status": None,
                 "has_reason": False,
                 "detail": "",
@@ -628,6 +644,7 @@ def _parse_audit_statuses(cleaned: str) -> list[dict]:
         evidence = after if is_typed_reference(after) else None
         records.append({
             "line": line,
+            "audit_id": audit_id,
             "status": status,
             "has_reason": has_reason,
             "detail": after,

--- a/tests/fixtures/audit/market-outlook-mixed-neg.md
+++ b/tests/fixtures/audit/market-outlook-mixed-neg.md
@@ -13,11 +13,11 @@ verification cannot be inferred from primary-route coverage.
 
 | Audit | Status | 证据 |
 |-------|--------|------|
-| market-outlook-audit | ✅ Passed | §3 监控信号完整 |
-| forward-looking-claims | ✅ Passed | §4 前瞻数字均带标签 |
-| source-traceability | ✅ Passed | §3-§5 正文使用 [S01]-[S03] 引用 |
-| final-audit | ✅ Passed | §2-§6 各核心关卡可追溯 |
-| quantitative-role-audit | ✅ Passed | §5 Comparison 表格含数字角色列 |
+| market-outlook-audit | ✅ Passed | report-section:Monitoring signals |
+| forward-looking-claims | ✅ Passed | report-section:Monitoring signals |
+| source-traceability | ✅ Passed | report-section:Findings |
+| final-audit | ✅ Passed | report-section:Executive summary |
+| quantitative-role-audit | ✅ Passed | report-table:Comparison Table |
 
 ## Executive summary
 
@@ -58,5 +58,5 @@ Each dimension conclusion is backed by [S01] and [S02].
 | S03 | Example C | secondary | 2026-03-01 | https://example.com/c | high | §4 |
 
 ```contract
-{"primary_route": "market-outlook", "secondary_routes": ["constrained-choice"], "disciplines": [], "audits": [{"id": "market-outlook-audit", "status": "passed", "evidence": "§3"}, {"id": "forward-looking-claims", "status": "passed", "evidence": "§4"}, {"id": "source-traceability", "status": "passed", "evidence": "§5"}, {"id": "final-audit", "status": "passed", "evidence": "§2"}], "artifact_id": "fixture-market-outlook-mixed-neg", "contract_version": "1.0.0", "created_at": "2026-08-13"}
+{"primary_route": "market-outlook", "secondary_routes": ["constrained-choice"], "disciplines": [], "audits": [{"id": "market-outlook-audit", "status": "passed", "evidence": "report-section:Monitoring signals"}, {"id": "forward-looking-claims", "status": "passed", "evidence": "report-section:Monitoring signals"}, {"id": "source-traceability", "status": "passed", "evidence": "report-section:Findings"}, {"id": "final-audit", "status": "passed", "evidence": "report-section:Executive summary"}], "artifact_id": "fixture-market-outlook-mixed-neg", "contract_version": "1.0.0", "created_at": "2026-08-13"}
 ```

--- a/tests/fixtures/audit/market-outlook-mixed-pos.md
+++ b/tests/fixtures/audit/market-outlook-mixed-pos.md
@@ -12,12 +12,12 @@ The secondary's hard-fail verification is tracked by an independent
 
 | Audit | Status | 证据 |
 |-------|--------|------|
-| market-outlook-audit | ✅ Passed | §3 监控信号完整 |
-| forward-looking-claims | ✅ Passed | §4 前瞻数字均带标签 |
-| source-traceability | ✅ Passed | §3-§5 正文使用 [S01]-[S03] 引用 |
-| final-audit | ✅ Passed | §2-§6 各核心关卡可追溯 |
-| quantitative-role-audit | ✅ Passed | §5 Comparison 表格含数字角色列 |
-| constrained-choice-secondary-hard-fail | ✅ Passed | §6 独立验证 4 项 hard-fail 条件 |
+| market-outlook-audit | ✅ Passed | report-section:Monitoring signals |
+| forward-looking-claims | ✅ Passed | report-section:Monitoring signals |
+| source-traceability | ✅ Passed | report-section:Findings |
+| final-audit | ✅ Passed | report-section:Executive summary |
+| quantitative-role-audit | ✅ Passed | report-table:Comparison Table |
+| constrained-choice-secondary-hard-fail | ✅ Passed | report-section:Dimension conclusions |
 
 ## Executive summary
 
@@ -58,5 +58,5 @@ Each dimension conclusion is backed by [S01] and [S02].
 | S03 | Example C | secondary | 2026-03-01 | https://example.com/c | high | §4 |
 
 ```contract
-{"primary_route": "market-outlook", "secondary_routes": ["constrained-choice"], "disciplines": [], "audits": [{"id": "market-outlook-audit", "status": "passed", "evidence": "§3"}, {"id": "forward-looking-claims", "status": "passed", "evidence": "§4"}, {"id": "source-traceability", "status": "passed", "evidence": "§5"}, {"id": "final-audit", "status": "passed", "evidence": "§2"}, {"id": "constrained-choice-secondary-hard-fail", "status": "passed", "evidence": "§6 verified 4 hard-fail conditions"}], "artifact_id": "fixture-market-outlook-mixed-pos", "contract_version": "1.0.0", "created_at": "2026-08-13"}
+{"primary_route": "market-outlook", "secondary_routes": ["constrained-choice"], "disciplines": [], "audits": [{"id": "market-outlook-audit", "status": "passed", "evidence": "report-section:Monitoring signals"}, {"id": "forward-looking-claims", "status": "passed", "evidence": "report-section:Monitoring signals"}, {"id": "source-traceability", "status": "passed", "evidence": "report-section:Findings"}, {"id": "final-audit", "status": "passed", "evidence": "report-section:Executive summary"}, {"id": "constrained-choice-secondary-hard-fail", "status": "passed", "evidence": "report-section:Dimension conclusions"}], "artifact_id": "fixture-market-outlook-mixed-pos", "contract_version": "1.0.0", "created_at": "2026-08-13"}
 ```

--- a/tests/fixtures/audit/market-outlook-neg.md
+++ b/tests/fixtures/audit/market-outlook-neg.md
@@ -58,5 +58,5 @@ Each dimension conclusion is backed by [S01] and [S02].
 | S03 | Example C | secondary | 2026-03-01 | https://example.com/c | high | §4 |
 
 ```contract
-{"primary_route": "market-outlook", "secondary_routes": [], "disciplines": [], "audits": [{"id": "market-outlook-audit", "status": "passed", "evidence": "§3"}, {"id": "forward-looking-claims", "status": "passed", "evidence": "§4"}, {"id": "source-traceability", "status": "passed", "evidence": "§5"}, {"id": "final-audit", "status": "passed", "evidence": "§2"}], "artifact_id": "fixture-market-outlook-neg", "contract_version": "1.0.0", "created_at": "2026-08-13"}
+{"primary_route": "market-outlook", "secondary_routes": [], "disciplines": [], "audits": [{"id": "market-outlook-audit", "status": "passed", "evidence": "report-section:Monitoring signals"}, {"id": "forward-looking-claims", "status": "passed", "evidence": "report-section:Monitoring signals"}, {"id": "source-traceability", "status": "passed", "evidence": "report-section:Findings"}, {"id": "final-audit", "status": "passed", "evidence": "report-section:Executive summary"}], "artifact_id": "fixture-market-outlook-neg", "contract_version": "1.0.0", "created_at": "2026-08-13"}
 ```

--- a/tests/fixtures/audit/market-outlook-pos.md
+++ b/tests/fixtures/audit/market-outlook-pos.md
@@ -6,11 +6,11 @@
 
 | Audit | Status | 证据 |
 |-------|--------|------|
-| market-outlook-audit | ✅ Passed | §3 监控信号完整 |
-| forward-looking-claims | ✅ Passed | §4 前瞻数字均带标签 |
-| source-traceability | ✅ Passed | §3-§5 正文使用 [S01]-[S03] 引用 |
-| final-audit | ✅ Passed | §2-§6 各核心关卡可追溯 |
-| quantitative-role-audit | ✅ Passed | §5 Comparison 表格含数字角色列 |
+| market-outlook-audit | ✅ Passed | report-section:Monitoring signals |
+| forward-looking-claims | ✅ Passed | report-section:Monitoring signals |
+| source-traceability | ✅ Passed | report-section:Findings |
+| final-audit | ✅ Passed | report-section:Executive summary |
+| quantitative-role-audit | ✅ Passed | report-table:Comparison Table |
 
 ## Executive summary
 
@@ -51,5 +51,5 @@ Each dimension conclusion is backed by [S01] and [S02].
 | S03 | Example C | secondary | 2026-03-01 | https://example.com/c | high | §4 |
 
 ```contract
-{"primary_route": "market-outlook", "secondary_routes": [], "disciplines": [], "audits": [{"id": "market-outlook-audit", "status": "passed", "evidence": "§3"}, {"id": "forward-looking-claims", "status": "passed", "evidence": "§4"}, {"id": "source-traceability", "status": "passed", "evidence": "§5"}, {"id": "final-audit", "status": "passed", "evidence": "§2"}], "artifact_id": "fixture-market-outlook-pos", "contract_version": "1.0.0", "created_at": "2026-08-13"}
+{"primary_route": "market-outlook", "secondary_routes": [], "disciplines": [], "audits": [{"id": "market-outlook-audit", "status": "passed", "evidence": "report-section:Monitoring signals"}, {"id": "forward-looking-claims", "status": "passed", "evidence": "report-section:Monitoring signals"}, {"id": "source-traceability", "status": "passed", "evidence": "report-section:Findings"}, {"id": "final-audit", "status": "passed", "evidence": "report-section:Executive summary"}], "artifact_id": "fixture-market-outlook-pos", "contract_version": "1.0.0", "created_at": "2026-08-13"}
 ```

--- a/tests/fixtures/audit/research-pack-mixed-pos.md
+++ b/tests/fixtures/audit/research-pack-mixed-pos.md
@@ -57,10 +57,10 @@ fixture-market-outlook-mixed-pos
 
 ## Required audits
 
-- market-outlook-audit — passed: executed by author
-- forward-looking-claims — passed: no mislabeled claims
-- source-traceability — passed: register complete
-- final-audit — passed: all gates verified
+- market-outlook-audit — passed — pack-section:Artifact contract
+- forward-looking-claims — passed — pack-section:Artifact contract
+- source-traceability — passed — pack-section:Artifact contract
+- final-audit — passed — pack-section:Artifact contract
 
 ## Final audit status
 

--- a/tests/fixtures/audit/research-pack-pos.md
+++ b/tests/fixtures/audit/research-pack-pos.md
@@ -57,10 +57,10 @@ fixture-market-outlook-pos
 
 ## Required audits
 
-- market-outlook-audit — passed: executed by author
-- forward-looking-claims — passed: no mislabeled claims
-- source-traceability — passed: register complete
-- final-audit — passed: all gates verified
+- market-outlook-audit — passed — pack-section:Artifact contract
+- forward-looking-claims — passed — pack-section:Artifact contract
+- source-traceability — passed — pack-section:Artifact contract
+- final-audit — passed — pack-section:Artifact contract
 
 ## Final audit status
 

--- a/tests/fixtures/audit/research-pack-shared-workflow-pos.md
+++ b/tests/fixtures/audit/research-pack-shared-workflow-pos.md
@@ -57,8 +57,8 @@ fixture-shared-workflow-pos
 
 ## Required audits
 
-- workflow-spine-audit — passed: executed by author
-- final-audit — passed: all gates verified
+- workflow-spine-audit — passed — pack-section:Artifact contract
+- final-audit — passed — pack-section:Artifact contract
 
 ## Final audit status
 

--- a/tests/fixtures/audit/shared-workflow-neg.md
+++ b/tests/fixtures/audit/shared-workflow-neg.md
@@ -43,5 +43,5 @@ Each dimension conclusion is backed by [S01] and [S02].
 | S02 | Example B | secondary | 2026-02-01 | https://example.com/b | high | §5 |
 
 ```contract
-{"primary_route": "shared-workflow", "secondary_routes": [], "disciplines": [], "audits": [{"id": "workflow-spine-audit", "status": "passed", "evidence": "§3"}, {"id": "final-audit", "status": "passed", "evidence": "§2"}], "artifact_id": "fixture-shared-workflow-neg", "contract_version": "1.0.0", "created_at": "2026-08-13"}
+{"primary_route": "shared-workflow", "secondary_routes": [], "disciplines": [], "audits": [{"id": "workflow-spine-audit", "status": "passed", "evidence": "report-section:Findings"}, {"id": "final-audit", "status": "passed", "evidence": "report-section:Executive summary"}], "artifact_id": "fixture-shared-workflow-neg", "contract_version": "1.0.0", "created_at": "2026-08-13"}
 ```

--- a/tests/fixtures/audit/shared-workflow-pos.md
+++ b/tests/fixtures/audit/shared-workflow-pos.md
@@ -6,9 +6,9 @@
 
 | Audit | Status | 证据 |
 |-------|--------|------|
-| workflow-spine-audit | ✅ Passed | §3 工作流脊柱可追溯 |
-| final-audit | ✅ Passed | §2-§4 各核心关卡可追溯 |
-| quantitative-role-audit | ✅ Passed | §5 Comparison 表格含数字角色列 |
+| workflow-spine-audit | ✅ Passed | report-section:Findings |
+| final-audit | ✅ Passed | report-section:Executive summary |
+| quantitative-role-audit | ✅ Passed | report-table:Comparison Table |
 
 ## Executive summary
 
@@ -40,5 +40,5 @@ Each dimension conclusion is backed by [S01] and [S02].
 | S02 | Example B | secondary | 2026-02-01 | https://example.com/b | high | §5 |
 
 ```contract
-{"primary_route": "shared-workflow", "secondary_routes": [], "disciplines": [], "audits": [{"id": "workflow-spine-audit", "status": "passed", "evidence": "§3"}, {"id": "final-audit", "status": "passed", "evidence": "§2"}], "artifact_id": "fixture-shared-workflow-pos", "contract_version": "1.0.0", "created_at": "2026-08-13"}
+{"primary_route": "shared-workflow", "secondary_routes": [], "disciplines": [], "audits": [{"id": "workflow-spine-audit", "status": "passed", "evidence": "report-section:Findings"}, {"id": "final-audit", "status": "passed", "evidence": "report-section:Executive summary"}], "artifact_id": "fixture-shared-workflow-pos", "contract_version": "1.0.0", "created_at": "2026-08-13"}
 ```

--- a/tests/fixtures/forward/academic-review-pack.md
+++ b/tests/fixtures/forward/academic-review-pack.md
@@ -77,9 +77,9 @@ md_ready
 
 ## Required audits
 
-- academic-analysis-audit — passed: evidence hierarchy and search scope checked
-- source-traceability — passed: claims map to the source register
-- final-audit — passed: conclusion is bounded by the evidence window
+- academic-analysis-audit — passed — pack-section:Artifact contract
+- source-traceability — passed — pack-section:Artifact contract
+- final-audit — passed — pack-section:Artifact contract
 
 ## Final audit status
 

--- a/tests/fixtures/forward/academic-review-report.md
+++ b/tests/fixtures/forward/academic-review-report.md
@@ -6,9 +6,9 @@
 
 | Audit | Status | 证据 | 数字角色 |
 |---|---|---|---|
-| academic-analysis-audit | ✅ Passed | §Search strategy | process |
-| source-traceability | ✅ Passed | §Source Register | process |
-| final-audit | ✅ Passed | §Executive summary | process |
+| academic-analysis-audit | ✅ Passed | report-section:Search strategy | process |
+| source-traceability | ✅ Passed | report-section:Source Register | process |
+| final-audit | ✅ Passed | report-section:Executive summary | process |
 
 ## Executive summary
 
@@ -59,9 +59,9 @@ recent but lower-confidence signal because its peer-review status is different
   "secondary_routes": [],
   "disciplines": ["source-traceability", "current-state", "forward-looking", "scope-completeness"],
   "audits": [
-    {"id": "academic-analysis-audit", "status": "passed", "evidence": "§Search strategy"},
-    {"id": "source-traceability", "status": "passed", "evidence": "§Source Register"},
-    {"id": "final-audit", "status": "passed", "evidence": "§Executive summary"}
+    {"id": "academic-analysis-audit", "status": "passed", "evidence": "report-section:Search strategy"},
+    {"id": "source-traceability", "status": "passed", "evidence": "report-section:Source Register"},
+    {"id": "final-audit", "status": "passed", "evidence": "report-section:Executive summary"}
   ]
 }
 ```

--- a/tests/fixtures/forward/channel-blocked-pack.md
+++ b/tests/fixtures/forward/channel-blocked-pack.md
@@ -88,10 +88,10 @@ md_ready
 
 ## Required audits
 
-- market-outlook-audit — passed: scenario structure recorded
-- forward-looking-claims — passed: forecast labels preserved
-- source-traceability — passed: available claims map to the register
-- final-audit — passed: channel limitation is visible
+- market-outlook-audit — passed — pack-section:Artifact contract
+- forward-looking-claims — passed — pack-section:Artifact contract
+- source-traceability — passed — pack-section:Artifact contract
+- final-audit — passed — pack-section:Artifact contract
 
 ## Final audit status
 

--- a/tests/fixtures/forward/company-technical-mixed-pack.md
+++ b/tests/fixtures/forward/company-technical-mixed-pack.md
@@ -77,10 +77,10 @@ md_ready
 
 ## Required audits
 
-- technical-analysis-audit — passed: mechanism judgment and viability evidence checked
-- source-traceability — passed: claims map to the source register
-- final-audit — passed: conclusion and limitations visible
-- listed-company-secondary-hard-fail — passed: secondary route checked independently
+- technical-analysis-audit — passed — pack-section:Artifact contract
+- source-traceability — passed — pack-section:Artifact contract
+- final-audit — passed — pack-section:Artifact contract
+- listed-company-secondary-hard-fail — passed — pack-section:Artifact contract
 
 ## Final audit status
 

--- a/tests/fixtures/forward/company-technical-mixed-report.md
+++ b/tests/fixtures/forward/company-technical-mixed-report.md
@@ -8,10 +8,10 @@
 
 | Audit | Status | 证据 | 数字角色 |
 |---|---|---|---|
-| technical-analysis-audit | ✅ Passed | §Technical judgment | process |
-| source-traceability | ✅ Passed | §Source Register | process |
-| final-audit | ✅ Passed | §Executive summary | process |
-| listed-company-secondary-hard-fail | ✅ Passed | §Company boundary | process |
+| technical-analysis-audit | ✅ Passed | report-section:Technical judgment | process |
+| source-traceability | ✅ Passed | report-section:Source Register | process |
+| final-audit | ✅ Passed | report-section:Executive summary | process |
+| listed-company-secondary-hard-fail | ✅ Passed | report-section:Company boundary | process |
 
 ## Executive summary
 
@@ -61,10 +61,10 @@ separate evidence layer [S02].
   "secondary_routes": ["listed-company"],
   "disciplines": ["current-state", "source-traceability", "forward-looking", "quantitative-role"],
   "audits": [
-    {"id": "technical-analysis-audit", "status": "passed", "evidence": "§Technical judgment"},
-    {"id": "source-traceability", "status": "passed", "evidence": "§Source Register"},
-    {"id": "final-audit", "status": "passed", "evidence": "§Executive summary"},
-    {"id": "listed-company-secondary-hard-fail", "status": "passed", "evidence": "§Company boundary"}
+    {"id": "technical-analysis-audit", "status": "passed", "evidence": "report-section:Technical judgment"},
+    {"id": "source-traceability", "status": "passed", "evidence": "report-section:Source Register"},
+    {"id": "final-audit", "status": "passed", "evidence": "report-section:Executive summary"},
+    {"id": "listed-company-secondary-hard-fail", "status": "passed", "evidence": "report-section:Company boundary"}
   ]
 }
 ```

--- a/tests/fixtures/forward/constrained-choice-pack.md
+++ b/tests/fixtures/forward/constrained-choice-pack.md
@@ -77,8 +77,8 @@ md_ready
 
 ## Required audits
 
-- option-selection-final-audit — passed: option universe and comparison unit checked
-- final-audit — passed: conclusion and reversal condition visible
+- option-selection-final-audit — passed — pack-section:Artifact contract
+- final-audit — passed — pack-section:Artifact contract
 
 ## Final audit status
 

--- a/tests/fixtures/forward/constrained-choice-report.md
+++ b/tests/fixtures/forward/constrained-choice-report.md
@@ -6,8 +6,8 @@
 
 | Audit | Status | 证据 | 数字角色 |
 |---|---|---|---|
-| option-selection-final-audit | ✅ Passed | §Decision scope | process |
-| final-audit | ✅ Passed | §Executive summary | process |
+| option-selection-final-audit | ✅ Passed | report-section:Decision scope | process |
+| final-audit | ✅ Passed | report-section:Executive summary | process |
 
 ## Executive summary
 
@@ -56,8 +56,8 @@ is conditional on the stated deployment boundary [S01].
   "secondary_routes": [],
   "disciplines": ["decision-utility", "quantitative-role"],
   "audits": [
-    {"id": "option-selection-final-audit", "status": "passed", "evidence": "§Decision scope"},
-    {"id": "final-audit", "status": "passed", "evidence": "§Executive summary"}
+    {"id": "option-selection-final-audit", "status": "passed", "evidence": "report-section:Decision scope"},
+    {"id": "final-audit", "status": "passed", "evidence": "report-section:Executive summary"}
   ]
 }
 ```

--- a/tests/fixtures/forward/market-outlook-baseline-pack.md
+++ b/tests/fixtures/forward/market-outlook-baseline-pack.md
@@ -76,10 +76,10 @@ md_ready
 
 ## Required audits
 
-- market-outlook-audit — passed: scenario and monitoring structure checked
-- forward-looking-claims — passed: forecast labels preserved
-- source-traceability — passed: available claims map to the register
-- final-audit — passed: conclusion and limitations visible
+- market-outlook-audit — passed — pack-section:Artifact contract
+- forward-looking-claims — passed — pack-section:Artifact contract
+- source-traceability — passed — pack-section:Artifact contract
+- final-audit — passed — pack-section:Artifact contract
 
 ## Final audit status
 

--- a/tests/fixtures/forward/mixed-negative-pack.md
+++ b/tests/fixtures/forward/mixed-negative-pack.md
@@ -74,10 +74,10 @@ md_ready
 
 ## Required audits
 
-- market-outlook-audit — passed: primary route structure inspected
-- forward-looking-claims — passed: labels inspected
-- source-traceability — passed: claims map to the register
-- final-audit — passed: process artifact reviewed
+- market-outlook-audit — passed — pack-section:Artifact contract
+- forward-looking-claims — passed — pack-section:Artifact contract
+- source-traceability — passed — pack-section:Artifact contract
+- final-audit — passed — pack-section:Artifact contract
 
 ## Final audit status
 

--- a/tests/fixtures/forward/pdf-failed-pack.md
+++ b/tests/fixtures/forward/pdf-failed-pack.md
@@ -75,10 +75,10 @@ pdf_failed
 
 ## Required audits
 
-- market-outlook-audit — passed: scenario structure recorded
-- forward-looking-claims — passed: forecast labels preserved
-- source-traceability — passed: available claims map to the register
-- final-audit — passed: content remains deliverable as Markdown
+- market-outlook-audit — passed — pack-section:Artifact contract
+- forward-looking-claims — passed — pack-section:Artifact contract
+- source-traceability — passed — pack-section:Artifact contract
+- final-audit — passed — pack-section:Artifact contract
 
 ## Final audit status
 

--- a/tests/fixtures/forward/provider-selection-pack.md
+++ b/tests/fixtures/forward/provider-selection-pack.md
@@ -77,9 +77,9 @@ md_ready
 
 ## Required audits
 
-- option-selection-final-audit — passed: decision scope and reversal condition checked
-- source-traceability — passed: claims map to the source register
-- final-audit — passed: conclusion and limitations visible
+- option-selection-final-audit — passed — pack-section:Artifact contract
+- source-traceability — passed — pack-section:Artifact contract
+- final-audit — passed — pack-section:Artifact contract
 
 ## Final audit status
 

--- a/tests/fixtures/forward/provider-selection-report.md
+++ b/tests/fixtures/forward/provider-selection-report.md
@@ -6,9 +6,9 @@
 
 | Audit | Status | 证据 | 数字角色 |
 |---|---|---|---|
-| option-selection-final-audit | ✅ Passed | §Decision scope | process |
-| source-traceability | ✅ Passed | §Source Register | process |
-| final-audit | ✅ Passed | §Executive summary | process |
+| option-selection-final-audit | ✅ Passed | report-section:Decision scope | process |
+| source-traceability | ✅ Passed | report-section:Source Register | process |
+| final-audit | ✅ Passed | report-section:Executive summary | process |
 
 ## Executive summary
 
@@ -60,9 +60,9 @@ not independent confirmation [S01] [S02].
   "secondary_routes": [],
   "disciplines": ["current-state", "source-traceability", "decision-utility", "quantitative-role", "data-conflict"],
   "audits": [
-    {"id": "option-selection-final-audit", "status": "passed", "evidence": "§Decision scope"},
-    {"id": "source-traceability", "status": "passed", "evidence": "§Source Register"},
-    {"id": "final-audit", "status": "passed", "evidence": "§Executive summary"}
+    {"id": "option-selection-final-audit", "status": "passed", "evidence": "report-section:Decision scope"},
+    {"id": "source-traceability", "status": "passed", "evidence": "report-section:Source Register"},
+    {"id": "final-audit", "status": "passed", "evidence": "report-section:Executive summary"}
   ]
 }
 ```

--- a/tests/fixtures/forward/shared-negative-pack.md
+++ b/tests/fixtures/forward/shared-negative-pack.md
@@ -63,8 +63,8 @@ md_ready
 
 ## Required audits
 
-- workflow-spine-audit — passed: workflow evidence visible
-- final-audit — passed: expected process gate
+- workflow-spine-audit — passed — pack-section:Artifact contract
+- final-audit — passed — pack-section:Artifact contract
 
 ## Final audit status
 

--- a/tests/fixtures/forward/shared-positive-pack.md
+++ b/tests/fixtures/forward/shared-positive-pack.md
@@ -64,8 +64,8 @@ md_ready
 
 ## Required audits
 
-- workflow-spine-audit — passed: workflow evidence visible
-- final-audit — passed: limitations visible
+- workflow-spine-audit — passed — pack-section:Artifact contract
+- final-audit — passed — pack-section:Artifact contract
 
 ## Final audit status
 

--- a/tests/test_audit_evidence_provenance.py
+++ b/tests/test_audit_evidence_provenance.py
@@ -1,0 +1,141 @@
+"""Issue #390 tests for typed audit evidence and provenance."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "audit_report.py"
+POSITIVE = ROOT / "tests" / "fixtures" / "audit" / "market-outlook-pos.md"
+PACK = ROOT / "tests" / "fixtures" / "audit" / "research-pack-pos.md"
+
+
+def _run_report(path: Path, *extra: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            str(path),
+            "--research-pack",
+            str(PACK),
+            *extra,
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _manual_audit(data: dict) -> dict:
+    return next(
+        audit for audit in data["audits"]
+        if audit["audit_id"] == "market-outlook-audit"
+    )
+
+
+def test_strict_json_distinguishes_manual_and_automated_provenance() -> None:
+    result = _run_report(POSITIVE, "--strict", "--require-contract", "--json")
+    assert result.returncode == 0, result.stdout
+    data = json.loads(result.stdout)
+    manual = _manual_audit(data)
+    automated = next(
+        audit for audit in data["audits"]
+        if audit["audit_id"] == "forward-looking-claims"
+    )
+
+    assert manual["execution_source"] == "manual_checklist_attestation"
+    assert manual["evidence_provenance"][0]["kind"] == "report_section"
+    assert manual["evidence_provenance"][0]["verified"] is True
+    assert automated["execution_source"] == "automated_validator"
+    assert automated["evidence_provenance"][0]["validator_binding"] == (
+        "forward-looking-claims"
+    )
+
+
+@pytest.mark.parametrize(
+    ("label", "replacement"),
+    [
+        ("free-text", "not actually checked"),
+        ("bare-section", "§3"),
+        ("missing-section", "report-section:§999"),
+    ],
+)
+def test_strict_manual_evidence_tampering_cannot_pass(
+    tmp_path: Path, label: str, replacement: str
+) -> None:
+    content = POSITIVE.read_text(encoding="utf-8")
+    content = content.replace(
+        "report-section:Monitoring signals", replacement, 1
+    )
+    report = tmp_path / f"{label}.md"
+    report.write_text(content, encoding="utf-8")
+
+    result = _run_report(report, "--strict", "--require-contract", "--json")
+    assert result.returncode == 2, result.stdout
+    data = json.loads(result.stdout)
+    assert data["overall"] == "fail"
+    assert _manual_audit(data)["status"] != "pass"
+
+
+def test_strict_contract_evidence_tampering_cannot_pass(tmp_path: Path) -> None:
+    content = POSITIVE.read_text(encoding="utf-8")
+    content = content.replace(
+        '"evidence": "report-section:Monitoring signals"',
+        '"evidence": "report-section:§999"',
+        1,
+    )
+    report = tmp_path / "contract-fake-section.md"
+    report.write_text(content, encoding="utf-8")
+
+    result = _run_report(report, "--strict", "--require-contract", "--json")
+    assert result.returncode == 2, result.stdout
+    data = json.loads(result.stdout)
+    assert any("evidence" in error.lower() for error in data["blocking"])
+
+
+def test_legacy_evidence_is_explicit_in_compatibility_json(tmp_path: Path) -> None:
+    content = POSITIVE.read_text(encoding="utf-8")
+    content = content.replace(
+        "report-section:Monitoring signals", "§3", 1
+    )
+    report = tmp_path / "legacy.md"
+    report.write_text(content, encoding="utf-8")
+
+    result = _run_report(report, "--json")
+    assert result.returncode in (0, 1), result.stdout
+    data = json.loads(result.stdout)
+    manual = _manual_audit(data)
+    assert manual["execution_source"] == "legacy_self_attested"
+    assert manual["evidence_provenance"][0]["verified"] is False
+
+
+def test_duplicate_evidence_reference_shape_is_rejected() -> None:
+    sys.path.insert(0, str(ROOT / "scripts"))
+    from audit_evidence import validate_evidence_reference
+
+    result = validate_evidence_reference(
+        [
+            "report-section:Findings",
+            "report-section:Findings",
+        ],
+        strict=True,
+    )
+    assert not result.is_valid
+    assert any("typed reference" in error for error in result.errors)
+
+
+def test_forged_checklist_item_is_rejected() -> None:
+    sys.path.insert(0, str(ROOT / "scripts"))
+    from audit_evidence import validate_evidence_reference
+
+    result = validate_evidence_reference(
+        "checklist-item:checklists/final-audit.md#NO_SUCH_ITEM",
+        base_dir=ROOT,
+        strict=True,
+    )
+    assert not result.is_valid
+    assert any("not found" in error for error in result.errors)

--- a/tests/test_audit_evidence_provenance.py
+++ b/tests/test_audit_evidence_provenance.py
@@ -15,14 +15,18 @@ POSITIVE = ROOT / "tests" / "fixtures" / "audit" / "market-outlook-pos.md"
 PACK = ROOT / "tests" / "fixtures" / "audit" / "research-pack-pos.md"
 
 
-def _run_report(path: Path, *extra: str) -> subprocess.CompletedProcess:
+def _run_report(
+    path: Path,
+    *extra: str,
+    pack: Path = PACK,
+) -> subprocess.CompletedProcess:
     return subprocess.run(
         [
             sys.executable,
             str(SCRIPT),
             str(path),
             "--research-pack",
-            str(PACK),
+            str(pack),
             *extra,
         ],
         capture_output=True,
@@ -175,6 +179,40 @@ def test_research_pack_manual_validator_reference_is_rejected(tmp_path: Path) ->
     )
     assert result.returncode == 4, result.stdout
     assert "manual audits cannot use validator evidence" in result.stdout
+
+
+def test_unknown_research_pack_audit_id_fails_both_entrypoints(tmp_path: Path) -> None:
+    content = PACK.read_text(encoding="utf-8").replace(
+        "market-outlook-audit",
+        "made-up-audit",
+        1,
+    )
+    pack = tmp_path / "unknown-audit-pack.md"
+    pack.write_text(content, encoding="utf-8")
+
+    standalone = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "validate_research_pack.py"),
+            str(pack),
+            "--strict",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert standalone.returncode == 4, standalone.stdout
+    assert "is not registered" in standalone.stdout
+
+    report = _run_report(
+        POSITIVE,
+        "--strict",
+        "--require-contract",
+        "--json",
+        pack=pack,
+    )
+    assert report.returncode == 2, report.stdout
+    data = json.loads(report.stdout)
+    assert any("is not registered" in error for error in data["blocking"])
 
 
 def test_audit_record_without_matching_content_cannot_pass(tmp_path: Path) -> None:

--- a/tests/test_audit_evidence_provenance.py
+++ b/tests/test_audit_evidence_provenance.py
@@ -97,6 +97,40 @@ def test_strict_contract_evidence_tampering_cannot_pass(tmp_path: Path) -> None:
     assert any("evidence" in error.lower() for error in data["blocking"])
 
 
+def test_unknown_validator_binding_cannot_pass(tmp_path: Path) -> None:
+    content = POSITIVE.read_text(encoding="utf-8")
+    content = content.replace(
+        "report-section:Monitoring signals",
+        "validator:not-a-real-binding",
+        1,
+    )
+    report = tmp_path / "unknown-validator.md"
+    report.write_text(content, encoding="utf-8")
+
+    result = _run_report(report, "--strict", "--require-contract", "--json")
+    assert result.returncode == 2, result.stdout
+    data = json.loads(result.stdout)
+    assert data["overall"] == "fail"
+    assert any("not registered" in error for error in data["blocking"])
+
+
+def test_audit_record_without_matching_content_cannot_pass(tmp_path: Path) -> None:
+    content = POSITIVE.read_text(encoding="utf-8")
+    content = content.replace(
+        "report-section:Monitoring signals",
+        "audit-record:README.md#not-a-real-record@2030-01-01T00:00:00Z",
+        1,
+    )
+    report = tmp_path / "unknown-record.md"
+    report.write_text(content, encoding="utf-8")
+
+    result = _run_report(report, "--strict", "--require-contract", "--json")
+    assert result.returncode == 2, result.stdout
+    data = json.loads(result.stdout)
+    assert data["overall"] == "fail"
+    assert any("audit record file" in error for error in data["blocking"])
+
+
 def test_legacy_evidence_is_explicit_in_compatibility_json(tmp_path: Path) -> None:
     content = POSITIVE.read_text(encoding="utf-8")
     content = content.replace(
@@ -139,3 +173,49 @@ def test_forged_checklist_item_is_rejected() -> None:
     )
     assert not result.is_valid
     assert any("not found" in error for error in result.errors)
+
+
+def test_real_checklist_item_is_verified() -> None:
+    sys.path.insert(0, str(ROOT / "scripts"))
+    from audit_evidence import validate_evidence_reference
+
+    result = validate_evidence_reference(
+        "checklist-item:checklists/final-audit.md#FA-001",
+        base_dir=ROOT,
+        strict=True,
+    )
+    assert result.is_valid, result.errors
+    assert result.provenance and result.provenance["verified"] is True
+
+
+def test_audit_record_requires_matching_record_content(tmp_path: Path) -> None:
+    sys.path.insert(0, str(ROOT / "scripts"))
+    from audit_evidence import validate_evidence_reference
+
+    record_file = tmp_path / "audit-record.json"
+    record_file.write_text(
+        json.dumps({
+            "records": [
+                {
+                    "record_id": "manual-001",
+                    "recorded_at": "2026-08-18T10:00:00Z",
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
+    valid = validate_evidence_reference(
+        "audit-record:audit-record.json#manual-001@2026-08-18T10:00:00Z",
+        base_dir=tmp_path,
+        strict=True,
+    )
+    assert valid.is_valid, valid.errors
+    assert valid.provenance and valid.provenance["verified"] is True
+
+    forged = validate_evidence_reference(
+        "audit-record:audit-record.json#not-real@2030-01-01T00:00:00Z",
+        base_dir=tmp_path,
+        strict=True,
+    )
+    assert not forged.is_valid
+    assert any("was not found" in error for error in forged.errors)

--- a/tests/test_audit_evidence_provenance.py
+++ b/tests/test_audit_evidence_provenance.py
@@ -111,7 +111,70 @@ def test_unknown_validator_binding_cannot_pass(tmp_path: Path) -> None:
     assert result.returncode == 2, result.stdout
     data = json.loads(result.stdout)
     assert data["overall"] == "fail"
-    assert any("not registered" in error for error in data["blocking"])
+    assert any("validator" in error.lower() for error in data["blocking"])
+
+
+def test_validator_reference_checks_registry_for_automated_context() -> None:
+    sys.path.insert(0, str(ROOT / "scripts"))
+    from audit_evidence import validate_evidence_reference
+
+    unknown = validate_evidence_reference(
+        "validator:not-a-real-binding",
+        strict=True,
+        execution_type="automated",
+    )
+    assert not unknown.is_valid
+    assert any("not registered" in error for error in unknown.errors)
+
+    known = validate_evidence_reference(
+        "validator:listed-company-delivery",
+        strict=True,
+        execution_type="automated",
+    )
+    assert known.is_valid, known.errors
+
+
+def test_registered_but_unexecuted_validator_cannot_back_manual_audit(
+    tmp_path: Path,
+) -> None:
+    content = POSITIVE.read_text(encoding="utf-8")
+    content = content.replace(
+        "report-section:Monitoring signals",
+        "validator:listed-company-delivery",
+        1,
+    )
+    report = tmp_path / "wrong-validator-for-manual.md"
+    report.write_text(content, encoding="utf-8")
+
+    result = _run_report(report, "--strict", "--require-contract", "--json")
+    assert result.returncode == 2, result.stdout
+    data = json.loads(result.stdout)
+    manual = _manual_audit(data)
+    assert manual["status"] != "pass"
+    assert any("manual" in error.lower() for error in data["blocking"])
+
+
+def test_research_pack_manual_validator_reference_is_rejected(tmp_path: Path) -> None:
+    content = PACK.read_text(encoding="utf-8").replace(
+        "pack-section:Artifact contract",
+        "validator:listed-company-delivery",
+        1,
+    )
+    pack = tmp_path / "manual-validator-pack.md"
+    pack.write_text(content, encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "validate_research_pack.py"),
+            str(pack),
+            "--strict",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 4, result.stdout
+    assert "manual audits cannot use validator evidence" in result.stdout
 
 
 def test_audit_record_without_matching_content_cannot_pass(tmp_path: Path) -> None:

--- a/tests/test_audit_required_execution.py
+++ b/tests/test_audit_required_execution.py
@@ -41,10 +41,10 @@ CONTRACT_TEMPLATE = {
     "secondary_routes": [],
     "disciplines": [],
     "audits": [
-        {"id": "market-outlook-audit", "status": "passed", "evidence": "§3"},
-        {"id": "forward-looking-claims", "status": "passed", "evidence": "§4"},
-        {"id": "source-traceability", "status": "passed", "evidence": "§5"},
-        {"id": "final-audit", "status": "passed", "evidence": "§2"},
+        {"id": "market-outlook-audit", "status": "passed", "evidence": "report-section:Monitoring signals"},
+        {"id": "forward-looking-claims", "status": "passed", "evidence": "report-section:Monitoring signals"},
+        {"id": "source-traceability", "status": "passed", "evidence": "report-section:Findings"},
+        {"id": "final-audit", "status": "passed", "evidence": "report-section:Executive summary"},
     ],
     "artifact_id": "fixture-market-outlook-pos",
     "contract_version": "1.0.0",
@@ -68,24 +68,24 @@ def _route_block(primary: str) -> str:
     """Route and audit status block declaring the primary route and audits."""
     audits = {
         "market-outlook": [
-            ("market-outlook-audit", "§3"),
-            ("forward-looking-claims", "§4"),
-            ("source-traceability", "§5"),
-            ("final-audit", "§2"),
+            ("market-outlook-audit", "report-section:Monitoring signals"),
+            ("forward-looking-claims", "report-section:Monitoring signals"),
+            ("source-traceability", "report-section:Findings"),
+            ("final-audit", "report-section:Executive summary"),
             # quantitative-role-audit keeps the table role-annotated
             # (table-role-labels: 3+ row tables need a role keyword).
-            ("quantitative-role-audit", "§6"),
+            ("quantitative-role-audit", "report-table:Comparison Table"),
         ],
         "technical-deep-dive": [
-            ("technical-analysis-audit", "§4"),
-            ("source-traceability", "§5"),
-            ("final-audit", "§2"),
-            ("quantitative-role-audit", "§6"),
+            ("technical-analysis-audit", "report-section:Findings"),
+            ("source-traceability", "report-section:Findings"),
+            ("final-audit", "report-section:Executive summary"),
+            ("quantitative-role-audit", "report-table:Comparison Table"),
         ],
         "shared-workflow": [
-            ("workflow-spine-audit", "§3"),
-            ("final-audit", "§2"),
-            ("quantitative-role-audit", "§6"),
+            ("workflow-spine-audit", "report-section:Findings"),
+            ("final-audit", "report-section:Executive summary"),
+            ("quantitative-role-audit", "report-table:Comparison Table"),
         ],
     }
     rows = audits.get(primary, audits["market-outlook"])
@@ -218,7 +218,7 @@ class TestManualAuditStatus:
             "**Primary route**: Market Outlook\n\n"
             "| Audit | Status | 证据 |\n"
             "|-------|--------|------|\n"
-            "| final-audit | ✅ Passed | §2 |\n"
+            "| final-audit | ✅ Passed | report-section:Executive summary |\n"
         )
         return _write(_report(route_block=block, contract=_contract()))
 
@@ -228,11 +228,11 @@ class TestManualAuditStatus:
             "**Primary route**: Market Outlook\n\n"
             "| Audit | Status | 证据 |\n"
             "|-------|--------|------|\n"
-            f"| market-outlook-audit | {status_cell} | §3 |\n"
-            "| forward-looking-claims | ✅ Passed | §4 |\n"
-            "| source-traceability | ✅ Passed | §5 |\n"
-            "| final-audit | ✅ Passed | §2 |\n"
-            "| quantitative-role-audit | ✅ Passed | §6 |\n"
+            f"| market-outlook-audit | {status_cell} | report-section:Monitoring signals |\n"
+            "| forward-looking-claims | ✅ Passed | report-section:Monitoring signals |\n"
+            "| source-traceability | ✅ Passed | report-section:Findings |\n"
+            "| final-audit | ✅ Passed | report-section:Executive summary |\n"
+            "| quantitative-role-audit | ✅ Passed | report-table:Comparison Table |\n"
         )
         return _write(_report(route_block=block, contract=_contract()))
 
@@ -329,12 +329,12 @@ class TestManualAuditStatus:
             "**Primary route**: Market Outlook\n\n"
             "| Audit | Status | 证据 |\n"
             "|-------|--------|------|\n"
-            f"| market-outlook-audit | {first} | §3 |\n"
-            f"| market-outlook-audit | {second} | §3 |\n"
-            "| forward-looking-claims | ✅ Passed | §4 |\n"
-            "| source-traceability | ✅ Passed | §5 |\n"
-            "| final-audit | ✅ Passed | §2 |\n"
-            "| quantitative-role-audit | ✅ Passed | §6 |\n"
+            f"| market-outlook-audit | {first} | report-section:Monitoring signals |\n"
+            f"| market-outlook-audit | {second} | report-section:Monitoring signals |\n"
+            "| forward-looking-claims | ✅ Passed | report-section:Monitoring signals |\n"
+            "| source-traceability | ✅ Passed | report-section:Findings |\n"
+            "| final-audit | ✅ Passed | report-section:Executive summary |\n"
+            "| quantitative-role-audit | ✅ Passed | report-table:Comparison Table |\n"
         )
         return _write(_report(route_block=block, contract=_contract()))
 
@@ -366,16 +366,16 @@ class TestManualAuditStatus:
         block1 = (
             "## Route and audit status\n\n**Primary route**: Market Outlook\n\n"
             "| Audit | Status | 证据 |\n|-------|--------|------|\n"
-            f"| market-outlook-audit | {first} | §3 |\n"
-            "| forward-looking-claims | ✅ Passed | §4 |\n"
-            "| source-traceability | ✅ Passed | §5 |\n"
-            "| final-audit | ✅ Passed | §2 |\n"
-            "| quantitative-role-audit | ✅ Passed | §6 |\n"
+            f"| market-outlook-audit | {first} | report-section:Monitoring signals |\n"
+            "| forward-looking-claims | ✅ Passed | report-section:Monitoring signals |\n"
+            "| source-traceability | ✅ Passed | report-section:Findings |\n"
+            "| final-audit | ✅ Passed | report-section:Executive summary |\n"
+            "| quantitative-role-audit | ✅ Passed | report-table:Comparison Table |\n"
         )
         block2 = (
             "## Route and audit status\n\n**Primary route**: Market Outlook\n\n"
             "| Audit | Status | 证据 |\n|-------|--------|------|\n"
-            f"| market-outlook-audit | {second} | §3 |\n"
+            f"| market-outlook-audit | {second} | report-section:Monitoring signals |\n"
         )
         return _write(_report(route_block=block1, contract=_contract()) + "\n" + block2)
 
@@ -1926,12 +1926,12 @@ class TestSecondaryHardFail:
         contract = _contract(
             secondary_routes=["constrained-choice"],
             audits=[
-                {"id": "market-outlook-audit", "status": "passed", "evidence": "§3"},
-                {"id": "forward-looking-claims", "status": "passed", "evidence": "§4"},
-                {"id": "source-traceability", "status": "passed", "evidence": "§5"},
-                {"id": "final-audit", "status": "passed", "evidence": "§2"},
+                {"id": "market-outlook-audit", "status": "passed", "evidence": "report-section:Monitoring signals"},
+                {"id": "forward-looking-claims", "status": "passed", "evidence": "report-section:Monitoring signals"},
+                {"id": "source-traceability", "status": "passed", "evidence": "report-section:Findings"},
+                {"id": "final-audit", "status": "passed", "evidence": "report-section:Executive summary"},
                 {"id": "constrained-choice-secondary-hard-fail", "status": "passed",
-                 "evidence": "§6 verified hard-fail conditions"},
+                 "evidence": "report-section:Dimension conclusions"},
             ],
         )
         path = self._secondary_report(contract)
@@ -1946,10 +1946,10 @@ class TestSecondaryHardFail:
         contract = _contract(
             secondary_routes=["constrained-choice"],
             audits=[
-                {"id": "market-outlook-audit", "status": "passed", "evidence": "§3"},
-                {"id": "forward-looking-claims", "status": "passed", "evidence": "§4"},
-                {"id": "source-traceability", "status": "passed", "evidence": "§5"},
-                {"id": "final-audit", "status": "passed", "evidence": "§2"},
+                {"id": "market-outlook-audit", "status": "passed", "evidence": "report-section:Monitoring signals"},
+                {"id": "forward-looking-claims", "status": "passed", "evidence": "report-section:Monitoring signals"},
+                {"id": "source-traceability", "status": "passed", "evidence": "report-section:Findings"},
+                {"id": "final-audit", "status": "passed", "evidence": "report-section:Executive summary"},
             ],
         )
         path = self._secondary_report(contract)
@@ -2020,10 +2020,10 @@ fixture-market-outlook-pos
 
 ## Required audits
 
-- market-outlook-audit — passed: executed by author
-- forward-looking-claims — passed: no mislabeled claims
-- source-traceability — passed: register complete
-- final-audit — passed: all gates verified
+- market-outlook-audit — passed — pack-section:Artifact contract
+- forward-looking-claims — passed — pack-section:Artifact contract
+- source-traceability — passed — pack-section:Artifact contract
+- final-audit — passed — pack-section:Artifact contract
 
 ## Final audit status
 

--- a/tests/test_contract_reference_integrity.py
+++ b/tests/test_contract_reference_integrity.py
@@ -37,7 +37,7 @@ OFTEN_CONFUSED = {r["id"]: r["often_confused_with"] for r in MANIFEST["routes"]}
 def build_contract(primary="listed-company", audits=None, **overrides):
     """Build a contract that satisfies all pre-existing rules by default."""
     audits = audits if audits is not None else [
-        {"id": aid, "status": "passed", "evidence": "§2"}
+        {"id": aid, "status": "passed", "evidence": "report-section:Executive summary"}
         for aid in REQUIRED_AUDITS[primary]
     ]
     contract = {

--- a/tests/test_research_pack_status.py
+++ b/tests/test_research_pack_status.py
@@ -62,7 +62,7 @@ When tests pass.
 The report must validate correctly.
 
 ## Required audits
-- final audit — passed
+- final audit — passed — pack-section:Artifact contract
 
 ## Final audit status
 Pass


### PR DESCRIPTION
## Summary

- Add a shared typed audit-evidence validator for report sections/tables, checklist items, audit records, and automated validator bindings.
- Make strict report, contract, and Research Pack validation reject free-form evidence, bare section references, and missing locators.
- Add `execution_source` and normalized evidence provenance to the JSON audit verdict, including explicit `legacy_self_attested` compatibility output.
- Migrate positive fixtures/templates and add Issue #390 tampering/compatibility tests.

## Root cause

Manual/process audits previously treated any non-empty evidence string as proof. Values such as `not actually checked` and `§999` therefore produced `overall=pass` under `--strict --require-contract`.

## Validation

- `python3 -m pytest -q`
- Result: `1493 passed`
- Final baseline: `origin/main@1485f1c7f0f5ad1af98146b1aa8d803db0420c4b`

## Scope

This PR does not add routes, rewrite route-specific checklist content, automate manual judgment, or include the follow-up route/forward-eval/registry/CommonMark issues.

Closes #390