### PR TITLE
fix: add activation-record forward eval gate (#392)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
       - run: python3 scripts/test_route_decision_tree.py
       - run: python3 -m pytest -q tests/test_registry_loader.py tests/test_route_activation.py
       - run: python3 -m pytest -q tests/test_issue_391_contract_integration.py tests/test_issue_391_research_pack.py
+      - run: python3 -m pytest -q tests/test_issue_392_activation_integration.py
       - run: python3 scripts/validate_contract.py references/report-template.md --require-contract
       - run: python3 scripts/test_issue_pr_acceptance.py
       # ── Issue #378: required-audit execution end-to-end fixtures ──────────

--- a/evals/README.md
+++ b/evals/README.md
@@ -87,7 +87,8 @@ Markdown case index:
 - `evals/registry.json` describes executable user-prompt, activation, process-
   artifact, audit, and delivery-status fixtures. Its `decision_tree_version`
   pins specialized Research Pack fields and activation snapshots to the same
-  canonical decision-tree registry.
+  canonical decision-tree registry. Each case declares an `evaluation_mode`:
+  `structured-decision-replay` or `activation-record-integration`.
 - `comparative-distillation/candidate-rule-registry.md` tracks candidate rule
   actions and coverage; it is not an execution registry.
 
@@ -101,9 +102,11 @@ python3 scripts/run_forward_evals.py --offline --check-baseline
 The runner binds each prompt to canonical `action_burden`,
 `weight_bearing_object`, secondary-route and prompt-hash fields, resolves that
 structured activation through the route-selection decision tree, then replays
-local report and Research Pack snapshots. It does not call a paid model or an
-external search provider, and it consumes the structured JSON verdict emitted
-by `scripts/audit_report.py` rather than parsing human-readable audit output.
+local report and Research Pack snapshots. Integration cases additionally pass
+the canonical activation snapshot to `scripts/audit_report.py`; a mismatch
+must be a blocking audit result. It does not call a paid model or an external
+search provider, and it consumes the structured JSON verdict emitted by
+`scripts/audit_report.py` rather than parsing human-readable audit output.
 The adapter is a fail-closed test surface, not a claim that production agent
 reasoning is a keyword classifier.
 
@@ -111,15 +114,21 @@ Forward cases retain a concrete `failure_family` and map it to one of four
 diagnostic classes: `missing-rule`, `missing-trigger`, `execution-drift`, or
 `fixture-reference-drift`. Registry and fixture failures are reported as
 `fixture-reference-drift` before any model or audit result is considered.
+Negative cases also expose a `failure_stage`: route misclassification is a
+`contract` mismatch, secondary-route verification is an `audit` failure, and
+declared-not-executed is an `evidence` failure.
 
-Metric denominators are explicit: `route_activation_accuracy` is correct
-prompt activation over positive cases; `pack_completeness` is complete expected
-pack fields over all active cases; `declared_not_executed_rate` is observed
-manual/process `not_run`/`partial`/`skipped` cases over all active cases; and
-`declared_not_executed_recall` is detection over its negative-case denominator.
-`false_passed_rate` counts negative fixtures whose raw audit verdict is Pass;
-`negative_case_failure_rate` counts negative fixtures the evaluator failed to
-recognize, so the two metrics are intentionally different.
+Metric denominators are explicit: `structured_route_resolution_rate` is correct
+structured activation over structured positive cases; `activation_report_consistency`
+is matching activation/report route over positive integration cases;
+`audit_false_pass_rate` counts only integration negative cases whose strict
+production audit still returns Pass and must be `0.0`; and
+`oracle_mismatch_detection_rate` counts route-mismatch negatives recognized by
+the evaluator. `negative_case_contract_pass_rate` is the positive rate at which
+all negative cases match their declared failure shape. `pack_completeness`,
+`declared_not_executed_rate`, and `declared_not_executed_recall` retain their
+existing denominators. The prompt SHA is fixture identity only, not route or
+agent accuracy.
 
 ## What not to put here
 

--- a/evals/forward-metrics-baseline.json
+++ b/evals/forward-metrics-baseline.json
@@ -1,11 +1,11 @@
 {
-  "version": 1,
+  "version": 2,
   "metrics": {
     "case_count": 11,
     "positive_case_count": 8,
     "negative_case_count": 3,
     "case_pass_count": 11,
-    "route_activation_accuracy": 1.0,
+    "structured_route_resolution_rate": 1.0,
     "activation_report_consistency": 1.0,
     "parallelization_decision_consistency": 1.0,
     "boundary_resolution_rate": 1.0,
@@ -13,9 +13,9 @@
     "secondary_hard_fail_recall": 1.0,
     "declared_not_executed_recall": 1.0,
     "declared_not_executed_rate": 0.1818,
-    "false_passed_rate": 0.3333,
-    "negative_case_failure_rate": 0.0,
-    "negative_detection_rate": 1.0,
+    "audit_false_pass_rate": 0.0,
+    "oracle_mismatch_detection_rate": 1.0,
+    "negative_case_contract_pass_rate": 1.0,
     "blocked_partial_and_pdf_failed_status_correctness": 1.0
   }
 }

--- a/evals/registry.json
+++ b/evals/registry.json
@@ -8,6 +8,7 @@
       "id": "forward-provider-selection",
       "type": "positive",
       "status": "active",
+      "evaluation_mode": "structured-decision-replay",
       "input": {
         "user_prompt": "应该选择哪个 AI 模型供应商，才能满足当前团队的访问和支持约束？",
         "prompt_sha256": "9bd3951b90c212e76c69c9548b80bb9574978c6e48f6b673059cf719d5a604a8",
@@ -39,6 +40,7 @@
       "id": "forward-constrained-choice",
       "type": "positive",
       "status": "active",
+      "evaluation_mode": "structured-decision-replay",
       "input": {
         "user_prompt": "在定义好的选项集合中，哪一个最适合当前部署约束？",
         "prompt_sha256": "5ca7883814895067ab4a5d44e95c7c79d72e230768433ef7ecb28ee81b80e887",
@@ -70,6 +72,7 @@
       "id": "forward-academic-vs-technical",
       "type": "positive",
       "status": "active",
+      "evaluation_mode": "structured-decision-replay",
       "input": {
         "user_prompt": "请基于学术文献评估这个研究方向的进展、证据质量和当前局限。",
         "prompt_sha256": "c270ca6004ab2327c2a460aa16bdf1b349210324f3492ce9e0e581c4382aa7c5",
@@ -101,6 +104,7 @@
       "id": "forward-company-technical-mixed",
       "type": "positive",
       "status": "active",
+      "evaluation_mode": "structured-decision-replay",
       "input": {
         "user_prompt": "分析一家上市公司的技术架构可行性，并单独检查公司层面的风险。",
         "prompt_sha256": "4b9b25b9e5883a9097cefd3a469793b5b148b863dba70cdebc09913c27acd17d",
@@ -138,6 +142,7 @@
       "id": "forward-shared-workflow-escape-hatch",
       "type": "positive",
       "status": "active",
+      "evaluation_mode": "structured-decision-replay",
       "input": {
         "user_prompt": "把一份轻量的内部流程复盘整理成可审计的工作流说明。",
         "prompt_sha256": "efaefff3ea868fcbc0b911de73b9f59606f11ffa1ae73c395cd824da7e736c2c",
@@ -169,6 +174,7 @@
       "id": "forward-channel-blocked",
       "type": "positive",
       "status": "active",
+      "evaluation_mode": "structured-decision-replay",
       "input": {
         "user_prompt": "在外部搜索通道不可用时，给出一个明确标注研究边界的行业展望。",
         "prompt_sha256": "d3ae00b29cf64007b02aa05561cc90df45ac8332b829776aecac16b278b1ff45",
@@ -200,6 +206,7 @@
       "id": "forward-markdown-ready-pdf-failed",
       "type": "positive",
       "status": "active",
+      "evaluation_mode": "structured-decision-replay",
       "input": {
         "user_prompt": "请给出这个市场未来 12 个月如何演化的展望，并交付 Markdown；若 PDF 渲染失败也要明确记录。",
         "prompt_sha256": "0962652aefa26a7833e4cbe01c089e129f1dbc5229503128e0c99c10f507ec3d",
@@ -231,6 +238,7 @@
       "id": "forward-market-outlook-baseline",
       "type": "positive",
       "status": "active",
+      "evaluation_mode": "activation-record-integration",
       "input": {
         "user_prompt": "未来 12 个月这个市场将如何演化，关键监测信号是什么？",
         "prompt_sha256": "db59e14712fb8287f0873e7e144dc5050b55e5cee4db85b281000f19de356ce5",
@@ -252,7 +260,8 @@
       },
       "fixtures": {
         "report": "tests/fixtures/audit/market-outlook-pos.md",
-        "research_pack": "tests/fixtures/forward/market-outlook-baseline-pack.md"
+        "research_pack": "tests/fixtures/forward/market-outlook-baseline-pack.md",
+        "activation_snapshot": "tests/fixtures/forward/forward-market-outlook-baseline-activation.json"
       },
       "failure_family": null,
       "related_rule": ["ROUTING-MATRIX.md#market-outlook-industry-evolution", "evals/cases/humanoid-robot-market-outlook-dual-route-case.md"],
@@ -262,6 +271,7 @@
       "id": "forward-secondary-route-not-verified",
       "type": "negative",
       "status": "active",
+      "evaluation_mode": "structured-decision-replay",
       "input": {
         "user_prompt": "分析市场未来 12 个月的展望，并在次级路由中记录选项边界，不做选项排序。",
         "prompt_sha256": "38a748892c9f61e95bd00f9a9ee545e6e6503b99face2b9368860edeb3213071",
@@ -285,6 +295,7 @@
         "research_pack_fields": ["Objective", "Decision context", "Primary route", "Action burden", "Weight-bearing object", "Decision tree path", "Decision tree version", "Secondary disciplines", "Core subquestions", "Stop condition", "Source register", "Claim register", "Uncertainty register", "Artifact id", "Artifact contract", "Research status", "Delivery status", "Required audits", "Final audit status"],
         "statuses": {"research_status": "complete", "audit_status": "fail", "delivery_status": "md_ready"},
         "verdict": "fail",
+        "failure_stage": "audit",
         "parallelization_decision": "parallel"
       },
       "fixtures": {
@@ -299,6 +310,7 @@
       "id": "forward-route-misclassification",
       "type": "negative",
       "status": "active",
+      "evaluation_mode": "activation-record-integration",
       "input": {
         "user_prompt": "AI 编程工具市场中哪家会领先？请给出选择和排序。",
         "prompt_sha256": "0dac0cd9e48109f7a88f36088cf58f7ade0f0cf212f125cc194f5fc6575abc02",
@@ -314,13 +326,15 @@
         "disciplines": ["decision-utility", "quantitative-role"],
         "required_audits": ["option-selection-final-audit", "final-audit"],
         "research_pack_fields": ["Objective", "Decision context", "Primary route", "Action burden", "Weight-bearing object", "Decision tree path", "Decision tree version", "Secondary disciplines", "Core subquestions", "Stop condition", "Source register", "Claim register", "Uncertainty register", "Artifact id", "Artifact contract", "Research status", "Delivery status", "Required audits", "Final audit status"],
-        "statuses": {"research_status": "complete", "audit_status": "pass", "delivery_status": "md_ready"},
+        "statuses": {"research_status": "complete", "audit_status": "fail", "delivery_status": "md_ready"},
         "verdict": "fail",
+        "failure_stage": "contract",
         "parallelization_decision": "single-track"
       },
       "fixtures": {
-        "report": "tests/fixtures/audit/market-outlook-pos.md",
-        "research_pack": "tests/fixtures/forward/market-outlook-baseline-pack.md"
+        "report": "tests/fixtures/forward/forward-route-misclassification-report.md",
+        "research_pack": "tests/fixtures/forward/forward-route-misclassification-pack.md",
+        "activation_snapshot": "tests/fixtures/forward/forward-route-misclassification-activation.json"
       },
       "failure_family": "route-misclassification",
       "related_rule": ["ROUTING-MATRIX.md#route-selection-decision-tree", "evals/cases/world-cup-constrained-choice-wrong-route-case.md"],
@@ -330,6 +344,7 @@
       "id": "forward-declared-not-executed",
       "type": "negative",
       "status": "active",
+      "evaluation_mode": "structured-decision-replay",
       "input": {
         "user_prompt": "把轻量工作流复盘交付出来，并声明最终审计已完成。",
         "prompt_sha256": "6984309fa8314a4c8bdf29d681220d8779c96b804b434cd7645222edef1cc9e0",
@@ -347,6 +362,7 @@
         "research_pack_fields": ["Objective", "Decision context", "Primary route", "Secondary disciplines", "Core subquestions", "Stop condition", "Source register", "Claim register", "Uncertainty register", "Artifact id", "Artifact contract", "Research status", "Delivery status", "Required audits", "Final audit status"],
         "statuses": {"research_status": "complete", "audit_status": "fail", "delivery_status": "md_ready"},
         "verdict": "fail",
+        "failure_stage": "evidence",
         "parallelization_decision": "not-needed"
       },
       "fixtures": {

--- a/schemas/research-pack.md
+++ b/schemas/research-pack.md
@@ -33,6 +33,9 @@ Include when the pack is part of a tracked delivery (issue #376):
   `scripts/validate_contract.py report.md --research-pack pack.md`).
 - `## Contract reference` — points back to the final report/contract artifact id
   once the report is delivered.
+- `## Activation snapshot` — required for `activation-record-integration` evals;
+  records the shared `activation_id`, `snapshot_sha256`, `snapshot_version`,
+  and `decision_tree_version` reference used by the report contract.
 
 ## Conditional sections
 

--- a/schemas/route-activation-contract.json
+++ b/schemas/route-activation-contract.json
@@ -20,6 +20,18 @@
       "minimum": 1,
       "description": "Version of schemas/route-decision-tree.json used to resolve action/object/conflict semantics."
     },
+    "activation_snapshot": {
+      "type": "object",
+      "description": "Stable reference to the canonical activation snapshot used by the integration audit.",
+      "required": ["activation_id", "snapshot_sha256", "snapshot_version", "decision_tree_version"],
+      "properties": {
+        "activation_id": {"type": "string", "minLength": 1},
+        "snapshot_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "snapshot_version": {"type": "integer", "minimum": 1},
+        "decision_tree_version": {"type": "integer", "minimum": 1}
+      },
+      "additionalProperties": false
+    },
     "created_at": {
       "type": "string",
       "description": "Generation timestamp (ISO 8601 date, e.g., 2026-08-13). Recommended; required under --strict."

--- a/scripts/activation_snapshot.py
+++ b/scripts/activation_snapshot.py
@@ -320,13 +320,19 @@ def extract_activation_snapshot_reference(
     label: str = "Research Pack",
 ) -> tuple[dict[str, Any] | None, list[str]]:
     """Extract a visible ``## Activation snapshot`` reference from Markdown."""
-    match = re.search(
+    matches = list(re.finditer(
         r"^## Activation snapshot\s*$\n(.*?)(?=^##\s|\Z)",
         text,
         re.MULTILINE | re.DOTALL,
-    )
-    if not match:
+    ))
+    if not matches:
         return None, []
+    if len(matches) > 1:
+        return None, [
+            f"{label} contains multiple '## Activation snapshot' sections "
+            f"({len(matches)}) — exactly one is required"
+        ]
+    match = matches[0]
 
     values: dict[str, Any] = {}
     errors: list[str] = []

--- a/scripts/activation_snapshot.py
+++ b/scripts/activation_snapshot.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Typed activation snapshots shared by forward evals and audit integration.
+
+An activation snapshot is a deterministic, versioned record of the structured
+route decision.  It is deliberately not a prompt classifier or a model output:
+the canonical action/object decision tree still owns route semantics.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Mapping
+
+from registry_loader import (
+    RegistryError,
+    load_decision_tree_registry,
+    load_route_registry,
+)
+from route_activation import ALLOWED_PARALLELIZATION, ActivationResult
+
+
+SNAPSHOT_VERSION = 1
+SNAPSHOT_MODES = {
+    "structured-decision-replay",
+    "activation-record-integration",
+}
+ACTIVATION_REF_FIELDS = {
+    "activation_id",
+    "snapshot_sha256",
+    "snapshot_version",
+    "decision_tree_version",
+}
+SNAPSHOT_REQUIRED_FIELDS = ACTIVATION_REF_FIELDS | {
+    "evaluation_mode",
+    "prompt_sha256",
+    "action_burden",
+    "weight_bearing_object",
+    "primary_route",
+    "secondary_routes",
+    "derived_secondary_routes",
+    "manual_secondary_routes",
+    "parallelization_decision",
+}
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ActivationSnapshotError(ValueError):
+    """Raised when an activation snapshot or reference is malformed."""
+
+
+def _canonical_payload(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the hash payload, excluding the self-referential digest."""
+    return {
+        key: snapshot[key]
+        for key in sorted(snapshot)
+        if key != "snapshot_sha256"
+    }
+
+
+def compute_snapshot_sha256(snapshot: Mapping[str, Any]) -> str:
+    """Hash a snapshot using stable JSON serialization."""
+    encoded = json.dumps(
+        _canonical_payload(snapshot),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def activation_reference(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    """Extract the stable cross-artifact reference from a snapshot."""
+    return {field: snapshot[field] for field in sorted(ACTIVATION_REF_FIELDS)}
+
+
+def _require_non_empty_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ActivationSnapshotError(f"{field} must be a non-empty string")
+    return value
+
+
+def _require_sha256(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not SHA256_RE.fullmatch(value):
+        raise ActivationSnapshotError(
+            f"{field} must be a 64-character lowercase SHA-256"
+        )
+    return value
+
+
+def _require_positive_int(value: Any, field: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise ActivationSnapshotError(f"{field} must be a positive integer")
+    return value
+
+
+def _require_string_list(value: Any, field: str) -> list[str]:
+    if not isinstance(value, list) or not all(
+        isinstance(item, str) and item.strip() for item in value
+    ):
+        raise ActivationSnapshotError(f"{field} must be a list of non-empty strings")
+    if value != sorted(value):
+        raise ActivationSnapshotError(f"{field} must be sorted canonically")
+    if len(value) != len(set(value)):
+        raise ActivationSnapshotError(f"{field} must not contain duplicates")
+    return list(value)
+
+
+def validate_activation_reference(
+    reference: Any,
+    *,
+    label: str = "activation_snapshot",
+) -> dict[str, Any]:
+    """Validate the stable reference embedded in a report or Research Pack."""
+    if not isinstance(reference, dict):
+        raise ActivationSnapshotError(f"{label} must be an object")
+    missing = ACTIVATION_REF_FIELDS - set(reference)
+    unexpected = set(reference) - ACTIVATION_REF_FIELDS
+    if missing:
+        raise ActivationSnapshotError(
+            f"{label} missing field(s): {', '.join(sorted(missing))}"
+        )
+    if unexpected:
+        raise ActivationSnapshotError(
+            f"{label} has unexpected field(s): {', '.join(sorted(unexpected))}"
+        )
+    activation_id = _require_non_empty_string(reference["activation_id"], f"{label}.activation_id")
+    digest = _require_sha256(reference["snapshot_sha256"], f"{label}.snapshot_sha256")
+    snapshot_version = _require_positive_int(
+        reference["snapshot_version"], f"{label}.snapshot_version"
+    )
+    decision_tree_version = _require_positive_int(
+        reference["decision_tree_version"], f"{label}.decision_tree_version"
+    )
+    return {
+        "activation_id": activation_id,
+        "snapshot_sha256": digest,
+        "snapshot_version": snapshot_version,
+        "decision_tree_version": decision_tree_version,
+    }
+
+
+def validate_snapshot(
+    snapshot: Any,
+    *,
+    expected_reference: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Validate a complete snapshot against the canonical decision tree."""
+    if not isinstance(snapshot, dict):
+        raise ActivationSnapshotError("activation snapshot must be a JSON object")
+    missing = SNAPSHOT_REQUIRED_FIELDS - set(snapshot)
+    unexpected = set(snapshot) - SNAPSHOT_REQUIRED_FIELDS
+    if missing:
+        raise ActivationSnapshotError(
+            "activation snapshot missing field(s): "
+            + ", ".join(sorted(missing))
+        )
+    if unexpected:
+        raise ActivationSnapshotError(
+            "activation snapshot has unexpected field(s): "
+            + ", ".join(sorted(unexpected))
+        )
+
+    normalized = dict(snapshot)
+    normalized["activation_id"] = _require_non_empty_string(
+        snapshot["activation_id"], "activation_id"
+    )
+    normalized["snapshot_version"] = _require_positive_int(
+        snapshot["snapshot_version"], "snapshot_version"
+    )
+    if normalized["snapshot_version"] != SNAPSHOT_VERSION:
+        raise ActivationSnapshotError(
+            f"snapshot_version {normalized['snapshot_version']} does not match "
+            f"supported version {SNAPSHOT_VERSION}"
+        )
+    normalized["evaluation_mode"] = _require_non_empty_string(
+        snapshot["evaluation_mode"], "evaluation_mode"
+    )
+    if normalized["evaluation_mode"] not in SNAPSHOT_MODES:
+        raise ActivationSnapshotError(
+            f"evaluation_mode must be one of {sorted(SNAPSHOT_MODES)}"
+        )
+    normalized["decision_tree_version"] = _require_positive_int(
+        snapshot["decision_tree_version"], "decision_tree_version"
+    )
+    normalized["prompt_sha256"] = _require_sha256(
+        snapshot["prompt_sha256"], "prompt_sha256"
+    )
+    normalized["action_burden"] = _require_non_empty_string(
+        snapshot["action_burden"], "action_burden"
+    )
+    normalized["weight_bearing_object"] = _require_non_empty_string(
+        snapshot["weight_bearing_object"], "weight_bearing_object"
+    )
+    normalized["primary_route"] = _require_non_empty_string(
+        snapshot["primary_route"], "primary_route"
+    )
+    normalized["secondary_routes"] = _require_string_list(
+        snapshot["secondary_routes"], "secondary_routes"
+    )
+    normalized["derived_secondary_routes"] = _require_string_list(
+        snapshot["derived_secondary_routes"], "derived_secondary_routes"
+    )
+    normalized["manual_secondary_routes"] = _require_string_list(
+        snapshot["manual_secondary_routes"], "manual_secondary_routes"
+    )
+    normalized["parallelization_decision"] = _require_non_empty_string(
+        snapshot["parallelization_decision"], "parallelization_decision"
+    )
+    if normalized["parallelization_decision"] not in ALLOWED_PARALLELIZATION:
+        raise ActivationSnapshotError(
+            "parallelization_decision must be one of "
+            f"{sorted(ALLOWED_PARALLELIZATION)}"
+        )
+    normalized["snapshot_sha256"] = _require_sha256(
+        snapshot["snapshot_sha256"], "snapshot_sha256"
+    )
+
+    try:
+        route_registry = load_route_registry()
+        decision_tree = load_decision_tree_registry(route_registry=route_registry)
+        resolved_primary, resolved_derived = decision_tree.resolve(
+            normalized["action_burden"], normalized["weight_bearing_object"]
+        )
+    except (RegistryError, KeyError) as exc:
+        raise ActivationSnapshotError(f"canonical activation resolution failed: {exc}") from exc
+
+    if normalized["decision_tree_version"] != decision_tree.version:
+        raise ActivationSnapshotError(
+            f"decision_tree_version {normalized['decision_tree_version']} does not "
+            f"match canonical version {decision_tree.version}"
+        )
+    if normalized["primary_route"] not in route_registry.route_ids():
+        raise ActivationSnapshotError(
+            f"primary_route '{normalized['primary_route']}' is not canonical"
+        )
+    if normalized["primary_route"] != resolved_primary:
+        raise ActivationSnapshotError(
+            f"primary_route '{normalized['primary_route']}' does not match "
+            f"canonical decision-tree route '{resolved_primary}'"
+        )
+    secondary = set(normalized["secondary_routes"])
+    if not secondary.issubset(route_registry.route_ids()):
+        unknown = sorted(secondary - route_registry.route_ids())
+        raise ActivationSnapshotError(
+            f"secondary_routes contains unknown route(s): {unknown}"
+        )
+    derived = set(normalized["derived_secondary_routes"])
+    manual = set(normalized["manual_secondary_routes"])
+    if derived != set(resolved_derived):
+        raise ActivationSnapshotError(
+            "derived_secondary_routes does not match canonical decision-tree result"
+        )
+    if derived | manual != secondary or derived & manual:
+        raise ActivationSnapshotError(
+            "secondary_routes must equal the disjoint derived/manual route sets"
+        )
+    if normalized["primary_route"] in secondary:
+        raise ActivationSnapshotError("primary_route cannot also be a secondary route")
+    expected_digest = compute_snapshot_sha256(normalized)
+    if normalized["snapshot_sha256"] != expected_digest:
+        raise ActivationSnapshotError(
+            "snapshot_sha256 does not match the canonical snapshot payload"
+        )
+
+    if expected_reference is not None:
+        reference = validate_activation_reference(expected_reference, label="expected activation reference")
+        actual_reference = activation_reference(normalized)
+        if actual_reference != reference:
+            raise ActivationSnapshotError(
+                "activation snapshot reference does not match the supplied artifact: "
+                f"expected {reference}, got {actual_reference}"
+            )
+    return normalized
+
+
+def load_activation_snapshot(path: Path) -> dict[str, Any]:
+    """Read and validate a snapshot JSON file."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ActivationSnapshotError(f"activation snapshot not found: {path}") from exc
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ActivationSnapshotError(
+            f"activation snapshot cannot be read as JSON: {exc}"
+        ) from exc
+    return validate_snapshot(data)
+
+
+def build_activation_snapshot(
+    activation_id: str,
+    activation: ActivationResult,
+    *,
+    evaluation_mode: str,
+) -> dict[str, Any]:
+    """Serialize a canonical ActivationResult and attach its stable hash."""
+    payload: dict[str, Any] = {
+        "activation_id": activation_id,
+        "snapshot_version": SNAPSHOT_VERSION,
+        "evaluation_mode": evaluation_mode,
+        "decision_tree_version": activation.decision_tree_version,
+        "prompt_sha256": activation.prompt_sha256,
+        "action_burden": activation.action_category,
+        "weight_bearing_object": activation.weight_bearing_object,
+        "primary_route": activation.primary_route,
+        "secondary_routes": sorted(activation.secondary_routes),
+        "derived_secondary_routes": sorted(activation.derived_secondary_routes),
+        "manual_secondary_routes": sorted(activation.manual_secondary_routes),
+        "parallelization_decision": activation.parallelization_decision,
+    }
+    payload["snapshot_sha256"] = compute_snapshot_sha256(payload)
+    return validate_snapshot(payload)
+
+
+def extract_activation_snapshot_reference(
+    text: str,
+    *,
+    label: str = "Research Pack",
+) -> tuple[dict[str, Any] | None, list[str]]:
+    """Extract a visible ``## Activation snapshot`` reference from Markdown."""
+    match = re.search(
+        r"^## Activation snapshot\s*$\n(.*?)(?=^##\s|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    if not match:
+        return None, []
+
+    values: dict[str, Any] = {}
+    errors: list[str] = []
+    allowed = ACTIVATION_REF_FIELDS
+    for raw_line in match.group(1).splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        line = re.sub(r"^[-*]\s+", "", line)
+        field_match = re.fullmatch(
+            r"(activation_id|snapshot_sha256|snapshot_version|decision_tree_version)\s*:\s*(.+)",
+            line,
+        )
+        if not field_match:
+            errors.append(f"{label} activation snapshot has malformed line: {raw_line.strip()}")
+            continue
+        field, raw_value = field_match.groups()
+        if field not in allowed:
+            errors.append(f"{label} activation snapshot has unknown field '{field}'")
+            continue
+        if field in {"snapshot_version", "decision_tree_version"}:
+            if not re.fullmatch(r"[0-9]+", raw_value.strip()):
+                errors.append(f"{label} activation snapshot field '{field}' must be an integer")
+                continue
+            value: Any = int(raw_value.strip())
+        else:
+            value = raw_value.strip()
+        if field in values:
+            errors.append(f"{label} activation snapshot repeats field '{field}'")
+        values[field] = value
+
+    if errors:
+        return None, errors
+    try:
+        return validate_activation_reference(values, label=f"{label} activation_snapshot"), []
+    except ActivationSnapshotError as exc:
+        return None, [str(exc)]

--- a/scripts/audit_report.py
+++ b/scripts/audit_report.py
@@ -8,6 +8,7 @@ audit status) and a single exit code.
 
 Usage:
     python3 scripts/audit_report.py path/to/report.md [--route ROUTE] [--strict]
+        [--activation-snapshot path/to/activation.json]
 
 Route auto-detection (from ## Route and audit status block) is the default;
 pass --route to override or when no route block is present.
@@ -84,6 +85,11 @@ from validate_research_pack import (
     strip_fenced_code_blocks as vrp_strip_fenced_code_blocks,
 )
 from audit_evidence import validate_evidence_reference
+from activation_snapshot import (
+    ActivationSnapshotError,
+    extract_activation_snapshot_reference,
+    load_activation_snapshot,
+)
 
 # ── Runtime control-plane registry (issue #374) ─────────────────────────────
 # Route identity, aliases and validator dispatch bindings come from
@@ -564,6 +570,17 @@ def _run_contract_check(path: Path, **kwargs: bool) -> CheckResult:
         )
     visible_text = vc_strip_fences(text)
 
+    activation_snapshot_path = kwargs.get("activation_snapshot")
+    activation_data: dict | None = None
+    if activation_snapshot_path is not None:
+        try:
+            activation_data = load_activation_snapshot(Path(activation_snapshot_path))
+        except ActivationSnapshotError as exc:
+            return CheckResult(
+                name="activation-record-integration",
+                errors=[str(exc)],
+            )
+
     # Cardinality checks on user-writable declarations (issue #378): more
     # than one contract block / route status block is structural
     # malformation — a second declaration could carry a conflicting route
@@ -583,10 +600,30 @@ def _run_contract_check(path: Path, **kwargs: bool) -> CheckResult:
         )
 
     research_pack = kwargs.get("research_pack")
+    pack_activation_snapshot: dict | None = None
     if research_pack is not None:
         pack_section_errors = vc_validate_pack_sections(str(research_pack))
         if pack_section_errors:
             return CheckResult(name="contract-check", errors=pack_section_errors)
+        try:
+            pack_text = Path(research_pack).read_text(
+                encoding="utf-8", errors="replace"
+            )
+            pack_activation_snapshot, activation_errors = (
+                extract_activation_snapshot_reference(
+                    vc_strip_fences(pack_text), label="Research Pack"
+                )
+            )
+        except (OSError, UnicodeError) as exc:
+            return CheckResult(
+                name="activation-record-integration",
+                errors=[f"cannot read Research Pack activation snapshot: {exc}"],
+            )
+        if activation_errors:
+            return CheckResult(
+                name="activation-record-integration",
+                errors=activation_errors,
+            )
 
     report_route, route_malformed = vc_extract_report_route_declaration(text)
     if route_malformed:
@@ -606,7 +643,7 @@ def _run_contract_check(path: Path, **kwargs: bool) -> CheckResult:
                 ],
             )
         # No contract block at all.
-        if require_contract:
+        if require_contract or activation_data is not None:
             return CheckResult(
                 name="contract-check",
                 errors=[
@@ -620,6 +657,9 @@ def _run_contract_check(path: Path, **kwargs: bool) -> CheckResult:
     result = validate_contract(
         contract,
         report_primary_route=report_route,
+        pack_activation_snapshot=pack_activation_snapshot,
+        activation_snapshot=activation_data,
+        require_activation_snapshot=activation_data is not None,
         strict=strict,
         report_text=visible_text,
         evidence_base_dir=Path(__file__).resolve().parent.parent,
@@ -658,6 +698,9 @@ def _run_contract_check(path: Path, **kwargs: bool) -> CheckResult:
             contract,
             pack_primary_route=pack_primary,
             pack_artifact_id=pack_artifact,
+            pack_activation_snapshot=pack_activation_snapshot,
+            activation_snapshot=activation_data,
+            require_activation_snapshot=activation_data is not None,
             research_pack_provided=True,
             strict=strict,
             report_text=visible_text,
@@ -1580,6 +1623,7 @@ def _audit_report_impl(
     allow_route_fallback: bool = False,
     require_contract: bool = False,
     research_pack: Path | None = None,
+    activation_snapshot: Path | None = None,
     delivery_result: Path | None = None,
 ) -> AuditVerdict:
     """Run route-aware audit on a report and return the consolidated verdict.
@@ -1605,6 +1649,10 @@ def _audit_report_impl(
         Research Pack file to validate as the research-pack required audit.
         None records the audit as ``skipped`` (non-strict) or ``not_run``
         + blocking (strict, issue #378).
+    activation_snapshot : Path | None
+        Canonical structured activation snapshot. When supplied, strict
+        contract validation requires report/pack/contract route and reference
+        consistency with this snapshot.
 
     Returns
     -------
@@ -1694,6 +1742,7 @@ def _audit_report_impl(
             strict=strict,
             require_contract=effective_require_contract,
             research_pack=research_pack,
+            activation_snapshot=activation_snapshot,
         )
         results.append(result)
 
@@ -1738,6 +1787,7 @@ def audit_report(
     allow_route_fallback: bool = False,
     require_contract: bool = False,
     research_pack: Path | None = None,
+    activation_snapshot: Path | None = None,
     delivery_result: Path | None = None,
 ) -> AuditVerdict:
     """Public entry point: run the audit and attach provenance to the verdict.
@@ -1751,6 +1801,7 @@ def audit_report(
         allow_route_fallback=allow_route_fallback,
         require_contract=require_contract,
         research_pack=research_pack,
+        activation_snapshot=activation_snapshot,
         delivery_result=delivery_result,
     )
     return _finalize_verdict(verdict, path)
@@ -1809,6 +1860,15 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--activation-snapshot",
+        type=str,
+        default=None,
+        help=(
+            "Path to a canonical activation snapshot JSON. When supplied, "
+            "strict mode blocks activation/report/pack/contract mismatches."
+        ),
+    )
+    parser.add_argument(
         "--delivery-result",
         type=str,
         default=None,
@@ -1837,6 +1897,9 @@ def main(argv: list[str] | None = None) -> int:
         allow_route_fallback=args.allow_route_fallback,
         require_contract=args.require_contract,
         research_pack=Path(args.research_pack) if args.research_pack else None,
+        activation_snapshot=(
+            Path(args.activation_snapshot) if args.activation_snapshot else None
+        ),
         delivery_result=Path(args.delivery_result) if args.delivery_result else None,
     )
 

--- a/scripts/eval_registry.py
+++ b/scripts/eval_registry.py
@@ -42,6 +42,11 @@ FORWARD_FIXTURE_DIR = ROOT / "tests" / "fixtures" / "forward"
 CASE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]+$")
 ALLOWED_CASE_STATUSES = {"active", "archived"}
 ALLOWED_CASE_TYPES = {"positive", "negative"}
+ALLOWED_EVALUATION_MODES = {
+    "structured-decision-replay",
+    "activation-record-integration",
+    "agent-prompt",
+}
 ALLOWED_RESEARCH_STATUSES = {"complete", "partial", "blocked"}
 ALLOWED_AUDIT_STATUSES = {
     "pass",
@@ -69,11 +74,18 @@ FAILURE_FAMILY_TO_GAP_CLASS = {
     "fixture-reference-drift": "fixture-reference-drift",
     "orphan-fixture": "fixture-reference-drift",
 }
+FAILURE_FAMILY_TO_STAGE = {
+    "route-misclassification": "contract",
+    "secondary-route-not-verified": "audit",
+    "declared-not-executed": "evidence",
+    "audit-failure": "audit",
+}
 
 REQUIRED_CASE_FIELDS = {
     "id",
     "type",
     "status",
+    "evaluation_mode",
     "input",
     "expected",
     "fixtures",
@@ -100,7 +112,9 @@ REQUIRED_EXPECTED_FIELDS = {
     "verdict",
     "parallelization_decision",
 }
+OPTIONAL_EXPECTED_FIELDS = {"failure_stage"}
 REQUIRED_FIXTURE_FIELDS = {"report", "research_pack"}
+OPTIONAL_FIXTURE_FIELDS = {"activation_snapshot"}
 ALLOWED_STATUS_KEYS = {"research_status", "audit_status", "delivery_status"}
 PACK_FIELD_NAMES = {
     "Objective",
@@ -137,6 +151,13 @@ def gap_class_for_failure_family(failure_family: str | None) -> str | None:
         return None
     mapped = FAILURE_FAMILY_TO_GAP_CLASS.get(failure_family)
     return mapped if mapped in GAP_CLASSES else None
+
+
+def failure_stage_for_failure_family(failure_family: str | None) -> str | None:
+    """Map a concrete failure family to its observable control-plane stage."""
+    if not isinstance(failure_family, str):
+        return None
+    return FAILURE_FAMILY_TO_STAGE.get(failure_family)
 
 
 def _is_non_empty_string(value: Any) -> bool:
@@ -214,10 +235,20 @@ def _validate_case(
 
     case_type = case["type"]
     case_status = case["status"]
+    evaluation_mode = case["evaluation_mode"]
     if not isinstance(case_type, str) or case_type not in ALLOWED_CASE_TYPES:
         errors.append(f"{prefix}.type must be one of {sorted(ALLOWED_CASE_TYPES)}")
     if not isinstance(case_status, str) or case_status not in ALLOWED_CASE_STATUSES:
         errors.append(f"{prefix}.status must be one of {sorted(ALLOWED_CASE_STATUSES)}")
+    if not isinstance(evaluation_mode, str) or evaluation_mode not in ALLOWED_EVALUATION_MODES:
+        errors.append(
+            f"{prefix}.evaluation_mode must be one of "
+            f"{sorted(ALLOWED_EVALUATION_MODES)}"
+        )
+    elif evaluation_mode == "agent-prompt" and case_status == "active":
+        errors.append(
+            f"{prefix}.evaluation_mode=agent-prompt cannot be active in the offline runner"
+        )
     failure_family = case["failure_family"]
     if case_type == "negative" and not _is_non_empty_string(failure_family):
         errors.append(f"{prefix}.failure_family is required for negative cases")
@@ -335,7 +366,9 @@ def _validate_case(
         expected = {}
     else:
         missing_expected = REQUIRED_EXPECTED_FIELDS - set(expected)
-        unexpected_expected = set(expected) - REQUIRED_EXPECTED_FIELDS
+        unexpected_expected = set(expected) - (
+            REQUIRED_EXPECTED_FIELDS | OPTIONAL_EXPECTED_FIELDS
+        )
         if missing_expected:
             errors.append(
                 f"{prefix}.expected missing field(s): {', '.join(sorted(missing_expected))}"
@@ -464,6 +497,16 @@ def _validate_case(
     expected_parallelization = expected.get("parallelization_decision")
     if not isinstance(expected_parallelization, str) or expected_parallelization not in ALLOWED_PARALLELIZATION:
         errors.append(f"{prefix}.expected.parallelization_decision is invalid")
+    failure_stage = expected.get("failure_stage")
+    if case_type == "negative":
+        expected_stage = FAILURE_FAMILY_TO_STAGE.get(failure_family)
+        if failure_stage != expected_stage:
+            errors.append(
+                f"{prefix}.expected.failure_stage must be {expected_stage!r} "
+                f"for failure_family {failure_family!r}"
+            )
+    elif failure_stage is not None:
+        errors.append(f"{prefix}.expected.failure_stage is only valid for negative cases")
 
     fixtures = case["fixtures"]
     if not isinstance(fixtures, dict):
@@ -471,7 +514,9 @@ def _validate_case(
         fixtures = {}
     else:
         missing_fixtures = REQUIRED_FIXTURE_FIELDS - set(fixtures)
-        unexpected_fixtures = set(fixtures) - REQUIRED_FIXTURE_FIELDS
+        unexpected_fixtures = set(fixtures) - (
+            REQUIRED_FIXTURE_FIELDS | OPTIONAL_FIXTURE_FIELDS
+        )
         if missing_fixtures:
             errors.append(
                 f"{prefix}.fixtures missing field(s): {', '.join(sorted(missing_fixtures))}"
@@ -481,7 +526,21 @@ def _validate_case(
                 f"{prefix}.fixtures has unexpected field(s): "
                 f"{', '.join(sorted(unexpected_fixtures))}"
             )
-    for fixture_key in REQUIRED_FIXTURE_FIELDS:
+    fixture_keys = set(REQUIRED_FIXTURE_FIELDS)
+    if evaluation_mode == "activation-record-integration":
+        if "activation_snapshot" not in fixtures:
+            errors.append(
+                f"{prefix}.fixtures.activation_snapshot is required for "
+                "activation-record-integration"
+            )
+        else:
+            fixture_keys.add("activation_snapshot")
+    elif "activation_snapshot" in fixtures:
+        errors.append(
+            f"{prefix}.fixtures.activation_snapshot is only valid for "
+            "activation-record-integration"
+        )
+    for fixture_key in fixture_keys:
         fixture_value = fixtures.get(fixture_key)
         fixture_path = _repo_relative_path(fixture_value, root) if isinstance(fixture_value, str) else None
         if fixture_path is None:
@@ -491,6 +550,26 @@ def _validate_case(
         referenced.add(relative)
         if not fixture_path.is_file():
             errors.append(f"{prefix}.fixtures.{fixture_key} does not exist: {relative}")
+        elif fixture_key == "activation_snapshot":
+            try:
+                from activation_snapshot import load_activation_snapshot
+
+                snapshot = load_activation_snapshot(fixture_path)
+            except Exception as exc:
+                errors.append(
+                    f"{prefix}.fixtures.activation_snapshot is invalid: {exc}"
+                )
+            else:
+                if snapshot["activation_id"] != case_id:
+                    errors.append(
+                        f"{prefix}.fixtures.activation_snapshot activation_id "
+                        f"must be {case_id!r}"
+                    )
+                if snapshot["evaluation_mode"] != evaluation_mode:
+                    errors.append(
+                        f"{prefix}.fixtures.activation_snapshot evaluation_mode "
+                        f"must be {evaluation_mode!r}"
+                    )
 
     for field in ("related_rule", "related_validator"):
         if not _as_string_list(case[field]):

--- a/scripts/run_forward_evals.py
+++ b/scripts/run_forward_evals.py
@@ -3,10 +3,10 @@
 
 The runner deliberately consumes the existing command-line audit surface and
 its JSON output. It does not call a paid model, browse the network, or invent a
-production prompt classifier. Each case supplies canonical action/object
-activation inputs and a prompt hash; the adapter resolves the structured route
-decision and the report/Research Pack fixtures replay the remaining output
-chain offline.
+production prompt classifier. Structured replay cases supply canonical
+action/object activation inputs and a prompt hash. Integration cases also pass
+a versioned activation snapshot into the production audit command so route
+mismatch is a real blocking assertion rather than a runner-only oracle.
 """
 
 from __future__ import annotations
@@ -24,6 +24,7 @@ from eval_registry import (
     EvalRegistryError,
     active_cases,
     gap_class_for_failure_family,
+    failure_stage_for_failure_family,
     load_registry,
 )
 from validate_contract import extract_contract_from_markdown
@@ -33,6 +34,13 @@ from validate_research_pack import (
     strip_fenced_code_blocks,
 )
 from route_activation import RouteActivationError, activate_prompt
+from activation_snapshot import (
+    ActivationSnapshotError,
+    activation_reference,
+    build_activation_snapshot,
+    extract_activation_snapshot_reference,
+    load_activation_snapshot,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -62,15 +70,24 @@ def _pack_observation(path: Path) -> dict[str, Any]:
         cleaned,
         re.MULTILINE,
     )
+    activation_snapshot, activation_snapshot_errors = (
+        extract_activation_snapshot_reference(cleaned, label="Research Pack")
+    )
     return {
         "fields": sorted(headings),
         "missing_required_fields": find_missing_headings(cleaned),
         "statuses": statuses,
         "decision_tree_version": int(version_match.group(1)) if version_match else None,
+        "activation_snapshot": activation_snapshot,
+        "activation_snapshot_errors": activation_snapshot_errors,
     }
 
 
-def _run_audit(report: Path, research_pack: Path) -> tuple[dict[str, Any] | None, str | None, int]:
+def _run_audit(
+    report: Path,
+    research_pack: Path,
+    activation_snapshot: Path | None = None,
+) -> tuple[dict[str, Any] | None, str | None, int]:
     command = [
         sys.executable,
         str(AUDIT_SCRIPT),
@@ -81,6 +98,8 @@ def _run_audit(report: Path, research_pack: Path) -> tuple[dict[str, Any] | None
         "--require-contract",
         "--json",
     ]
+    if activation_snapshot is not None:
+        command.extend(["--activation-snapshot", str(activation_snapshot)])
     completed = subprocess.run(command, capture_output=True, text=True, cwd=ROOT)
     try:
         data = json.loads(completed.stdout)
@@ -158,6 +177,7 @@ def _negative_structure_matches(case: dict[str, Any], actual: dict[str, Any], ch
                 checks["report_secondary_routes_match"],
                 checks["parallelization_match"],
                 checks["prompt_identity_match"],
+                checks["activation_snapshot_match"],
                 checks["statuses_match"],
             ]
         )
@@ -221,12 +241,15 @@ def _evaluate_case(
     expected = case["expected"]
     input_data = case["input"]
     fixtures = case["fixtures"]
+    evaluation_mode = case.get("evaluation_mode", "structured-decision-replay")
     report = ROOT / fixtures["report"]
     research_pack = ROOT / fixtures["research_pack"]
     pack = _pack_observation(research_pack)
-    audit_data, runner_error, returncode = _run_audit(report, research_pack)
 
     activation_error: str | None = None
+    activation_snapshot_error: str | None = None
+    activation_snapshot_data: dict[str, Any] | None = None
+    activation_snapshot_path: Path | None = None
     try:
         activation = activate_prompt(
             input_data["user_prompt"],
@@ -240,6 +263,33 @@ def _evaluate_case(
     except RouteActivationError as exc:
         activation = None
         activation_error = str(exc)
+
+    if evaluation_mode == "activation-record-integration":
+        activation_snapshot_path = ROOT / fixtures["activation_snapshot"]
+        try:
+            activation_snapshot_data = load_activation_snapshot(
+                activation_snapshot_path
+            )
+            if activation is None:
+                raise ActivationSnapshotError(
+                    "structured activation did not produce a snapshot"
+                )
+            expected_snapshot = build_activation_snapshot(
+                case["id"], activation, evaluation_mode=evaluation_mode
+            )
+            if activation_snapshot_data != expected_snapshot:
+                raise ActivationSnapshotError(
+                    "fixture activation snapshot does not match the structured "
+                    "activation result"
+                )
+        except (ActivationSnapshotError, OSError, KeyError) as exc:
+            activation_snapshot_error = str(exc)
+
+    audit_data, runner_error, returncode = _run_audit(
+        report,
+        research_pack,
+        activation_snapshot=activation_snapshot_path,
+    )
 
     contract: dict[str, Any] = {}
     if report.is_file():
@@ -277,6 +327,15 @@ def _evaluate_case(
         ),
         "pack_decision_tree_version": pack["decision_tree_version"],
         "activation_error": activation_error,
+        "evaluation_mode": evaluation_mode,
+        "activation_snapshot_error": activation_snapshot_error,
+        "activation_snapshot": (
+            activation_reference(activation_snapshot_data)
+            if activation_snapshot_data is not None
+            else None
+        ),
+        "contract_activation_snapshot": contract.get("activation_snapshot"),
+        "pack_activation_snapshot": pack.get("activation_snapshot"),
         "closest_alternative": contract.get("closest_alternative"),
         "secondary_routes": sorted(contract.get("secondary_routes", []) or []),
         "disciplines": sorted(contract.get("disciplines", []) or []),
@@ -295,6 +354,9 @@ def _evaluate_case(
     }
     actual["failure_family"] = _detect_failure_family(case, actual)
     actual["gap_class"] = gap_class_for_failure_family(actual["failure_family"])
+    actual["failure_stage"] = failure_stage_for_failure_family(
+        actual["failure_family"]
+    )
 
     expected_pack_fields = set(expected["research_pack_fields"])
     expected_audits = set(expected["required_audits"])
@@ -317,6 +379,15 @@ def _evaluate_case(
         == expected["parallelization_decision"]
     )
     prompt_identity_match = actual["activation_prompt_sha256"] == input_data["prompt_sha256"]
+    activation_snapshot_match = (
+        evaluation_mode != "activation-record-integration"
+        or (
+            actual["activation_snapshot_error"] is None
+            and actual["activation_snapshot"] is not None
+            and actual["contract_activation_snapshot"] == actual["activation_snapshot"]
+            and actual["pack_activation_snapshot"] == actual["activation_snapshot"]
+        )
+    )
     expected_returncode = {
         "pass": 0,
         "conditional-pass": 1,
@@ -338,13 +409,16 @@ def _evaluate_case(
                 parallelization_match,
                 prompt_identity_match,
                 decision_tree_version_match,
+                activation_snapshot_match,
                 actual["overall"] == expected["statuses"]["audit_status"],
                 returncode == expected_returncode,
             ]
         )
     else:
         negative_returncode_ok = (
-            returncode in {0, 1}
+            returncode == 2
+            if evaluation_mode == "activation-record-integration"
+            else returncode in {0, 1}
             if case.get("failure_family") == "route-misclassification"
             else returncode == 2
         )
@@ -359,6 +433,7 @@ def _evaluate_case(
             "parallelization_match": parallelization_match,
             "prompt_identity_match": prompt_identity_match,
             "decision_tree_version_match": decision_tree_version_match,
+            "activation_snapshot_match": activation_snapshot_match,
             "statuses_match": status_match,
         }
         case_passed = all(
@@ -381,6 +456,8 @@ def _evaluate_case(
             "verdict": expected["verdict"],
             "failure_family": case["failure_family"],
             "gap_class": gap_class_for_failure_family(case["failure_family"]),
+            "evaluation_mode": evaluation_mode,
+            "failure_stage": expected.get("failure_stage"),
         },
         "actual": {
             "route": actual["route"],
@@ -403,6 +480,12 @@ def _evaluate_case(
             "overall": actual["overall"],
             "failure_family": actual["failure_family"],
             "gap_class": actual["gap_class"],
+            "failure_stage": actual["failure_stage"],
+            "evaluation_mode": actual["evaluation_mode"],
+            "activation_snapshot_error": actual["activation_snapshot_error"],
+            "activation_snapshot": actual["activation_snapshot"],
+            "contract_activation_snapshot": actual["contract_activation_snapshot"],
+            "pack_activation_snapshot": actual["pack_activation_snapshot"],
             "pack_missing_required_fields": actual["pack_missing_required_fields"],
             "returncode": returncode,
             "runner_error": runner_error,
@@ -422,6 +505,7 @@ def _evaluate_case(
             "parallelization_match": parallelization_match,
             "prompt_identity_match": prompt_identity_match,
             "decision_tree_version_match": decision_tree_version_match,
+            "activation_snapshot_match": activation_snapshot_match,
         },
     }
 
@@ -430,6 +514,27 @@ def _metrics(cases: list[dict[str, Any]], results: list[dict[str, Any]]) -> dict
     by_id = {result["case_id"]: result for result in results}
     positives = [case for case in cases if case["type"] == "positive"]
     negatives = [case for case in cases if case["type"] == "negative"]
+    structured_positive_cases = [
+        case
+        for case in positives
+        if case.get("evaluation_mode", "structured-decision-replay")
+        == "structured-decision-replay"
+    ]
+    integration_positive_cases = [
+        case
+        for case in positives
+        if case.get("evaluation_mode") == "activation-record-integration"
+    ]
+    integration_negative_cases = [
+        case
+        for case in negatives
+        if case.get("evaluation_mode") == "activation-record-integration"
+    ]
+    oracle_mismatch_cases = [
+        case
+        for case in negatives
+        if case.get("failure_family") == "route-misclassification"
+    ]
     boundary_cases = [
         case
         for case in positives
@@ -438,11 +543,13 @@ def _metrics(cases: list[dict[str, Any]], results: list[dict[str, Any]]) -> dict
     boundary_resolved = sum(
         by_id[case["id"]]["checks"]["alternative_match"] for case in boundary_cases
     )
-    route_correct = sum(
-        by_id[case["id"]]["checks"]["activation_route_match"] for case in positives
+    structured_route_correct = sum(
+        by_id[case["id"]]["checks"]["activation_route_match"]
+        for case in structured_positive_cases
     )
     report_route_consistent = sum(
-        by_id[case["id"]]["checks"]["activation_report_consistent"] for case in positives
+        by_id[case["id"]]["checks"]["activation_report_consistent"]
+        for case in integration_positive_cases
     )
     secondary_cases = [
         case for case in negatives if case.get("failure_family") == "secondary-route-not-verified"
@@ -469,11 +576,14 @@ def _metrics(cases: list[dict[str, Any]], results: list[dict[str, Any]]) -> dict
         )
         for result in results
     )
-    false_passed = sum(
-        by_id[case["id"]]["actual"]["overall"] == "pass" for case in negatives
+    integration_false_passed = sum(
+        by_id[case["id"]]["actual"]["overall"] == "pass"
+        for case in integration_negative_cases
     )
-    negative_case_failure = sum(
-        not by_id[case["id"]]["passed"] for case in negatives
+    oracle_mismatch_detected = sum(
+        by_id[case["id"]]["actual"]["failure_family"]
+        == "route-misclassification"
+        for case in oracle_mismatch_cases
     )
     status_cases = [
         case
@@ -489,8 +599,12 @@ def _metrics(cases: list[dict[str, Any]], results: list[dict[str, Any]]) -> dict
         "positive_case_count": len(positives),
         "negative_case_count": len(negatives),
         "case_pass_count": sum(result["passed"] for result in results),
-        "route_activation_accuracy": _ratio(route_correct, len(positives)),
-        "activation_report_consistency": _ratio(report_route_consistent, len(positives)),
+        "structured_route_resolution_rate": _ratio(
+            structured_route_correct, len(structured_positive_cases)
+        ),
+        "activation_report_consistency": _ratio(
+            report_route_consistent, len(integration_positive_cases)
+        ),
         "parallelization_decision_consistency": _ratio(
             sum(result["checks"]["parallelization_match"] for result in results),
             len(results),
@@ -500,9 +614,13 @@ def _metrics(cases: list[dict[str, Any]], results: list[dict[str, Any]]) -> dict
         "secondary_hard_fail_recall": _ratio(secondary_recalled, len(secondary_cases)),
         "declared_not_executed_recall": _ratio(declared_recalled, len(declared_cases)),
         "declared_not_executed_rate": _ratio(declared_not_executed_observed, len(results)),
-        "false_passed_rate": _ratio(false_passed, len(negatives)),
-        "negative_case_failure_rate": _ratio(negative_case_failure, len(negatives)),
-        "negative_detection_rate": _ratio(
+        "audit_false_pass_rate": _ratio(
+            integration_false_passed, len(integration_negative_cases)
+        ),
+        "oracle_mismatch_detection_rate": _ratio(
+            oracle_mismatch_detected, len(oracle_mismatch_cases)
+        ),
+        "negative_case_contract_pass_rate": _ratio(
             sum(by_id[case["id"]]["passed"] for case in negatives),
             len(negatives),
         ),
@@ -545,6 +663,19 @@ def run(registry_path: Path = DEFAULT_REGISTRY_PATH, *, check_baseline: bool = F
         "registry_version": registry["version"],
         "decision_tree_version": registry["decision_tree_version"],
         "offline": True,
+        "evaluation_mode": "offline",
+        "case_evaluation_modes": {
+            mode: sum(
+                case.get("evaluation_mode", "structured-decision-replay") == mode
+                for case in cases
+            )
+            for mode in sorted(
+                {
+                    case.get("evaluation_mode", "structured-decision-replay")
+                    for case in cases
+                }
+            )
+        },
         "metrics": metrics,
         "baseline_errors": baseline_errors,
         "passed": not failed_cases and not baseline_errors,

--- a/scripts/run_forward_evals.py
+++ b/scripts/run_forward_evals.py
@@ -163,6 +163,18 @@ def _blocking_ids_are_allowed(actual: dict[str, Any], allowed: set[str]) -> bool
     return True
 
 
+def _blocking_ids_are_exact(actual: dict[str, Any], allowed: set[str]) -> bool:
+    """Require every blocking message to carry one of the allowed sources."""
+    blocking = actual.get("blocking", [])
+    if not blocking:
+        return False
+    return all(
+        (match := re.match(r"\[([^\]]+)\]", str(message))) is not None
+        and match.group(1) in allowed
+        for message in blocking
+    )
+
+
 def _negative_structure_matches(case: dict[str, Any], actual: dict[str, Any], checks: dict[str, bool]) -> bool:
     """Require the intended defect shape, not merely any failing audit."""
     family = case.get("failure_family")
@@ -179,6 +191,7 @@ def _negative_structure_matches(case: dict[str, Any], actual: dict[str, Any], ch
                 checks["prompt_identity_match"],
                 checks["activation_snapshot_match"],
                 checks["statuses_match"],
+                _blocking_ids_are_exact(actual, {"contract-check"}),
             ]
         )
 
@@ -476,6 +489,7 @@ def _evaluate_case(
             "disciplines": actual["disciplines"],
             "audit_ids": actual["audit_ids"],
             "audits": actual["audits"],
+            "blocking": actual["blocking"],
             "statuses": actual["statuses"],
             "overall": actual["overall"],
             "failure_family": actual["failure_family"],

--- a/scripts/validate_contract.py
+++ b/scripts/validate_contract.py
@@ -18,7 +18,8 @@ and audits, plus reference integrity (issue #376):
   contract's primary route.
 
 Usage:
-    python3 scripts/validate_contract.py path/to/report.md [--strict] [--research-pack path/to/pack.md]
+    python3 scripts/validate_contract.py path/to/report.md [--strict]
+        [--research-pack path/to/pack.md] [--activation-snapshot path/to/activation.json]
 
 Exit codes:
     0 = contract is valid (or no contract found)
@@ -44,6 +45,14 @@ from registry_loader import (
     load_route_registry,
 )
 from audit_evidence import validate_evidence_reference
+from activation_snapshot import (
+    ActivationSnapshotError,
+    activation_reference,
+    extract_activation_snapshot_reference,
+    load_activation_snapshot,
+    validate_activation_reference,
+    validate_snapshot,
+)
 
 # ── Paths relative to project root ──────────────────────────────────────────
 
@@ -251,6 +260,9 @@ def validate_contract(
     pack_primary_route: str | None = None,
     report_primary_route: str | None = None,
     pack_artifact_id: str | None = None,
+    pack_activation_snapshot: dict | None = None,
+    activation_snapshot: dict | None = None,
+    require_activation_snapshot: bool = False,
     research_pack_provided: bool = False,
     strict: bool = False,
     report_text: str | None = None,
@@ -277,6 +289,7 @@ def validate_contract(
     14. report status block primary route matches contract primary route
         (when provided)
     15. pack artifact id matches contract artifact_id (when both provided)
+    16. activation snapshot references and route fields agree in integration mode
 
     Args:
         contract: parsed contract object.
@@ -294,6 +307,13 @@ def validate_contract(
         research_pack_provided: True when the CLI was given --research-pack.
             Single-side artifact id warnings are only emitted in that case
             (without --research-pack there is no pack to trace to).
+        pack_activation_snapshot: stable activation snapshot reference parsed
+            from the Research Pack, when present.
+        activation_snapshot: validated activation snapshot supplied by the
+            integration audit. When provided, its route and reference must
+            agree with the report contract and Research Pack.
+        require_activation_snapshot: require an actual activation snapshot
+            for this validation call.
         strict: when True, missing artifact identity fields are errors
             instead of warnings.
         report_text: visible report text used to resolve report-section/table
@@ -322,7 +342,8 @@ def validate_contract(
         "primary_route", "secondary_routes", "disciplines", "audits",
         "closest_alternative", "boundary_judgment",
         "artifact_id", "contract_version", "created_at",
-        "decision_tree_version", "secondary_route_contracts",
+        "decision_tree_version", "activation_snapshot",
+        "secondary_route_contracts",
     }
     for field in contract:
         if field not in known_fields:
@@ -417,6 +438,80 @@ def validate_contract(
                         f"decision_tree_version {decision_tree_version} does not match "
                         f"canonical version {canonical_tree.version}"
                     )
+
+    # 3c. Activation snapshot references are optional for legacy contracts,
+    # but become a required cross-artifact boundary for integration audits.
+    contract_activation_ref: dict | None = None
+    if "activation_snapshot" in contract:
+        try:
+            contract_activation_ref = validate_activation_reference(
+                contract["activation_snapshot"], label="contract activation_snapshot"
+            )
+        except ActivationSnapshotError as exc:
+            errors.append(str(exc))
+    if pack_activation_snapshot is not None:
+        try:
+            pack_activation_snapshot = validate_activation_reference(
+                pack_activation_snapshot, label="Research Pack activation_snapshot"
+            )
+        except ActivationSnapshotError as exc:
+            errors.append(str(exc))
+            pack_activation_snapshot = None
+    if require_activation_snapshot and activation_snapshot is None:
+        errors.append(
+            "activation snapshot is required for activation-record-integration"
+        )
+    actual_activation: dict | None = None
+    if activation_snapshot is not None:
+        try:
+            actual_activation = validate_snapshot(activation_snapshot)
+        except ActivationSnapshotError as exc:
+            errors.append(str(exc))
+        else:
+            actual_ref = activation_reference(actual_activation)
+            if contract_activation_ref is None:
+                errors.append(
+                    "integration audit requires contract.activation_snapshot"
+                )
+            elif contract_activation_ref != actual_ref:
+                errors.append(
+                    "contract activation_snapshot does not match the supplied "
+                    "activation snapshot"
+                )
+            if pack_activation_snapshot is None:
+                errors.append(
+                    "integration audit requires Research Pack activation_snapshot"
+                )
+            elif pack_activation_snapshot != actual_ref:
+                errors.append(
+                    "Research Pack activation_snapshot does not match the supplied "
+                    "activation snapshot"
+                )
+            if primary != actual_activation["primary_route"]:
+                errors.append(
+                    f"Activation/report route mismatch: activation snapshot declares "
+                    f"'{actual_activation['primary_route']}' but contract declares "
+                    f"'{primary}'"
+                )
+            if sorted(secondary) != actual_activation["secondary_routes"]:
+                errors.append(
+                    "Activation/contract secondary route mismatch: activation "
+                    "snapshot and contract must declare the same routes"
+                )
+            contract_tree_version = contract.get("decision_tree_version")
+            if (
+                contract_tree_version is not None
+                and contract_tree_version != actual_activation["decision_tree_version"]
+            ):
+                errors.append(
+                    "Activation/contract decision_tree_version mismatch"
+                )
+    elif contract_activation_ref is not None and pack_activation_snapshot is not None:
+        if contract_activation_ref != pack_activation_snapshot:
+            errors.append(
+                "Research Pack activation_snapshot does not match contract "
+                "activation_snapshot"
+            )
 
     if "secondary_route_contracts" in contract:
         secondary_contracts = contract["secondary_route_contracts"]
@@ -885,6 +980,15 @@ def main(argv: list[str] | None = None) -> int:
              "primary route matches the contract's primary route (exit code 2 "
              "on mismatch).",
     )
+    parser.add_argument(
+        "--activation-snapshot",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Path to a canonical activation snapshot JSON. When supplied, "
+             "the report contract and Research Pack must reference the same "
+             "snapshot and route.",
+    )
     args = parser.parse_args(argv)
 
     path = Path(args.path)
@@ -922,6 +1026,7 @@ def main(argv: list[str] | None = None) -> int:
 
     pack_primary_route: str | None = None
     pack_artifact_id: str | None = None
+    pack_activation_snapshot: dict | None = None
     if args.research_pack:
         pack_section_errors = validate_pack_sections(args.research_pack)
         if pack_section_errors:
@@ -932,6 +1037,35 @@ def main(argv: list[str] | None = None) -> int:
         if pack_primary_route is None:
             return 2
         pack_artifact_id = _extract_pack_artifact_id(args.research_pack)
+        try:
+            pack_text = Path(args.research_pack).read_text(
+                encoding="utf-8", errors="replace"
+            )
+            pack_activation_snapshot, activation_errors = (
+                extract_activation_snapshot_reference(
+                    _strip_fences(pack_text), label="Research Pack"
+                )
+            )
+        except (OSError, UnicodeError) as exc:
+            print(
+                f"Error: cannot read Research Pack activation snapshot: {exc}",
+                file=sys.stderr,
+            )
+            return 2
+        if activation_errors:
+            for err in activation_errors:
+                print(f"Error: {err}", file=sys.stderr)
+            return 2
+
+    activation_snapshot: dict | None = None
+    if args.activation_snapshot:
+        try:
+            activation_snapshot = load_activation_snapshot(
+                Path(args.activation_snapshot)
+            )
+        except ActivationSnapshotError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 2
 
     # Report status block route (issue #376 验收标准 5 — 三方一致性).
     report_primary_route, route_malformed = extract_report_route_declaration(text)
@@ -945,6 +1079,9 @@ def main(argv: list[str] | None = None) -> int:
         pack_primary_route=pack_primary_route,
         report_primary_route=report_primary_route,
         pack_artifact_id=pack_artifact_id,
+        pack_activation_snapshot=pack_activation_snapshot,
+        activation_snapshot=activation_snapshot,
+        require_activation_snapshot=args.activation_snapshot is not None,
         research_pack_provided=args.research_pack is not None,
         strict=args.strict,
         report_text=_strip_fences(text) if args.strict else None,

--- a/scripts/validate_contract.py
+++ b/scripts/validate_contract.py
@@ -1018,8 +1018,13 @@ def main(argv: list[str] | None = None) -> int:
                 f"or not a valid object. Fix the ```contract fenced block."
             )
             return 2
-        if args.require_contract:
-            print(f"Error: No contract block found in {path} (--require-contract set).")
+        if args.require_contract or args.activation_snapshot:
+            reason = (
+                "--require-contract set"
+                if args.require_contract
+                else "--activation-snapshot requires a contract"
+            )
+            print(f"Error: No contract block found in {path} ({reason}).")
             return 2
         print(f"No contract block found in {path}. Skipping validation.")
         return 0

--- a/scripts/validate_research_pack.py
+++ b/scripts/validate_research_pack.py
@@ -6,6 +6,7 @@ from collections.abc import Collection
 from pathlib import Path
 
 from audit_evidence import validate_evidence_reference, is_typed_reference
+from activation_snapshot import extract_activation_snapshot_reference
 from registry_loader import (
     RegistryError,
     load_audit_registry,
@@ -401,6 +402,10 @@ def run_strict_checks(
     errors: list[str] = []
     warnings: list[str] = []
     errors.extend(_check_decision_tree_version(cleaned))
+    _, activation_snapshot_errors = extract_activation_snapshot_reference(
+        cleaned, label="Research Pack"
+    )
+    errors.extend(activation_snapshot_errors)
 
     source_ids, sid_issues = _collect_register_ids(cleaned, "Source register")
     uncertainty_ids, uid_issues = _collect_register_ids(cleaned, "Uncertainty register")

--- a/tests/fixtures/forward/forward-market-outlook-baseline-activation.json
+++ b/tests/fixtures/forward/forward-market-outlook-baseline-activation.json
@@ -1,0 +1,15 @@
+{
+  "activation_id": "forward-market-outlook-baseline",
+  "snapshot_version": 1,
+  "evaluation_mode": "activation-record-integration",
+  "decision_tree_version": 1,
+  "prompt_sha256": "db59e14712fb8287f0873e7e144dc5050b55e5cee4db85b281000f19de356ce5",
+  "action_burden": "Judge direction / scenario",
+  "weight_bearing_object": "Market / category trajectory",
+  "primary_route": "market-outlook",
+  "secondary_routes": [],
+  "derived_secondary_routes": [],
+  "manual_secondary_routes": [],
+  "parallelization_decision": "parallel",
+  "snapshot_sha256": "aec9f2e6ccf91281590f5769abe1252d45a5a27c0680233ef77f861ec381949d"
+}

--- a/tests/fixtures/forward/forward-route-misclassification-activation.json
+++ b/tests/fixtures/forward/forward-route-misclassification-activation.json
@@ -1,0 +1,15 @@
+{
+  "activation_id": "forward-route-misclassification",
+  "snapshot_version": 1,
+  "evaluation_mode": "activation-record-integration",
+  "decision_tree_version": 1,
+  "prompt_sha256": "0dac0cd9e48109f7a88f36088cf58f7ade0f0cf212f125cc194f5fc6575abc02",
+  "action_burden": "Select / rank / predict",
+  "weight_bearing_object": "Market / category trajectory",
+  "primary_route": "constrained-choice",
+  "secondary_routes": [],
+  "derived_secondary_routes": [],
+  "manual_secondary_routes": [],
+  "parallelization_decision": "single-track",
+  "snapshot_sha256": "3bf7ccf7086d1eba693dc753bb633d6a009a13421f6424250bcf98a2c4b89a56"
+}

--- a/tests/fixtures/forward/forward-route-misclassification-pack.md
+++ b/tests/fixtures/forward/forward-route-misclassification-pack.md
@@ -1,12 +1,12 @@
 ## Objective
 
-Explain the market direction represented by the positive baseline report [S01].
+Explain the market direction represented by the route-mismatch integration report [S01].
 
 ## Decision context
 
-Market Outlook was chosen because the question asks about direction rather than
-selection. Shared-workflow was rejected because the scenario and monitoring
-structure are load-bearing.
+The report fixture deliberately declares Market Outlook while the canonical
+activation snapshot resolves the selection burden to Constrained Choice. The
+integration audit must block this disagreement.
 
 ## Primary route
 
@@ -37,8 +37,8 @@ current-state, forward-looking, source-traceability, scope-completeness, quantit
 
 ## Activation snapshot
 
-- activation_id: forward-market-outlook-baseline
-- snapshot_sha256: aec9f2e6ccf91281590f5769abe1252d45a5a27c0680233ef77f861ec381949d
+- activation_id: forward-route-misclassification
+- snapshot_sha256: 3bf7ccf7086d1eba693dc753bb633d6a009a13421f6424250bcf98a2c4b89a56
 - snapshot_version: 1
 - decision_tree_version: 1
 
@@ -70,7 +70,7 @@ Stop when the current snapshot, scenarios, and monitoring signals are complete.
 
 ## Artifact id
 
-fixture-market-outlook-pos
+fixture-forward-route-misclassification
 
 ## Artifact contract
 

--- a/tests/fixtures/forward/forward-route-misclassification-report.md
+++ b/tests/fixtures/forward/forward-route-misclassification-report.md
@@ -1,4 +1,4 @@
-# Market Outlook 2027 — Positive Fixture (issue #378)
+# Market Outlook 2027 — Route Mismatch Integration Fixture
 
 ## Route and audit status
 
@@ -51,5 +51,5 @@ Each dimension conclusion is backed by [S01] and [S02].
 | S03 | Example C | secondary | 2026-03-01 | https://example.com/c | high | §4 |
 
 ```contract
-{"primary_route": "market-outlook", "secondary_routes": [], "disciplines": [], "decision_tree_version": 1, "activation_snapshot": {"activation_id": "forward-market-outlook-baseline", "snapshot_sha256": "aec9f2e6ccf91281590f5769abe1252d45a5a27c0680233ef77f861ec381949d", "snapshot_version": 1, "decision_tree_version": 1}, "audits": [{"id": "market-outlook-audit", "status": "passed", "evidence": "report-section:Monitoring signals"}, {"id": "forward-looking-claims", "status": "passed", "evidence": "report-section:Monitoring signals"}, {"id": "source-traceability", "status": "passed", "evidence": "report-section:Findings"}, {"id": "final-audit", "status": "passed", "evidence": "report-section:Executive summary"}], "artifact_id": "fixture-market-outlook-pos", "contract_version": "1.0.0", "created_at": "2026-08-13"}
+{"primary_route": "market-outlook", "secondary_routes": [], "disciplines": [], "decision_tree_version": 1, "activation_snapshot": {"activation_id": "forward-route-misclassification", "snapshot_sha256": "3bf7ccf7086d1eba693dc753bb633d6a009a13421f6424250bcf98a2c4b89a56", "snapshot_version": 1, "decision_tree_version": 1}, "audits": [{"id": "market-outlook-audit", "status": "passed", "evidence": "report-section:Monitoring signals"}, {"id": "forward-looking-claims", "status": "passed", "evidence": "report-section:Monitoring signals"}, {"id": "source-traceability", "status": "passed", "evidence": "report-section:Findings"}, {"id": "final-audit", "status": "passed", "evidence": "report-section:Executive summary"}], "artifact_id": "fixture-forward-route-misclassification", "contract_version": "1.0.0", "created_at": "2026-08-18"}
 ```

--- a/tests/test_eval_registry.py
+++ b/tests/test_eval_registry.py
@@ -175,13 +175,37 @@ def test_offline_forward_runner_passes_and_reports_metrics() -> None:
     assert report["passed"] is True
     assert report["failed_cases"] == []
     assert report["offline"] is True
+    assert report["evaluation_mode"] == "offline"
+    assert report["case_evaluation_modes"] == {
+        "activation-record-integration": 2,
+        "structured-decision-replay": 9,
+    }
     assert report["decision_tree_version"] == 1
     metrics = report["metrics"]
     assert metrics["case_count"] >= 8
-    assert metrics["negative_detection_rate"] == 1.0
-    assert metrics["false_passed_rate"] == 0.3333
-    assert metrics["negative_case_failure_rate"] == 0.0
+    assert metrics["structured_route_resolution_rate"] == 1.0
+    assert metrics["activation_report_consistency"] == 1.0
+    assert metrics["audit_false_pass_rate"] == 0.0
+    assert metrics["oracle_mismatch_detection_rate"] == 1.0
+    assert metrics["negative_case_contract_pass_rate"] == 1.0
     assert metrics["blocked_partial_and_pdf_failed_status_correctness"] == 1.0
+
+
+def test_route_misclassification_is_blocked_by_production_integration_gate() -> None:
+    case = next(
+        item
+        for item in load_registry()["cases"]
+        if item["id"] == "forward-route-misclassification"
+    )
+    result = _evaluate_case(case, 1)
+    assert result["passed"] is True
+    assert result["actual"]["evaluation_mode"] == "activation-record-integration"
+    assert result["actual"]["activation_route"] == "constrained-choice"
+    assert result["actual"]["report_route"] == "market-outlook"
+    assert result["actual"]["overall"] == "fail"
+    assert result["actual"]["returncode"] == 2
+    assert result["actual"]["failure_stage"] == "contract"
+    assert result["checks"]["activation_snapshot_match"] is True
 
 
 def test_cli_output_is_machine_readable() -> None:

--- a/tests/test_eval_registry.py
+++ b/tests/test_eval_registry.py
@@ -208,6 +208,31 @@ def test_route_misclassification_is_blocked_by_production_integration_gate() -> 
     assert result["checks"]["activation_snapshot_match"] is True
 
 
+def test_route_misclassification_does_not_mask_unrelated_report_failure(
+    tmp_path: Path,
+) -> None:
+    case = copy.deepcopy(next(
+        item
+        for item in load_registry()["cases"]
+        if item["id"] == "forward-route-misclassification"
+    ))
+    original = ROOT / case["fixtures"]["report"]
+    tampered = tmp_path / "mixed-route-mismatch.md"
+    tampered.write_text(
+        original.read_text(encoding="utf-8").replace(
+            "Body text with citations [S01], [S02] and [S03].",
+            "Body text with citations [S01], [S99] and [S03].",
+        ),
+        encoding="utf-8",
+    )
+    case["fixtures"]["report"] = str(tampered)
+
+    result = _evaluate_case(case, 1)
+    assert result["passed"] is False
+    assert result["actual"]["failure_family"] == "route-misclassification"
+    assert any(item.startswith("[report-quality]") for item in result["actual"]["blocking"])
+
+
 def test_cli_output_is_machine_readable() -> None:
     completed = subprocess.run(
         [

--- a/tests/test_issue_392_activation_integration.py
+++ b/tests/test_issue_392_activation_integration.py
@@ -1,0 +1,80 @@
+"""Production audit integration coverage for Issue 392."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT = ROOT / "scripts" / "audit_report.py"
+POSITIVE_REPORT = ROOT / "tests" / "fixtures" / "audit" / "market-outlook-pos.md"
+POSITIVE_PACK = ROOT / "tests" / "fixtures" / "forward" / "market-outlook-baseline-pack.md"
+POSITIVE_SNAPSHOT = ROOT / "tests" / "fixtures" / "forward" / "forward-market-outlook-baseline-activation.json"
+MISMATCH_REPORT = ROOT / "tests" / "fixtures" / "forward" / "forward-route-misclassification-report.md"
+MISMATCH_PACK = ROOT / "tests" / "fixtures" / "forward" / "forward-route-misclassification-pack.md"
+MISMATCH_SNAPSHOT = ROOT / "tests" / "fixtures" / "forward" / "forward-route-misclassification-activation.json"
+
+
+def _run(
+    report: Path,
+    pack: Path,
+    snapshot: Path,
+) -> tuple[subprocess.CompletedProcess[str], dict]:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(AUDIT),
+            str(report),
+            "--research-pack",
+            str(pack),
+            "--activation-snapshot",
+            str(snapshot),
+            "--strict",
+            "--require-contract",
+            "--json",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result, json.loads(result.stdout)
+
+
+def test_matching_activation_report_pack_contract_passes() -> None:
+    result, payload = _run(POSITIVE_REPORT, POSITIVE_PACK, POSITIVE_SNAPSHOT)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert payload["overall"] == "pass"
+    assert payload["blocking"] == []
+
+
+def test_route_mismatch_is_a_blocking_production_audit_failure() -> None:
+    result, payload = _run(MISMATCH_REPORT, MISMATCH_PACK, MISMATCH_SNAPSHOT)
+    assert result.returncode == 2
+    assert payload["overall"] == "fail"
+    assert any("mismatch" in item.lower() for item in payload["blocking"])
+
+
+def test_tampered_snapshot_hash_fails_closed(tmp_path: Path) -> None:
+    tampered = tmp_path / "tampered-activation.json"
+    data = json.loads(POSITIVE_SNAPSHOT.read_text(encoding="utf-8"))
+    data["snapshot_sha256"] = "0" * 64
+    tampered.write_text(json.dumps(data), encoding="utf-8")
+
+    result, payload = _run(POSITIVE_REPORT, POSITIVE_PACK, tampered)
+    assert result.returncode == 2
+    assert payload["overall"] == "fail"
+    assert any("snapshot_sha256" in item for item in payload["blocking"])
+
+
+def test_tampered_pack_snapshot_reference_fails_closed(tmp_path: Path) -> None:
+    tampered = tmp_path / "tampered-pack.md"
+    text = POSITIVE_PACK.read_text(encoding="utf-8")
+    tampered.write_text(text.replace("aec9f2e6", "00000000", 1), encoding="utf-8")
+
+    result, payload = _run(POSITIVE_REPORT, tampered, POSITIVE_SNAPSHOT)
+    assert result.returncode == 2
+    assert payload["overall"] == "fail"
+    assert any("activation_snapshot" in item for item in payload["blocking"])

--- a/tests/test_issue_392_activation_integration.py
+++ b/tests/test_issue_392_activation_integration.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 AUDIT = ROOT / "scripts" / "audit_report.py"
+VALIDATE_CONTRACT = ROOT / "scripts" / "validate_contract.py"
 POSITIVE_REPORT = ROOT / "tests" / "fixtures" / "audit" / "market-outlook-pos.md"
 POSITIVE_PACK = ROOT / "tests" / "fixtures" / "forward" / "market-outlook-baseline-pack.md"
 POSITIVE_SNAPSHOT = ROOT / "tests" / "fixtures" / "forward" / "forward-market-outlook-baseline-activation.json"
@@ -78,3 +79,42 @@ def test_tampered_pack_snapshot_reference_fails_closed(tmp_path: Path) -> None:
     assert result.returncode == 2
     assert payload["overall"] == "fail"
     assert any("activation_snapshot" in item for item in payload["blocking"])
+
+
+def test_activation_snapshot_implies_contract_requirement(tmp_path: Path) -> None:
+    report = tmp_path / "without-contract.md"
+    report.write_text("# Report without a contract\n", encoding="utf-8")
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(VALIDATE_CONTRACT),
+            str(report),
+            "--activation-snapshot",
+            str(POSITIVE_SNAPSHOT),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert "requires a contract" in result.stdout
+
+
+def test_duplicate_visible_pack_activation_snapshot_fails_closed(
+    tmp_path: Path,
+) -> None:
+    duplicate = tmp_path / "duplicate-pack.md"
+    duplicate.write_text(
+        POSITIVE_PACK.read_text(encoding="utf-8")
+        + "\n## Activation snapshot\n\n"
+        + "- activation_id: conflicting-activation\n"
+        + "- snapshot_sha256: "
+        + "0" * 64
+        + "\n- snapshot_version: 1\n- decision_tree_version: 1\n",
+        encoding="utf-8",
+    )
+    result, payload = _run(POSITIVE_REPORT, duplicate, POSITIVE_SNAPSHOT)
+    assert result.returncode == 2
+    assert payload["overall"] == "fail"
+    assert any("multiple" in item.lower() for item in payload["blocking"])


### PR DESCRIPTION
## Summary

- 新增 versioned activation snapshot，并校验 canonical decision-tree route、secondary routes、prompt SHA、snapshot SHA 和 version。
- 让 `audit_report.py --activation-snapshot` 在 strict 模式校验 activation/report/Research Pack/contract 一致性，route mismatch 返回 blocking exit code 2。
- 将 forward eval 明确区分 `structured-decision-replay` 与 `activation-record-integration`，重命名并拆分 metrics。
- 为 route-misclassification、secondary-route-not-verified、declared-not-executed 输出 contract/audit/evidence failure stage。
- 保留 11 个 active cases；新增一个匹配 integration positive 和一个真实 route mismatch integration negative。

## Why

此前 route-misclassification negative 的 structured activation 是 `constrained-choice`，但 report fixture 是 `market-outlook`；runner 自己能识别 mismatch，而 production audit 仍返回 Pass。该 PR 把至少一个 mismatch 接入真实 audit surface，并把 `audit_false_pass_rate` 的 strict baseline 收敛到 `0.0`。

## Validation

- `python3 scripts/validate_eval_registry.py --json`
- `python3 scripts/run_forward_evals.py --offline --check-baseline --json`
- Issue 392 regression tests: 6 passed
- targeted pytest: 32 passed
- full pytest: 1537 passed
- `git diff --check`: passed
- `python3 scripts/validate_route_manifest.py`
- `python3 scripts/generate_route_cards.py --check`
- `python3 scripts/test_audit_report.py`
- `python3 scripts/test_route_decision_tree.py`
- strict contract integration positive: exit 0
- strict route mismatch integration negative: exit 2
- CI run `32206032083`: completed/success, all 4 jobs passed

No paid model, external search, new route taxonomy, or route business-rule change is included.

Closes #392
