### PR TITLE
[P1] 禁止 checklist 模板 marker 冒充人工审计执行证据 (#401)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ __pycache__/
 # Generated pipeline artifacts (PDF, HTML intermediates) — eval output only
 evals/cases/*.pdf
 evals/cases/*.html
+
+# ephemeral test artifacts for issue #401 audit-record binding
+tmp/
+.tmp/

--- a/references/report-template.md
+++ b/references/report-template.md
@@ -246,8 +246,8 @@ This symmetry matters because asymmetric structure signals to the reader that on
 - 该区块不追求详尽审计记录，只追求评审者可见——证明审计已运行
 - **一致性要求**：区块中每个声称已通过的审计（✅ Passed 或等效表达/emoji）必须在正文或交付物结构中有对应的执行证据（如 source-traceability ✅ 需要正文存在 `[SN]` 引用，workflow-spine-audit ✅ 需要交付物有清晰的工作流结构）；无对应执行证据的 ✅ Passed 视为自评不准确，由 final-audit 门控标记为未通过
 - **证据列要求**：每项审计的「证据」列必须填写具体的正文引用，不得为空或仅写"是"、"通过"等无明确引用内容：
-  - ✅ **已通过 (Passed)** — 使用 typed reference：`report-section:<heading>`、`report-table:<heading>`、`checklist-item:<path>#<id>` 或 `audit-record:<path>#<id>@<ISO-8601>`
-    Checklist item IDs are declared by stable markers such as `<!-- audit-item: FA-001 -->` in the referenced checklist.
+  - ✅ **已通过 (Passed)** — 使用 typed reference：`report-section:<heading>`、`report-table:<heading>` 或 `audit-record:<path>#<id>@<ISO-8601>`（Pack 上下文可用 `pack-section` / `pack-table`）
+  - `checklist-item:<path>#<id>` only identifies a checklist definition. In strict mode it cannot independently prove execution and must be referenced from an artifact-bound `audit-record` (see `audit-record` evidence above). Checklist item IDs are declared by stable markers such as `<!-- audit-item: FA-001 -->` in the referenced checklist.
   - ⚠️ **已跳过 (Skipped)** — 引用正文中说明跳过理由的章节位置，或说明"§X 已在正文覆盖，未独立运行"
   - ❌ **未运行 (Not run)** — 引用正文中说明未运行原因的章节位置
   「证据」列与 Status 列的自评状态共同构成可审计记录——评审者无需全文扫描即可定位每项审计的执行证据或决定理由。裸 `§3`、`§999` 和任意自由文本不属于可验证 evidence。

--- a/scripts/audit_evidence.py
+++ b/scripts/audit_evidence.py
@@ -303,7 +303,10 @@ def _validate_audit_record(
     expected_audit_id: str | None = None,
     expected_artifact_sha256: str | None = None,
     expected_artifact_id: str | None = None,
+    expected_route: str | None = None,
     execution_type: str | None = None,
+    artifact_text: str | None = None,
+    artifact_label: str = "report",
 ) -> EvidenceValidation:
     match = re.fullmatch(r"([^#]+)#([^@]+)@(.+)", locator)
     if not match:
@@ -378,7 +381,8 @@ def _validate_audit_record(
         return parsed.astimezone(timezone.utc)
 
     expected_time = _parse_timestamp(timestamp)
-    matching_record = None
+    # Collect all matching records to detect duplicates (P3: first-match-wins is fail-open)
+    matching_records: list[dict] = []
     for record in records:
         if not isinstance(record, dict):
             continue
@@ -389,18 +393,30 @@ def _validate_audit_record(
         )
         if candidate_id != record_id or _parse_timestamp(candidate_time) != expected_time:
             continue
-        matching_record = record
-        break
-    if matching_record is None:
+        matching_records.append(record)
+    if not matching_records:
         return EvidenceValidation(
             errors=(
                 f"audit record {record_id!r} with timestamp {timestamp!r} "
                 f"was not found in {path_value}",
             )
         )
+    if len(matching_records) > 1:
+        return EvidenceValidation(
+            provenance={
+                **provenance,
+                "verified": False,
+                "duplicate_matches": len(matching_records),
+            },
+            errors=(
+                f"audit record {record_id!r} with timestamp {timestamp!r} "
+                f"is ambiguous ({len(matching_records)} matches) — duplicate/ambiguous record (see issue #401)",
+            ),
+        )
+    matching_record = matching_records[0]
 
     # Strict artifact / audit binding (issue #401): an audit-record must be
-    # provably bound to the current artifact, audit, and execution state.
+    # provably bound to the current artifact, audit, execution state, and evidence.
     if strict:
         strict_errors: list[str] = []
         # audit_id must match the audit being validated when expected is known
@@ -429,7 +445,7 @@ def _validate_audit_record(
                 f"audit record status {record_status!r} is not passed (strict requires passed)"
             )
         # artifact binding: each provided expected field is fail-closed independently (issue #401 P1).
-        # When audit_report passes both sha256 and artifact_id, both must match if the record declares them;
+        # When audit_report passes both sha256 and artifact_id, both must match;
         # a hash mismatch cannot be rescued by an id match.  When only one expected is given
         # (contract / pack), that single field must match.
         record_sha = matching_record.get("artifact_sha256") or matching_record.get("artifact_hash") or matching_record.get("sha256")
@@ -450,6 +466,13 @@ def _validate_audit_record(
             ):
                 strict_errors.append(
                     "audit record is missing artifact binding (strict requires artifact_sha256 or artifact_id)"
+                )
+        # route binding (issue #401 #4): record should declare the route it was executed for
+        if expected_route is not None:
+            record_route = matching_record.get("route") or matching_record.get("primary_route")
+            if not isinstance(record_route, str) or record_route.strip() != expected_route:
+                strict_errors.append(
+                    f"audit record route {record_route!r} does not match expected route {expected_route!r}"
                 )
         # executed_at must be present and not in the future
         executed_at_value = matching_record.get("executed_at") or matching_record.get("recorded_at") or matching_record.get("timestamp")
@@ -476,12 +499,15 @@ def _validate_audit_record(
                         strict_errors.append(
                             f"audit record executed_at {executed_at_value!r} is in the future"
                         )
-        # execution_source must align with registry execution_type (issue #401 P2).
-        # manual ↔ manual_checklist_attestation, process ↔ process_node_evidence; any cross (e.g. manual eating process record)
-        # or legacy/automated masquerading is fail-closed.  Use precise set check.
+        # execution_source must be explicitly declared and align with registry (issue #401 P2).
+        # Missing source is now fail-closed; caller must not auto-fill.
         if execution_type in {"manual", "process"}:
             src = matching_record.get("execution_source") or matching_record.get("source")
-            if isinstance(src, str) and src.strip():
+            if not isinstance(src, str) or not src.strip():
+                strict_errors.append(
+                    "audit record is missing execution_source (strict requires manual_checklist_attestation or process_node_evidence)"
+                )
+            else:
                 allowed = {
                     "manual": {"manual_checklist_attestation"},
                     "process": {"process_node_evidence"},
@@ -490,6 +516,63 @@ def _validate_audit_record(
                     strict_errors.append(
                         f"audit record execution_source {src!r} does not match {execution_type} audit (expected {sorted(allowed)})"
                     )
+        # evidence binding (issue #401 P1): record must reference the actual checklist/section that was checked
+        # This prevents JSON self-attestation: hash alone is not proof that a specific audit step was executed.
+        evidence_value = (
+            matching_record.get("evidence")
+            or matching_record.get("evidence_locator")
+            or matching_record.get("checklist_item")
+            or matching_record.get("report_section")
+            or matching_record.get("report_table")
+            or matching_record.get("pack_section")
+            or matching_record.get("pack_table")
+        )
+        if not isinstance(evidence_value, str) or not evidence_value.strip():
+            strict_errors.append(
+                "audit record is missing evidence (strict requires checklist-item or report-section/table reference that was verified, see issue #401)"
+            )
+        else:
+            evidence_str = evidence_value.strip()
+            m = _REFERENCE_RE.match(evidence_str)
+            if not m or m.group(1).lower() not in _PREFIX_TO_KIND:
+                strict_errors.append(
+                    f"audit record evidence {evidence_value!r} must be a typed reference (checklist-item, report-section, etc.)"
+                )
+            else:
+                kind = _PREFIX_TO_KIND[m.group(1).lower()]
+                locator = m.group(2).strip()
+                if kind not in {"checklist_item", "report_section", "report_table", "pack_section", "pack_table"}:
+                    strict_errors.append(
+                        f"audit record evidence kind {kind!r} is not allowed — use checklist-item or report/pack section/table"
+                    )
+                else:
+                    nested_result: EvidenceValidation | None = None
+                    if kind == "checklist_item":
+                        # Checklist definition existence only; strict definition-only check is bypassed for nested evidence
+                        # (the record is the execution attestation, the checklist item is the definition it attests to)
+                        nested_result = _validate_checklist_item(locator, base_dir, strict=False)
+                        # Also ensure the marker actually exists
+                        if nested_result.errors:
+                            strict_errors.append(
+                                f"audit record evidence {evidence_value!r} is not verifiable: {'; '.join(nested_result.errors)}"
+                            )
+                    elif kind in {"report_section", "pack_section"}:
+                        label = "pack" if kind == "pack_section" else artifact_label
+                        nested_result = _validate_artifact_heading(kind, locator, artifact_text, label)
+                        if nested_result.errors:
+                            strict_errors.append(
+                                f"audit record evidence {evidence_value!r} is not verifiable: {'; '.join(nested_result.errors)}"
+                            )
+                    elif kind in {"report_table", "pack_table"}:
+                        label = "pack" if kind == "pack_table" else artifact_label
+                        nested_result = _validate_artifact_table(kind, locator, artifact_text, label)
+                        if nested_result.errors:
+                            strict_errors.append(
+                                f"audit record evidence {evidence_value!r} is not verifiable: {'; '.join(nested_result.errors)}"
+                            )
+                    if nested_result is not None and not nested_result.errors and nested_result.provenance:
+                        provenance["record_evidence"] = evidence_value
+                        provenance["record_evidence_provenance"] = nested_result.provenance
 
         if strict_errors:
             provenance["verified"] = False
@@ -502,6 +585,16 @@ def _validate_audit_record(
                 provenance["record_artifact_sha256"] = record_sha
             if record_aid is not None:
                 provenance["record_artifact_id"] = record_aid
+            # expose route / execution_source / evidence for debugging
+            _r = matching_record.get("route") or matching_record.get("primary_route")
+            if _r is not None:
+                provenance["record_route"] = _r
+            _src = matching_record.get("execution_source") or matching_record.get("source")
+            if _src is not None:
+                provenance["record_execution_source"] = _src
+            _ev = matching_record.get("evidence") or matching_record.get("evidence_locator")
+            if _ev is not None:
+                provenance["record_evidence"] = _ev
             return EvidenceValidation(
                 provenance=provenance,
                 errors=tuple(strict_errors),
@@ -517,10 +610,45 @@ def _validate_audit_record(
         provenance["record_artifact_sha256"] = matching_record.get("artifact_sha256")
     if matching_record.get("artifact_id") is not None:
         provenance["record_artifact_id"] = matching_record.get("artifact_id")
+    if matching_record.get("route") is not None:
+        provenance["record_route"] = matching_record.get("route")
+    elif matching_record.get("primary_route") is not None:
+        provenance["record_route"] = matching_record.get("primary_route")
+    if matching_record.get("execution_source") is not None:
+        provenance["record_execution_source"] = matching_record.get("execution_source")
+    elif matching_record.get("source") is not None:
+        provenance["record_execution_source"] = matching_record.get("source")
+    if matching_record.get("evidence") is not None:
+        provenance["record_evidence"] = matching_record.get("evidence")
+    elif matching_record.get("evidence_locator") is not None:
+        provenance["record_evidence"] = matching_record.get("evidence_locator")
     if matching_record.get("executed_at") is not None:
         provenance["record_executed_at"] = matching_record.get("executed_at")
     elif matching_record.get("recorded_at") is not None:
         provenance["record_executed_at"] = matching_record.get("recorded_at")
+    # Preserve nested evidence provenance if it was computed in strict mode
+    if "record_evidence_provenance" not in provenance and matching_record.get("evidence") is not None:
+        # For non-strict, still try to expose nested evidence verification (best-effort)
+        try:
+            ev = matching_record.get("evidence")
+            if isinstance(ev, str) and ev.strip():
+                m2 = _REFERENCE_RE.match(ev.strip())
+                if m2 and _PREFIX_TO_KIND.get(m2.group(1).lower()) in {"checklist_item", "report_section", "report_table", "pack_section", "pack_table"}:
+                    k2 = _PREFIX_TO_KIND[m2.group(1).lower()]
+                    loc2 = m2.group(2).strip()
+                    nr = None
+                    if k2 == "checklist_item":
+                        nr = _validate_checklist_item(loc2, base_dir, strict=False)
+                    elif k2 in {"report_section", "pack_section"}:
+                        lbl = "pack" if k2 == "pack_section" else artifact_label
+                        nr = _validate_artifact_heading(k2, loc2, artifact_text, lbl)
+                    elif k2 in {"report_table", "pack_table"}:
+                        lbl = "pack" if k2 == "pack_table" else artifact_label
+                        nr = _validate_artifact_table(k2, loc2, artifact_text, lbl)
+                    if nr and nr.provenance:
+                        provenance["record_evidence_provenance"] = nr.provenance
+        except Exception:
+            pass
     return EvidenceValidation(provenance=provenance)
 
 
@@ -545,6 +673,7 @@ def validate_evidence_reference(
     expected_audit_id: str | None = None,
     expected_artifact_sha256: str | None = None,
     expected_artifact_id: str | None = None,
+    expected_route: str | None = None,
 ) -> EvidenceValidation:
     """Validate one typed evidence reference.
 
@@ -625,7 +754,10 @@ def validate_evidence_reference(
             expected_audit_id=expected_audit_id,
             expected_artifact_sha256=expected_artifact_sha256,
             expected_artifact_id=expected_artifact_id,
+            expected_route=expected_route,
             execution_type=execution_type,
+            artifact_text=artifact_text,
+            artifact_label=artifact_label,
         )
     if kind == "automated_validator":
         if execution_type in {"manual", "process"}:

--- a/scripts/audit_evidence.py
+++ b/scripts/audit_evidence.py
@@ -307,6 +307,8 @@ def _validate_audit_record(
     execution_type: str | None = None,
     artifact_text: str | None = None,
     artifact_label: str = "report",
+    report_text: str | None = None,
+    pack_text: str | None = None,
 ) -> EvidenceValidation:
     match = re.fullmatch(r"([^#]+)#([^@]+)@(.+)", locator)
     if not match:
@@ -518,6 +520,10 @@ def _validate_audit_record(
                     )
         # evidence binding (issue #401 P1): record must reference the actual checklist/section that was checked
         # This prevents JSON self-attestation: hash alone is not proof that a specific audit step was executed.
+        # P1/P2 review (b1916b3): nested report-/pack- evidence must be validated against the correct artifact text.
+        # Using a single artifact_text for both causes type confusion (e.g. report-section:Artifact contract
+        # verified against pack text).  Dispatch strictly: report-* against report_text, pack-* against pack_text,
+        # checklist against base_dir (both contexts allowed).
         evidence_value = (
             matching_record.get("evidence")
             or matching_record.get("evidence_locator")
@@ -548,28 +554,59 @@ def _validate_audit_record(
                 else:
                     nested_result: EvidenceValidation | None = None
                     if kind == "checklist_item":
-                        # Checklist definition existence only; strict definition-only check is bypassed for nested evidence
-                        # (the record is the execution attestation, the checklist item is the definition it attests to)
                         nested_result = _validate_checklist_item(locator, base_dir, strict=False)
-                        # Also ensure the marker actually exists
                         if nested_result.errors:
                             strict_errors.append(
                                 f"audit record evidence {evidence_value!r} is not verifiable: {'; '.join(nested_result.errors)}"
                             )
-                    elif kind in {"report_section", "pack_section"}:
-                        label = "pack" if kind == "pack_section" else artifact_label
-                        nested_result = _validate_artifact_heading(kind, locator, artifact_text, label)
-                        if nested_result.errors:
+                    elif kind in {"report_section", "report_table"}:
+                        # Report evidence must be validated against report artifact, not pack
+                        effective_report_text = report_text
+                        if effective_report_text is None and artifact_label == "report":
+                            effective_report_text = artifact_text
+                        if effective_report_text is None:
                             strict_errors.append(
-                                f"audit record evidence {evidence_value!r} is not verifiable: {'; '.join(nested_result.errors)}"
+                                f"audit record evidence {evidence_value!r} is report-scoped but no report artifact text is available for verification"
                             )
-                    elif kind in {"report_table", "pack_table"}:
-                        label = "pack" if kind == "pack_table" else artifact_label
-                        nested_result = _validate_artifact_table(kind, locator, artifact_text, label)
-                        if nested_result.errors:
+                        else:
+                            # Also enforce context: report context should not verify pack evidence via report text
+                            # If this record is being validated in a pack-only context (e.g. research-pack without report_text), report evidence is allowed only if report_text was supplied
+                            if report_text is None and artifact_label == "pack" and pack_text is not None:
+                                # Pack context without report_text — report evidence is cross-artifact, require explicit report_text
+                                strict_errors.append(
+                                    f"audit record evidence {evidence_value!r} is report-scoped but current pack validation has no report text"
+                                )
+                            else:
+                                if kind == "report_section":
+                                    nested_result = _validate_artifact_heading(kind, locator, effective_report_text, "report")
+                                else:
+                                    nested_result = _validate_artifact_table(kind, locator, effective_report_text, "report")
+                                if nested_result and nested_result.errors:
+                                    strict_errors.append(
+                                        f"audit record evidence {evidence_value!r} is not verifiable in report: {'; '.join(nested_result.errors)}"
+                                    )
+                    elif kind in {"pack_section", "pack_table"}:
+                        effective_pack_text = pack_text
+                        if effective_pack_text is None and artifact_label == "pack":
+                            effective_pack_text = artifact_text
+                        if effective_pack_text is None:
                             strict_errors.append(
-                                f"audit record evidence {evidence_value!r} is not verifiable: {'; '.join(nested_result.errors)}"
+                                f"audit record evidence {evidence_value!r} is pack-scoped but no pack artifact text is available — not allowed in report context (see issue #401)"
                             )
+                        else:
+                            if pack_text is None and artifact_label == "report":
+                                strict_errors.append(
+                                    f"audit record evidence {evidence_value!r} is pack-scoped but current report validation has no pack text — not allowed in report context"
+                                )
+                            else:
+                                if kind == "pack_section":
+                                    nested_result = _validate_artifact_heading(kind, locator, effective_pack_text, "pack")
+                                else:
+                                    nested_result = _validate_artifact_table(kind, locator, effective_pack_text, "pack")
+                                if nested_result and nested_result.errors:
+                                    strict_errors.append(
+                                        f"audit record evidence {evidence_value!r} is not verifiable in pack: {'; '.join(nested_result.errors)}"
+                                    )
                     if nested_result is not None and not nested_result.errors and nested_result.provenance:
                         provenance["record_evidence"] = evidence_value
                         provenance["record_evidence_provenance"] = nested_result.provenance
@@ -674,6 +711,8 @@ def validate_evidence_reference(
     expected_artifact_sha256: str | None = None,
     expected_artifact_id: str | None = None,
     expected_route: str | None = None,
+    report_text: str | None = None,
+    pack_text: str | None = None,
 ) -> EvidenceValidation:
     """Validate one typed evidence reference.
 
@@ -758,6 +797,8 @@ def validate_evidence_reference(
             execution_type=execution_type,
             artifact_text=artifact_text,
             artifact_label=artifact_label,
+            report_text=report_text,
+            pack_text=pack_text,
         )
     if kind == "automated_validator":
         if execution_type in {"manual", "process"}:

--- a/scripts/audit_evidence.py
+++ b/scripts/audit_evidence.py
@@ -224,6 +224,8 @@ def _validate_artifact_table(
 def _validate_checklist_item(
     locator: str,
     base_dir: Path | None,
+    *,
+    strict: bool = False,
 ) -> EvidenceValidation:
     if "#" not in locator:
         return EvidenceValidation(
@@ -276,6 +278,19 @@ def _validate_checklist_item(
                 f"checklist item {item_id!r} was not found in {path_value}",
             )
         )
+    # In strict mode a checklist definition is not execution evidence (issue #401).
+    # It must not be used alone to obtain a trusted Pass; callers must supply
+    # an audit-record bound to the current artifact.
+    if strict:
+        provenance["definition_only"] = True
+        provenance["verified"] = False
+        return EvidenceValidation(
+            provenance=provenance,
+            errors=(
+                "checklist-item is definition-only; strict requires "
+                "audit-record with artifact binding (see issue #401)",
+            ),
+        )
     provenance["verified"] = True
     return EvidenceValidation(provenance=provenance)
 
@@ -283,6 +298,12 @@ def _validate_checklist_item(
 def _validate_audit_record(
     locator: str,
     base_dir: Path | None,
+    *,
+    strict: bool = False,
+    expected_audit_id: str | None = None,
+    expected_artifact_sha256: str | None = None,
+    expected_artifact_id: str | None = None,
+    execution_type: str | None = None,
 ) -> EvidenceValidation:
     match = re.fullmatch(r"([^#]+)#([^@]+)@(.+)", locator)
     if not match:
@@ -377,7 +398,147 @@ def _validate_audit_record(
                 f"was not found in {path_value}",
             )
         )
+
+    # Strict artifact / audit binding (issue #401): an audit-record must be
+    # provably bound to the current artifact, audit, and execution state.
+    if strict:
+        strict_errors: list[str] = []
+        # audit_id must match the audit being validated when expected is known
+        record_audit_id = (
+            matching_record.get("audit_id")
+            or matching_record.get("audit")
+            or matching_record.get("auditId")
+        )
+        if expected_audit_id is not None:
+            if not isinstance(record_audit_id, str) or record_audit_id.strip() != expected_audit_id:
+                strict_errors.append(
+                    f"audit record audit_id {record_audit_id!r} does not match expected audit {expected_audit_id!r}"
+                )
+        elif strict:
+            # In strict mode without an explicit expected id, the record must at least declare one
+            if not isinstance(record_audit_id, str) or not record_audit_id.strip():
+                strict_errors.append("audit record is missing audit_id (strict requires it)")
+        # status must be passed
+        record_status = matching_record.get("status", "")
+        if not isinstance(record_status, str) or record_status.strip().lower() not in {
+            "passed",
+            "pass",
+            "已通过",
+        }:
+            strict_errors.append(
+                f"audit record status {record_status!r} is not passed (strict requires passed)"
+            )
+        # artifact binding: at least one of sha256 / artifact_id must match expected when provided,
+        # otherwise at least one must exist
+        record_sha = matching_record.get("artifact_sha256") or matching_record.get("artifact_hash") or matching_record.get("sha256")
+        record_aid = matching_record.get("artifact_id") or matching_record.get("artifactId")
+        if expected_artifact_sha256 is not None or expected_artifact_id is not None:
+            sha_ok = (
+                isinstance(record_sha, str)
+                and record_sha.strip().lower() == expected_artifact_sha256.lower()
+                if expected_artifact_sha256 is not None and isinstance(record_sha, str)
+                else False
+            )
+            aid_ok = (
+                isinstance(record_aid, str)
+                and record_aid.strip() == expected_artifact_id
+                if expected_artifact_id is not None and isinstance(record_aid, str)
+                else False
+            )
+            # Require the corresponding field to be present and equal; if both expected are given, one match is enough
+            if expected_artifact_sha256 is not None and expected_artifact_id is not None:
+                if not (sha_ok or aid_ok):
+                    strict_errors.append(
+                        "audit record artifact binding does not match current artifact (sha256/id mismatch)"
+                    )
+            elif expected_artifact_sha256 is not None:
+                if not sha_ok:
+                    strict_errors.append(
+                        f"audit record artifact_sha256 {record_sha!r} does not match expected {expected_artifact_sha256!r}"
+                    )
+            elif expected_artifact_id is not None:
+                if not aid_ok:
+                    strict_errors.append(
+                        f"audit record artifact_id {record_aid!r} does not match expected {expected_artifact_id!r}"
+                    )
+        else:
+            if not (isinstance(record_sha, str) and record_sha.strip()) and not (
+                isinstance(record_aid, str) and record_aid.strip()
+            ):
+                strict_errors.append(
+                    "audit record is missing artifact binding (strict requires artifact_sha256 or artifact_id)"
+                )
+        # executed_at must be present and not in the future
+        executed_at_value = matching_record.get("executed_at") or matching_record.get("recorded_at") or matching_record.get("timestamp")
+        if not isinstance(executed_at_value, str) or not executed_at_value.strip():
+            strict_errors.append("audit record is missing executed_at/recorded_at (strict requires it)")
+        else:
+            parsed_exec = _parse_timestamp(executed_at_value)
+            if parsed_exec is None:
+                strict_errors.append(
+                    f"audit record executed_at is not ISO-8601: {executed_at_value!r}"
+                )
+            else:
+                now = datetime.now(timezone.utc)
+                # Allow small clock skew (60s) but reject clearly future timestamps
+                if parsed_exec > now:
+                    # Use 60s grace
+                    try:
+                        # compare with tolerance
+                        if (parsed_exec - now).total_seconds() > 60:
+                            strict_errors.append(
+                                f"audit record executed_at {executed_at_value!r} is in the future"
+                            )
+                    except Exception:
+                        strict_errors.append(
+                            f"audit record executed_at {executed_at_value!r} is in the future"
+                        )
+        # execution_source alignment (advisory but fail-closed if explicitly wrong)
+        if execution_type in {"manual", "process"}:
+            src = matching_record.get("execution_source") or matching_record.get("source")
+            if isinstance(src, str) and src.strip():
+                allowed = {
+                    "manual": {"manual_checklist_attestation"},
+                    "process": {"process_node_evidence"},
+                }.get(execution_type, set())
+                # Allow the matching type, reject automated/legacy masquerading
+                if src.strip() not in allowed and src.strip() not in {"manual_checklist_attestation", "process_node_evidence"}:
+                    # If record claims automated but audit is manual, that's a mismatch
+                    if src.strip() == "automated_validator":
+                        strict_errors.append(
+                            f"audit record execution_source {src!r} does not match {execution_type} audit"
+                        )
+
+        if strict_errors:
+            provenance["verified"] = False
+            # expose what was found for debugging / provenance
+            if record_audit_id is not None:
+                provenance["record_audit_id"] = record_audit_id
+            if record_status:
+                provenance["record_status"] = record_status
+            if record_sha is not None:
+                provenance["record_artifact_sha256"] = record_sha
+            if record_aid is not None:
+                provenance["record_artifact_id"] = record_aid
+            return EvidenceValidation(
+                provenance=provenance,
+                errors=tuple(strict_errors),
+            )
+
     provenance["verified"] = True
+    # enrich provenance with bound fields when present
+    if matching_record.get("audit_id") is not None:
+        provenance["record_audit_id"] = matching_record.get("audit_id")
+    if matching_record.get("status") is not None:
+        provenance["record_status"] = matching_record.get("status")
+    if matching_record.get("artifact_sha256") is not None:
+        provenance["record_artifact_sha256"] = matching_record.get("artifact_sha256")
+    if matching_record.get("artifact_id") is not None:
+        provenance["record_artifact_id"] = matching_record.get("artifact_id")
+    if matching_record.get("executed_at") is not None:
+        provenance["record_executed_at"] = matching_record.get("executed_at")
+    elif matching_record.get("recorded_at") is not None:
+        provenance["record_executed_at"] = matching_record.get("recorded_at")
     return EvidenceValidation(provenance=provenance)
 
 
@@ -399,6 +560,9 @@ def validate_evidence_reference(
     artifact_label: str = "report",
     known_validator_bindings: Collection[str] | None = None,
     execution_type: str | None = None,
+    expected_audit_id: str | None = None,
+    expected_artifact_sha256: str | None = None,
+    expected_artifact_id: str | None = None,
 ) -> EvidenceValidation:
     """Validate one typed evidence reference.
 
@@ -470,9 +634,17 @@ def validate_evidence_reference(
         label = "pack" if kind == "pack_table" else artifact_label
         return _validate_artifact_table(kind, locator, artifact_text, label)
     if kind == "checklist_item":
-        return _validate_checklist_item(locator, base_dir)
+        return _validate_checklist_item(locator, base_dir, strict=strict)
     if kind == "audit_record":
-        return _validate_audit_record(locator, base_dir)
+        return _validate_audit_record(
+            locator,
+            base_dir,
+            strict=strict,
+            expected_audit_id=expected_audit_id,
+            expected_artifact_sha256=expected_artifact_sha256,
+            expected_artifact_id=expected_artifact_id,
+            execution_type=execution_type,
+        )
     if kind == "automated_validator":
         if execution_type in {"manual", "process"}:
             return EvidenceValidation(

--- a/scripts/audit_evidence.py
+++ b/scripts/audit_evidence.py
@@ -428,40 +428,23 @@ def _validate_audit_record(
             strict_errors.append(
                 f"audit record status {record_status!r} is not passed (strict requires passed)"
             )
-        # artifact binding: at least one of sha256 / artifact_id must match expected when provided,
-        # otherwise at least one must exist
+        # artifact binding: each provided expected field is fail-closed independently (issue #401 P1).
+        # When audit_report passes both sha256 and artifact_id, both must match if the record declares them;
+        # a hash mismatch cannot be rescued by an id match.  When only one expected is given
+        # (contract / pack), that single field must match.
         record_sha = matching_record.get("artifact_sha256") or matching_record.get("artifact_hash") or matching_record.get("sha256")
         record_aid = matching_record.get("artifact_id") or matching_record.get("artifactId")
-        if expected_artifact_sha256 is not None or expected_artifact_id is not None:
-            sha_ok = (
-                isinstance(record_sha, str)
-                and record_sha.strip().lower() == expected_artifact_sha256.lower()
-                if expected_artifact_sha256 is not None and isinstance(record_sha, str)
-                else False
-            )
-            aid_ok = (
-                isinstance(record_aid, str)
-                and record_aid.strip() == expected_artifact_id
-                if expected_artifact_id is not None and isinstance(record_aid, str)
-                else False
-            )
-            # Require the corresponding field to be present and equal; if both expected are given, one match is enough
-            if expected_artifact_sha256 is not None and expected_artifact_id is not None:
-                if not (sha_ok or aid_ok):
-                    strict_errors.append(
-                        "audit record artifact binding does not match current artifact (sha256/id mismatch)"
-                    )
-            elif expected_artifact_sha256 is not None:
-                if not sha_ok:
-                    strict_errors.append(
-                        f"audit record artifact_sha256 {record_sha!r} does not match expected {expected_artifact_sha256!r}"
-                    )
-            elif expected_artifact_id is not None:
-                if not aid_ok:
-                    strict_errors.append(
-                        f"audit record artifact_id {record_aid!r} does not match expected {expected_artifact_id!r}"
-                    )
-        else:
+        if expected_artifact_sha256 is not None:
+            if not isinstance(record_sha, str) or record_sha.strip().lower() != expected_artifact_sha256.lower():
+                strict_errors.append(
+                    f"audit record artifact_sha256 {record_sha!r} does not match expected {expected_artifact_sha256!r}"
+                )
+        if expected_artifact_id is not None:
+            if not isinstance(record_aid, str) or record_aid.strip() != expected_artifact_id:
+                strict_errors.append(
+                    f"audit record artifact_id {record_aid!r} does not match expected {expected_artifact_id!r}"
+                )
+        if expected_artifact_sha256 is None and expected_artifact_id is None:
             if not (isinstance(record_sha, str) and record_sha.strip()) and not (
                 isinstance(record_aid, str) and record_aid.strip()
             ):
@@ -493,7 +476,9 @@ def _validate_audit_record(
                         strict_errors.append(
                             f"audit record executed_at {executed_at_value!r} is in the future"
                         )
-        # execution_source alignment (advisory but fail-closed if explicitly wrong)
+        # execution_source must align with registry execution_type (issue #401 P2).
+        # manual ↔ manual_checklist_attestation, process ↔ process_node_evidence; any cross (e.g. manual eating process record)
+        # or legacy/automated masquerading is fail-closed.  Use precise set check.
         if execution_type in {"manual", "process"}:
             src = matching_record.get("execution_source") or matching_record.get("source")
             if isinstance(src, str) and src.strip():
@@ -501,13 +486,10 @@ def _validate_audit_record(
                     "manual": {"manual_checklist_attestation"},
                     "process": {"process_node_evidence"},
                 }.get(execution_type, set())
-                # Allow the matching type, reject automated/legacy masquerading
-                if src.strip() not in allowed and src.strip() not in {"manual_checklist_attestation", "process_node_evidence"}:
-                    # If record claims automated but audit is manual, that's a mismatch
-                    if src.strip() == "automated_validator":
-                        strict_errors.append(
-                            f"audit record execution_source {src!r} does not match {execution_type} audit"
-                        )
+                if src.strip() not in allowed:
+                    strict_errors.append(
+                        f"audit record execution_source {src!r} does not match {execution_type} audit (expected {sorted(allowed)})"
+                    )
 
         if strict_errors:
             provenance["verified"] = False

--- a/scripts/audit_report.py
+++ b/scripts/audit_report.py
@@ -1238,6 +1238,23 @@ def _execute_required_audits(
         )
     except (OSError, UnicodeError):
         visible_text = None
+    # Artifact binding for strict provenance (issue #401): audit-record must
+    # prove it targets the current artifact, not any template.  Compute the
+    # input hash once and extract the contract's stable artifact_id up front
+    # so validation can fail closed on mismatched bindings.
+    expected_artifact_sha256 = _sha256(path) if path.is_file() else None
+    contract_data_for_binding: dict | None = None
+    try:
+        contract_data_for_binding = extract_contract_from_markdown(
+            path.read_text(encoding="utf-8", errors="replace")
+        )
+    except (OSError, UnicodeError):
+        contract_data_for_binding = None
+    expected_artifact_id: str | None = None
+    if isinstance(contract_data_for_binding, dict):
+        raw_aid = contract_data_for_binding.get("artifact_id")
+        if isinstance(raw_aid, str) and raw_aid.strip():
+            expected_artifact_id = raw_aid.strip()
     results: list[AuditResult] = []
     blocking: list[str] = []
     warnings: list[str] = []
@@ -1298,6 +1315,9 @@ def _execute_required_audits(
                     artifact_label="report",
                     known_validator_bindings=_registered_validator_bindings(),
                     execution_type=audit.execution_type,
+                    expected_audit_id=audit_id,
+                    expected_artifact_sha256=expected_artifact_sha256,
+                    expected_artifact_id=expected_artifact_id,
                 )
                 if evidence_result.legacy:
                     execution_source = _execution_source(
@@ -1478,6 +1498,9 @@ def _execute_required_audits(
                 artifact_label="report",
                 known_validator_bindings=_registered_validator_bindings(),
                 execution_type="manual",
+                expected_audit_id=derived_id,
+                expected_artifact_sha256=expected_artifact_sha256,
+                expected_artifact_id=expected_artifact_id,
             )
             if evidence_result.legacy:
                 execution_source = _execution_source("manual", legacy=True)

--- a/scripts/audit_report.py
+++ b/scripts/audit_report.py
@@ -1319,6 +1319,8 @@ def _execute_required_audits(
                     expected_artifact_sha256=expected_artifact_sha256,
                     expected_artifact_id=expected_artifact_id,
                     expected_route=route_id,
+                    report_text=visible_text,
+                    pack_text=None,
                 )
                 # P2: do not auto-fill execution_source when record declares it; use the record's value (already validated)
                 if evidence_result.provenance and "record_execution_source" in evidence_result.provenance:
@@ -1327,6 +1329,13 @@ def _execute_required_audits(
                     execution_source = _execution_source(
                         audit.execution_type, legacy=True
                     )
+                # P2: if record is audit-record but missing/invalid source, do not伪造 trusted attestation
+                elif strict and evidence and evidence[0].startswith("audit-record:"):
+                    # If strict validation failed due to missing execution_source, don't keep derived trusted source
+                    if any("missing execution_source" in e for e in evidence_result.errors) or any(
+                        "execution_source" in e for e in evidence_result.errors
+                    ):
+                        execution_source = "unknown"
                 if evidence_result.provenance:
                     evidence_provenance.append(
                         {
@@ -1506,11 +1515,18 @@ def _execute_required_audits(
                 expected_artifact_sha256=expected_artifact_sha256,
                 expected_artifact_id=expected_artifact_id,
                 expected_route=route_id,
+                report_text=visible_text,
+                pack_text=None,
             )
             if evidence_result.provenance and "record_execution_source" in evidence_result.provenance:
                 execution_source = str(evidence_result.provenance["record_execution_source"])
             elif evidence_result.legacy:
                 execution_source = _execution_source("manual", legacy=True)
+            elif strict and raw_evidence and isinstance(raw_evidence, str) and raw_evidence.startswith("audit-record:"):
+                if any("missing execution_source" in e for e in evidence_result.errors) or any(
+                    "execution_source" in e for e in evidence_result.errors
+                ):
+                    execution_source = "unknown"
             if evidence_result.provenance:
                 evidence_provenance.append(
                     {

--- a/scripts/audit_report.py
+++ b/scripts/audit_report.py
@@ -1318,8 +1318,12 @@ def _execute_required_audits(
                     expected_audit_id=audit_id,
                     expected_artifact_sha256=expected_artifact_sha256,
                     expected_artifact_id=expected_artifact_id,
+                    expected_route=route_id,
                 )
-                if evidence_result.legacy:
+                # P2: do not auto-fill execution_source when record declares it; use the record's value (already validated)
+                if evidence_result.provenance and "record_execution_source" in evidence_result.provenance:
+                    execution_source = str(evidence_result.provenance["record_execution_source"])
+                elif evidence_result.legacy:
                     execution_source = _execution_source(
                         audit.execution_type, legacy=True
                     )
@@ -1501,8 +1505,11 @@ def _execute_required_audits(
                 expected_audit_id=derived_id,
                 expected_artifact_sha256=expected_artifact_sha256,
                 expected_artifact_id=expected_artifact_id,
+                expected_route=route_id,
             )
-            if evidence_result.legacy:
+            if evidence_result.provenance and "record_execution_source" in evidence_result.provenance:
+                execution_source = str(evidence_result.provenance["record_execution_source"])
+            elif evidence_result.legacy:
                 execution_source = _execution_source("manual", legacy=True)
             if evidence_result.provenance:
                 evidence_provenance.append(

--- a/scripts/validate_contract.py
+++ b/scripts/validate_contract.py
@@ -766,6 +766,8 @@ def validate_contract(
                 expected_audit_id=audit_id,
                 expected_artifact_id=expected_aid,
                 expected_route=expected_route_for_record,
+                report_text=report_text if strict else None,
+                pack_text=None,
             )
             errors.extend(
                 f"Audit '{audit_id}' evidence: {error}"

--- a/scripts/validate_contract.py
+++ b/scripts/validate_contract.py
@@ -745,6 +745,14 @@ def validate_contract(
                 f"Evidence must reference a concrete location in the artifact."
             )
         elif status == "passed":
+            # Issue #401: strict contract audits must bind to the current artifact
+            # when the evidence is an audit-record.  Pass the contract's stable
+            # artifact_id and the audit id so a forged record for another
+            # artifact/audit cannot be reused.
+            expected_aid = None
+            raw_aid = contract.get("artifact_id")
+            if isinstance(raw_aid, str) and raw_aid.strip():
+                expected_aid = raw_aid.strip()
             evidence_result = validate_evidence_reference(
                 evidence,
                 artifact_text=report_text if strict else None,
@@ -753,6 +761,8 @@ def validate_contract(
                 artifact_label="report",
                 known_validator_bindings=known_validator_bindings,
                 execution_type=audit_execution_type,
+                expected_audit_id=audit_id,
+                expected_artifact_id=expected_aid,
             )
             errors.extend(
                 f"Audit '{audit_id}' evidence: {error}"

--- a/scripts/validate_contract.py
+++ b/scripts/validate_contract.py
@@ -747,12 +747,14 @@ def validate_contract(
         elif status == "passed":
             # Issue #401: strict contract audits must bind to the current artifact
             # when the evidence is an audit-record.  Pass the contract's stable
-            # artifact_id and the audit id so a forged record for another
-            # artifact/audit cannot be reused.
+            # artifact_id, primary route, and audit id so a forged record for another
+            # artifact/audit/route cannot be reused, and nested evidence is verified.
             expected_aid = None
             raw_aid = contract.get("artifact_id")
             if isinstance(raw_aid, str) and raw_aid.strip():
                 expected_aid = raw_aid.strip()
+            # Determine expected route for binding (contract's primary_route)
+            expected_route_for_record = primary if isinstance(primary, str) and primary.strip() else None
             evidence_result = validate_evidence_reference(
                 evidence,
                 artifact_text=report_text if strict else None,
@@ -763,6 +765,7 @@ def validate_contract(
                 execution_type=audit_execution_type,
                 expected_audit_id=audit_id,
                 expected_artifact_id=expected_aid,
+                expected_route=expected_route_for_record,
             )
             errors.extend(
                 f"Audit '{audit_id}' evidence: {error}"

--- a/scripts/validate_research_pack.py
+++ b/scripts/validate_research_pack.py
@@ -612,6 +612,22 @@ def _check_audit_evidence(
             ):
                 target_text = report_text
                 target_label = "report"
+            # Issue #401: pack audit evidence must also be artifact-bound
+            # when it is an audit-record.  Extract the pack's declared artifact id
+            # if present so a record for another artifact cannot be reused.
+            pack_artifact_id: str | None = None
+            # artifact_text is the pack's cleaned markdown; reuse _section_body
+            try:
+                _pack_aid_body = _section_body(artifact_text, "Artifact id")
+                if _pack_aid_body:
+                    first_aid_line = next(
+                        (ln.strip() for ln in _pack_aid_body.split("\n") if ln.strip()),
+                        "",
+                    )
+                    if first_aid_line:
+                        pack_artifact_id = first_aid_line.split()[0]
+            except Exception:
+                pack_artifact_id = None
             result = validate_evidence_reference(
                 evidence,
                 artifact_text=target_text,
@@ -620,6 +636,8 @@ def _check_audit_evidence(
                 artifact_label=target_label,
                 known_validator_bindings=known_validator_bindings,
                 execution_type=execution_type,
+                expected_audit_id=str(audit_id) if isinstance(audit_id, str) else None,
+                expected_artifact_id=pack_artifact_id,
             )
             errors.extend(
                 f"Required audit evidence: {error}"

--- a/scripts/validate_research_pack.py
+++ b/scripts/validate_research_pack.py
@@ -614,9 +614,9 @@ def _check_audit_evidence(
                 target_label = "report"
             # Issue #401: pack audit evidence must also be artifact-bound
             # when it is an audit-record.  Extract the pack's declared artifact id
-            # if present so a record for another artifact cannot be reused.
+            # and primary route so a record for another artifact/route cannot be reused.
             pack_artifact_id: str | None = None
-            # artifact_text is the pack's cleaned markdown; reuse _section_body
+            pack_route: str | None = None
             try:
                 _pack_aid_body = _section_body(artifact_text, "Artifact id")
                 if _pack_aid_body:
@@ -626,8 +626,24 @@ def _check_audit_evidence(
                     )
                     if first_aid_line:
                         pack_artifact_id = first_aid_line.split()[0]
+                # Primary route for route binding (P2)
+                _pack_route_body = _section_body(artifact_text, "Primary route")
+                if _pack_route_body:
+                    first_route_line = next(
+                        (ln.strip() for ln in _pack_route_body.split("\n") if ln.strip() and not ln.strip().lower().startswith("closest")),
+                        "",
+                    )
+                    if first_route_line:
+                        raw = re.sub(r"^[-*>]+\s+", "", first_route_line)
+                        raw = re.sub(r"^\d+[.)]\s+", "", raw)
+                        raw = re.sub(r"\*{1,2}([^*]+)\*{1,2}", r"\1", raw)
+                        try:
+                            pack_route = load_route_registry().resolve_route(raw)
+                        except Exception:
+                            pack_route = None
             except Exception:
                 pack_artifact_id = None
+                pack_route = None
             result = validate_evidence_reference(
                 evidence,
                 artifact_text=target_text,
@@ -638,6 +654,7 @@ def _check_audit_evidence(
                 execution_type=execution_type,
                 expected_audit_id=str(audit_id) if isinstance(audit_id, str) else None,
                 expected_artifact_id=pack_artifact_id,
+                expected_route=pack_route,
             )
             errors.extend(
                 f"Required audit evidence: {error}"

--- a/scripts/validate_research_pack.py
+++ b/scripts/validate_research_pack.py
@@ -655,6 +655,8 @@ def _check_audit_evidence(
                 expected_audit_id=str(audit_id) if isinstance(audit_id, str) else None,
                 expected_artifact_id=pack_artifact_id,
                 expected_route=pack_route,
+                report_text=report_text,
+                pack_text=artifact_text,
             )
             errors.extend(
                 f"Required audit evidence: {error}"

--- a/tests/test_audit_evidence_provenance.py
+++ b/tests/test_audit_evidence_provenance.py
@@ -305,7 +305,7 @@ def test_audit_record_requires_matching_record_content(tmp_path: Path) -> None:
     from audit_evidence import validate_evidence_reference
 
     record_file = tmp_path / "audit-record.json"
-    # Valid record must include strict provenance fields (issue #401)
+    # Valid record must include strict provenance fields (issue #401) including evidence
     record_file.write_text(
         json.dumps({
             "records": [
@@ -317,6 +317,8 @@ def test_audit_record_requires_matching_record_content(tmp_path: Path) -> None:
                     "artifact_sha256": "a" * 64,
                     "executed_at": "2026-08-18T10:00:00Z",
                     "execution_source": "manual_checklist_attestation",
+                    "evidence": "report-section:Monitoring signals",
+                    "route": "market-outlook",
                 }
             ]
         }),
@@ -328,6 +330,8 @@ def test_audit_record_requires_matching_record_content(tmp_path: Path) -> None:
         strict=True,
         expected_audit_id="market-outlook-audit",
         expected_artifact_sha256="a" * 64,
+        expected_route="market-outlook",
+        artifact_text="## Monitoring signals\n\ncontent",
     )
     assert valid.is_valid, valid.errors
     assert valid.provenance and valid.provenance["verified"] is True

--- a/tests/test_audit_evidence_provenance.py
+++ b/tests/test_audit_evidence_provenance.py
@@ -280,13 +280,24 @@ def test_real_checklist_item_is_verified() -> None:
     sys.path.insert(0, str(ROOT / "scripts"))
     from audit_evidence import validate_evidence_reference
 
-    result = validate_evidence_reference(
+    # Strict mode: checklist definition alone is not execution evidence (issue #401)
+    strict_result = validate_evidence_reference(
         "checklist-item:checklists/final-audit.md#FA-001",
         base_dir=ROOT,
         strict=True,
     )
-    assert result.is_valid, result.errors
-    assert result.provenance and result.provenance["verified"] is True
+    assert not strict_result.is_valid
+    assert any("definition-only" in e or "audit-record" in e for e in strict_result.errors)
+    assert strict_result.provenance and strict_result.provenance.get("definition_only") is True
+
+    # Compatibility mode: the definition can still be verified as existing
+    compat = validate_evidence_reference(
+        "checklist-item:checklists/final-audit.md#FA-001",
+        base_dir=ROOT,
+        strict=False,
+    )
+    assert compat.is_valid, compat.errors
+    assert compat.provenance and compat.provenance["verified"] is True
 
 
 def test_audit_record_requires_matching_record_content(tmp_path: Path) -> None:
@@ -294,12 +305,18 @@ def test_audit_record_requires_matching_record_content(tmp_path: Path) -> None:
     from audit_evidence import validate_evidence_reference
 
     record_file = tmp_path / "audit-record.json"
+    # Valid record must include strict provenance fields (issue #401)
     record_file.write_text(
         json.dumps({
             "records": [
                 {
                     "record_id": "manual-001",
                     "recorded_at": "2026-08-18T10:00:00Z",
+                    "audit_id": "market-outlook-audit",
+                    "status": "passed",
+                    "artifact_sha256": "a" * 64,
+                    "executed_at": "2026-08-18T10:00:00Z",
+                    "execution_source": "manual_checklist_attestation",
                 }
             ]
         }),
@@ -309,6 +326,8 @@ def test_audit_record_requires_matching_record_content(tmp_path: Path) -> None:
         "audit-record:audit-record.json#manual-001@2026-08-18T10:00:00Z",
         base_dir=tmp_path,
         strict=True,
+        expected_audit_id="market-outlook-audit",
+        expected_artifact_sha256="a" * 64,
     )
     assert valid.is_valid, valid.errors
     assert valid.provenance and valid.provenance["verified"] is True

--- a/tests/test_issue401_checklist_not_execution.py
+++ b/tests/test_issue401_checklist_not_execution.py
@@ -302,7 +302,7 @@ def test_audit_record_legacy_source_cannot_pass(tmp_path: Path) -> None:
 
 
 def test_audit_record_missing_execution_source_cannot_pass(tmp_path: Path) -> None:
-    """P1-blocker: record without execution_source must not obtain trusted pass."""
+    """P1-blocker: record without execution_source must not obtain trusted pass and must not be伪造为 manual."""
     record_dir = _make_record_dir()
     try:
         content = POS.read_text(encoding="utf-8")
@@ -322,9 +322,10 @@ def test_audit_record_missing_execution_source_cannot_pass(tmp_path: Path) -> No
         assert proc.returncode == 2, proc.stdout
         data = json.loads(proc.stdout)
         assert any("execution_source" in b.lower() and "missing" in b.lower() for b in data["blocking"])
-        # Ensure JSON does not伪造为 manual_checklist_attestation
         audit = next(a for a in data["audits"] if a["audit_id"] == "market-outlook-audit")
         assert audit["status"] != "pass"
+        # P2: missing source must not be displayed as trusted attestation
+        assert audit["execution_source"] != "manual_checklist_attestation", "missing source should not be shown as trusted attestation"
     finally:
         shutil.rmtree(record_dir, ignore_errors=True)
 
@@ -441,5 +442,96 @@ def test_json_distinguishes_execution_sources(tmp_path: Path) -> None:
         res = validate_evidence_reference(f"audit-record:{rel}#p1@2026-08-18T10:00:00Z", base_dir=ROOT, strict=True, execution_type="process", expected_audit_id="mid-research-review-audit", expected_artifact_sha256="b"*64, expected_route="market-outlook", artifact_text="## Monitoring signals\n\ncontent")
         assert res.is_valid, res.errors
         assert res.provenance and res.provenance["verified"] is True
+    finally:
+        shutil.rmtree(rec_dir, ignore_errors=True)
+
+
+def test_nested_report_section_only_in_pack_must_fail(tmp_path: Path) -> None:
+    """P1/P2: report-section evidence that exists only in pack must not be verified against report."""
+    from audit_evidence import validate_evidence_reference
+    rec_dir = _make_record_dir()
+    try:
+        # Pack has ## Artifact contract, report fixture does not
+        pack_text = "## Artifact contract\n\ncontract body\n"
+        report_text = "## Monitoring signals\n\nsignals\n"
+        payload = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "c"*64, "artifact_id": "test-artifact", "executed_at": "2026-08-18T10:00:00Z", "execution_source": "manual_checklist_attestation", "evidence": "report-section:Artifact contract", "route": "market-outlook"}]}
+        rec_path, rel = _write_record_file(rec_dir, "r.json", payload)
+        # Validate as report audit: report_text is report_text (without Artifact contract), pack_text is pack_text
+        # Inner report-section:Artifact contract should fail because it's not in report_text
+        res = validate_evidence_reference(
+            f"audit-record:{rel}#r1@2026-08-18T10:00:00Z",
+            base_dir=ROOT,
+            strict=True,
+            execution_type="manual",
+            expected_audit_id="market-outlook-audit",
+            expected_artifact_sha256="c"*64,
+            expected_artifact_id="test-artifact",
+            expected_route="market-outlook",
+            artifact_text=report_text,
+            report_text=report_text,
+            pack_text=pack_text,
+        )
+        assert not res.is_valid, "report-section that only exists in pack should not verify against report"
+        assert any("Artifact contract" in e for e in res.errors)
+    finally:
+        shutil.rmtree(rec_dir, ignore_errors=True)
+
+
+def test_nested_pack_section_only_in_report_must_fail(tmp_path: Path) -> None:
+    """P1/P2: pack-section evidence that exists only in report must not be verified against pack."""
+    from audit_evidence import validate_evidence_reference
+    rec_dir = _make_record_dir()
+    try:
+        # Report has Monitoring signals, pack has Artifact contract only
+        pack_text = "## Artifact contract\n\ncontract body\n"
+        report_text = "## Monitoring signals\n\nsignals\n"
+        payload = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "c"*64, "artifact_id": "test-artifact", "executed_at": "2026-08-18T10:00:00Z", "execution_source": "manual_checklist_attestation", "evidence": "pack-section:Monitoring signals", "route": "market-outlook"}]}
+        rec_path, rel = _write_record_file(rec_dir, "r.json", payload)
+        # Validate via research_pack context: artifact_text is pack, report_text is report
+        # Inner pack-section:Monitoring signals should fail because pack_text doesn't have it
+        res = validate_evidence_reference(
+            f"audit-record:{rel}#r1@2026-08-18T10:00:00Z",
+            base_dir=ROOT,
+            strict=True,
+            execution_type="manual",
+            expected_audit_id="market-outlook-audit",
+            expected_artifact_sha256="c"*64,
+            expected_artifact_id="test-artifact",
+            expected_route="market-outlook",
+            artifact_text=pack_text,
+            artifact_label="pack",
+            report_text=report_text,
+            pack_text=pack_text,
+        )
+        assert not res.is_valid, "pack-section that only exists in report should not verify against pack"
+        assert any("Monitoring signals" in e for e in res.errors)
+    finally:
+        shutil.rmtree(rec_dir, ignore_errors=True)
+
+
+def test_report_context_rejects_pack_evidence_without_pack_text(tmp_path: Path) -> None:
+    """Report context without pack_text must reject pack-scoped evidence."""
+    from audit_evidence import validate_evidence_reference
+    rec_dir = _make_record_dir()
+    try:
+        payload = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "d"*64, "artifact_id": "art", "executed_at": "2026-08-18T10:00:00Z", "execution_source": "manual_checklist_attestation", "evidence": "pack-section:Artifact contract", "route": "market-outlook"}]}
+        rec_path, rel = _write_record_file(rec_dir, "r.json", payload)
+        # Report-only context: no pack_text
+        res = validate_evidence_reference(
+            f"audit-record:{rel}#r1@2026-08-18T10:00:00Z",
+            base_dir=ROOT,
+            strict=True,
+            execution_type="manual",
+            expected_audit_id="market-outlook-audit",
+            expected_artifact_sha256="d"*64,
+            expected_artifact_id="art",
+            expected_route="market-outlook",
+            artifact_text="## Monitoring signals\n",
+            artifact_label="report",
+            report_text="## Monitoring signals\n",
+            pack_text=None,
+        )
+        assert not res.is_valid
+        assert any("pack" in e.lower() and "not allowed" in e.lower() for e in res.errors)
     finally:
         shutil.rmtree(rec_dir, ignore_errors=True)

--- a/tests/test_issue401_checklist_not_execution.py
+++ b/tests/test_issue401_checklist_not_execution.py
@@ -4,8 +4,9 @@ Covers the acceptance criteria:
 
 - checklist marker alone (even if exists) cannot obtain trusted pass in strict
 - forged item id, missing checklist, unchecked template (all strict) -> partial/not_run
-- audit-record missing / status != passed / artifact mismatch / audit_id mismatch -> fail closed
-- valid audit-record with artifact binding -> pass
+- audit-record missing / status != passed / artifact mismatch / audit_id mismatch / route mismatch / missing evidence/source -> fail closed
+- duplicate record -> fail closed
+- valid audit-record with artifact binding + evidence + route -> pass
 - JSON distinguishes 4 execution sources
 """
 
@@ -57,15 +58,9 @@ def _write_report_with_evidence(tmp_path: Path, evidence_locator: str) -> Path:
 
 
 def _make_record_dir() -> Path:
-    """Create an isolated directory under ROOT/tmp for audit-record files.
-
-    Using a unique subdir under ROOT/tmp keeps the relative locator inside the
-    repository root (required by _safe_path) while avoiding collisions and
-    allowing safe cleanup without touching the shared tmp/ directory itself.
-    """
+    """Create an isolated directory under ROOT/tmp for audit-record files."""
     base = ROOT / "tmp"
     base.mkdir(parents=True, exist_ok=True)
-    # mkdtemp under base gives a unique isolated folder like tmp/tmpxxx
     tmpdir = Path(tempfile.mkdtemp(dir=base))
     return tmpdir
 
@@ -112,13 +107,10 @@ def test_audit_record_status_not_passed_cannot_pass(tmp_path: Path) -> None:
         content = POS.read_text(encoding="utf-8")
         report_tmp = tmp_path / "report.md"
         placeholder = content.replace("report-section:Monitoring signals", "audit-record:tmp/placeholder#r1@2026-08-18T10:00:00Z", 1)
-        # temporary placeholder to compute aid
         m = re.search(r'"artifact_id"\s*:\s*"([^"]+)"', placeholder)
         aid = m.group(1) if m else "fixture-market-outlook-pos"
-        # create isolated record file
-        rec_payload = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "partial", "artifact_sha256": "x"*64, "artifact_id": aid, "executed_at": "2026-08-18T10:00:00Z"}]}
+        rec_payload = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "partial", "artifact_sha256": "x"*64, "artifact_id": aid, "executed_at": "2026-08-18T10:00:00Z", "execution_source": "manual_checklist_attestation", "evidence": "report-section:Monitoring signals", "route": "market-outlook"}]}
         rec_path, rel = _write_record_file(record_dir, "record.json", rec_payload)
-        # patch placeholder to use real rel
         placeholder = content.replace("report-section:Monitoring signals", f"audit-record:{rel}#r1@2026-08-18T10:00:00Z", 1)
         placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', f'"evidence": "audit-record:{rel}#r1@2026-08-18T10:00:00Z"', 1)
         report_tmp.write_text(placeholder, encoding="utf-8")
@@ -139,7 +131,7 @@ def test_audit_record_wrong_artifact_cannot_pass(tmp_path: Path) -> None:
     try:
         content = POS.read_text(encoding="utf-8")
         report_tmp = tmp_path / "report.md"
-        rec_payload = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "0"*64, "artifact_id": "some-other-artifact", "executed_at": "2026-08-18T10:00:00Z"}]}
+        rec_payload = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "0"*64, "artifact_id": "some-other-artifact", "executed_at": "2026-08-18T10:00:00Z", "execution_source": "manual_checklist_attestation", "evidence": "report-section:Monitoring signals", "route": "market-outlook"}]}
         rec_path, rel = _write_record_file(record_dir, "record.json", rec_payload)
         placeholder = content.replace("report-section:Monitoring signals", f"audit-record:{rel}#r1@2026-08-18T10:00:00Z", 1)
         placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', f'"evidence": "audit-record:{rel}#r1@2026-08-18T10:00:00Z"', 1)
@@ -147,7 +139,6 @@ def test_audit_record_wrong_artifact_cannot_pass(tmp_path: Path) -> None:
         proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
         assert proc.returncode == 2, proc.stdout
         data = json.loads(proc.stdout)
-        # Each provided artifact field is now independently fail-closed (P1)
         assert any("artifact" in b.lower() and ("mismatch" in b.lower() or "does not match" in b.lower()) for b in data["blocking"])
     finally:
         shutil.rmtree(record_dir, ignore_errors=True)
@@ -161,11 +152,10 @@ def test_audit_record_wrong_audit_id_cannot_pass(tmp_path: Path) -> None:
         placeholder = content.replace("report-section:Monitoring signals", "audit-record:tmp/placeholder#r1@2026-08-18T10:00:00Z", 1)
         m = re.search(r'"artifact_id"\s*:\s*"([^"]+)"', placeholder)
         aid = m.group(1) if m else "fixture-market-outlook-pos"
-        # pre-write to compute sha
         tmp_placeholder = placeholder.replace("audit-record:tmp/placeholder#r1@2026-08-18T10:00:00Z", "audit-record:tmp/dummy#r1@2026-08-18T10:00:00Z", 1)
         report_tmp.write_text(tmp_placeholder, encoding="utf-8")
         sha_probe = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
-        rec_payload = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "final-audit", "status": "passed", "artifact_sha256": sha_probe, "artifact_id": aid, "executed_at": "2026-08-18T10:00:00Z"}]}
+        rec_payload = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "final-audit", "status": "passed", "artifact_sha256": sha_probe, "artifact_id": aid, "executed_at": "2026-08-18T10:00:00Z", "execution_source": "manual_checklist_attestation", "evidence": "report-section:Monitoring signals", "route": "market-outlook"}]}
         rec_path, rel = _write_record_file(record_dir, "record.json", rec_payload)
         placeholder = content.replace("report-section:Monitoring signals", f"audit-record:{rel}#r1@2026-08-18T10:00:00Z", 1)
         placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', f'"evidence": "audit-record:{rel}#r1@2026-08-18T10:00:00Z"', 1)
@@ -186,11 +176,10 @@ def test_valid_audit_record_with_binding_passes(tmp_path: Path) -> None:
     try:
         content = POS.read_text(encoding="utf-8")
         report_tmp = tmp_path / "report.md"
-        rec_payload: dict = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "placeholder", "artifact_id": "fixture-market-outlook-pos", "executed_at": "2026-08-18T10:00:00Z", "execution_source": "manual_checklist_attestation"}]}
+        rec_payload: dict = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "placeholder", "artifact_id": "fixture-market-outlook-pos", "executed_at": "2026-08-18T10:00:00Z", "execution_source": "manual_checklist_attestation", "evidence": "report-section:Monitoring signals", "route": "market-outlook"}]}
         rec_path, rel = _write_record_file(record_dir, "record.json", rec_payload)
         placeholder = content.replace("report-section:Monitoring signals", f"audit-record:{rel}#r1@2026-08-18T10:00:00Z", 1)
         placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', f'"evidence": "audit-record:{rel}#r1@2026-08-18T10:00:00Z"', 1)
-        # Extract aid
         m = re.search(r'"artifact_id"\s*:\s*"([^"]+)"', placeholder)
         aid = m.group(1) if m else "fixture-market-outlook-pos"
         report_tmp.write_text(placeholder, encoding="utf-8")
@@ -207,6 +196,8 @@ def test_valid_audit_record_with_binding_passes(tmp_path: Path) -> None:
         assert audit["execution_source"] == "manual_checklist_attestation"
         assert audit["evidence_provenance"][0]["verified"] is True
         assert audit["evidence_provenance"][0]["kind"] == "audit_record"
+        # nested evidence should be present
+        assert audit["evidence_provenance"][0].get("record_evidence") == "report-section:Monitoring signals"
     finally:
         shutil.rmtree(record_dir, ignore_errors=True)
 
@@ -217,23 +208,20 @@ def test_audit_record_hash_mismatch_even_if_id_matches_cannot_pass(tmp_path: Pat
     try:
         content = POS.read_text(encoding="utf-8")
         report_tmp = tmp_path / "report.md"
-        rec_payload: dict = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "0"*64, "artifact_id": "fixture-market-outlook-pos", "executed_at": "2026-08-18T10:00:00Z"}]}
+        rec_payload: dict = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "0"*64, "artifact_id": "fixture-market-outlook-pos", "executed_at": "2026-08-18T10:00:00Z", "execution_source": "manual_checklist_attestation", "evidence": "report-section:Monitoring signals", "route": "market-outlook"}]}
         rec_path, rel = _write_record_file(record_dir, "record.json", rec_payload)
         placeholder = content.replace("report-section:Monitoring signals", f"audit-record:{rel}#r1@2026-08-18T10:00:00Z", 1)
         placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', f'"evidence": "audit-record:{rel}#r1@2026-08-18T10:00:00Z"', 1)
         m = re.search(r'"artifact_id"\s*:\s*"([^"]+)"', placeholder)
         aid = m.group(1) if m else "fixture-market-outlook-pos"
-        placeholder = placeholder.replace("some-other-artifact", aid)  # ensure id will match
+        placeholder = placeholder.replace("some-other-artifact", aid)
         report_tmp.write_text(placeholder, encoding="utf-8")
-        sha = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
-        # Intentionally keep wrong hash (0*64) but correct id
         rec_payload["records"][0]["artifact_sha256"] = "0"*64
         rec_payload["records"][0]["artifact_id"] = aid
         rec_path.write_text(json.dumps(rec_payload), encoding="utf-8")
         proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
         assert proc.returncode == 2, proc.stdout
         data = json.loads(proc.stdout)
-        # Should fail on sha mismatch even though id matched
         assert any("artifact_sha256" in b or "artifact" in b.lower() for b in data["blocking"])
         assert any("does not match" in b for b in data["blocking"])
     finally:
@@ -246,8 +234,7 @@ def test_audit_record_id_mismatch_even_if_hash_matches_cannot_pass(tmp_path: Pat
     try:
         content = POS.read_text(encoding="utf-8")
         report_tmp = tmp_path / "report.md"
-        # First compute real sha
-        rec_payload: dict = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "placeholder", "artifact_id": "wrong-id", "executed_at": "2026-08-18T10:00:00Z"}]}
+        rec_payload: dict = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "placeholder", "artifact_id": "wrong-id", "executed_at": "2026-08-18T10:00:00Z", "execution_source": "manual_checklist_attestation", "evidence": "report-section:Monitoring signals", "route": "market-outlook"}]}
         rec_path, rel = _write_record_file(record_dir, "record.json", rec_payload)
         placeholder = content.replace("report-section:Monitoring signals", f"audit-record:{rel}#r1@2026-08-18T10:00:00Z", 1)
         placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', f'"evidence": "audit-record:{rel}#r1@2026-08-18T10:00:00Z"', 1)
@@ -270,7 +257,7 @@ def test_audit_record_execution_source_mismatch_cannot_pass(tmp_path: Path) -> N
     try:
         content = POS.read_text(encoding="utf-8")
         report_tmp = tmp_path / "report.md"
-        rec_payload: dict = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "placeholder", "artifact_id": "placeholder", "executed_at": "2026-08-18T10:00:00Z", "execution_source": "process_node_evidence"}]}
+        rec_payload: dict = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "placeholder", "artifact_id": "placeholder", "executed_at": "2026-08-18T10:00:00Z", "execution_source": "process_node_evidence", "evidence": "report-section:Monitoring signals", "route": "market-outlook"}]}
         rec_path, rel = _write_record_file(record_dir, "record.json", rec_payload)
         placeholder = content.replace("report-section:Monitoring signals", f"audit-record:{rel}#r1@2026-08-18T10:00:00Z", 1)
         placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', f'"evidence": "audit-record:{rel}#r1@2026-08-18T10:00:00Z"', 1)
@@ -280,7 +267,6 @@ def test_audit_record_execution_source_mismatch_cannot_pass(tmp_path: Path) -> N
         sha = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
         rec_payload["records"][0]["artifact_sha256"] = sha
         rec_payload["records"][0]["artifact_id"] = aid
-        # keep process source (mismatch for manual)
         rec_path.write_text(json.dumps(rec_payload), encoding="utf-8")
         proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
         assert proc.returncode == 2, proc.stdout
@@ -296,7 +282,7 @@ def test_audit_record_legacy_source_cannot_pass(tmp_path: Path) -> None:
     try:
         content = POS.read_text(encoding="utf-8")
         report_tmp = tmp_path / "report.md"
-        rec_payload: dict = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "placeholder", "artifact_id": "placeholder", "executed_at": "2026-08-18T10:00:00Z", "execution_source": "legacy_self_attested"}]}
+        rec_payload: dict = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "placeholder", "artifact_id": "placeholder", "executed_at": "2026-08-18T10:00:00Z", "execution_source": "legacy_self_attested", "evidence": "report-section:Monitoring signals", "route": "market-outlook"}]}
         rec_path, rel = _write_record_file(record_dir, "record.json", rec_payload)
         placeholder = content.replace("report-section:Monitoring signals", f"audit-record:{rel}#r1@2026-08-18T10:00:00Z", 1)
         placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', f'"evidence": "audit-record:{rel}#r1@2026-08-18T10:00:00Z"', 1)
@@ -311,6 +297,120 @@ def test_audit_record_legacy_source_cannot_pass(tmp_path: Path) -> None:
         assert proc.returncode == 2, proc.stdout
         data = json.loads(proc.stdout)
         assert any("execution_source" in b for b in data["blocking"])
+    finally:
+        shutil.rmtree(record_dir, ignore_errors=True)
+
+
+def test_audit_record_missing_execution_source_cannot_pass(tmp_path: Path) -> None:
+    """P1-blocker: record without execution_source must not obtain trusted pass."""
+    record_dir = _make_record_dir()
+    try:
+        content = POS.read_text(encoding="utf-8")
+        report_tmp = tmp_path / "report.md"
+        rec_payload: dict = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "placeholder", "artifact_id": "placeholder", "executed_at": "2026-08-18T10:00:00Z", "evidence": "report-section:Monitoring signals", "route": "market-outlook"}]}
+        rec_path, rel = _write_record_file(record_dir, "record.json", rec_payload)
+        placeholder = content.replace("report-section:Monitoring signals", f"audit-record:{rel}#r1@2026-08-18T10:00:00Z", 1)
+        placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', f'"evidence": "audit-record:{rel}#r1@2026-08-18T10:00:00Z"', 1)
+        m = re.search(r'"artifact_id"\s*:\s*"([^"]+)"', placeholder)
+        aid = m.group(1) if m else "fixture-market-outlook-pos"
+        report_tmp.write_text(placeholder, encoding="utf-8")
+        sha = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
+        rec_payload["records"][0]["artifact_sha256"] = sha
+        rec_payload["records"][0]["artifact_id"] = aid
+        rec_path.write_text(json.dumps(rec_payload), encoding="utf-8")
+        proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
+        assert proc.returncode == 2, proc.stdout
+        data = json.loads(proc.stdout)
+        assert any("execution_source" in b.lower() and "missing" in b.lower() for b in data["blocking"])
+        # Ensure JSON does not伪造为 manual_checklist_attestation
+        audit = next(a for a in data["audits"] if a["audit_id"] == "market-outlook-audit")
+        assert audit["status"] != "pass"
+    finally:
+        shutil.rmtree(record_dir, ignore_errors=True)
+
+
+def test_audit_record_missing_evidence_cannot_pass(tmp_path: Path) -> None:
+    """P1-blocker: record that only self-declares passed without referencing checklist/section must not pass."""
+    record_dir = _make_record_dir()
+    try:
+        content = POS.read_text(encoding="utf-8")
+        report_tmp = tmp_path / "report.md"
+        rec_payload: dict = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "placeholder", "artifact_id": "placeholder", "executed_at": "2026-08-18T10:00:00Z", "execution_source": "manual_checklist_attestation", "route": "market-outlook"}]}
+        rec_path, rel = _write_record_file(record_dir, "record.json", rec_payload)
+        placeholder = content.replace("report-section:Monitoring signals", f"audit-record:{rel}#r1@2026-08-18T10:00:00Z", 1)
+        placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', f'"evidence": "audit-record:{rel}#r1@2026-08-18T10:00:00Z"', 1)
+        m = re.search(r'"artifact_id"\s*:\s*"([^"]+)"', placeholder)
+        aid = m.group(1) if m else "fixture-market-outlook-pos"
+        report_tmp.write_text(placeholder, encoding="utf-8")
+        sha = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
+        rec_payload["records"][0]["artifact_sha256"] = sha
+        rec_payload["records"][0]["artifact_id"] = aid
+        rec_path.write_text(json.dumps(rec_payload), encoding="utf-8")
+        proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
+        assert proc.returncode == 2, proc.stdout
+        data = json.loads(proc.stdout)
+        assert any("evidence" in b.lower() and "missing" in b.lower() for b in data["blocking"])
+    finally:
+        shutil.rmtree(record_dir, ignore_errors=True)
+
+
+def test_audit_record_duplicate_cannot_pass(tmp_path: Path) -> None:
+    """P1/P2: duplicate record (same id+timestamp) must fail closed, order-independent."""
+    record_dir = _make_record_dir()
+    try:
+        content = POS.read_text(encoding="utf-8")
+        report_tmp = tmp_path / "report.md"
+        # Two records with same id+timestamp but different status/evidence - should be ambiguous
+        rec_payload = {"records": [
+            {"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "placeholder", "artifact_id": "placeholder", "executed_at": "2026-08-18T10:00:00Z", "execution_source": "manual_checklist_attestation", "evidence": "report-section:Monitoring signals", "route": "market-outlook"},
+            {"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "partial", "artifact_sha256": "placeholder", "artifact_id": "placeholder", "executed_at": "2026-08-18T10:00:00Z", "execution_source": "manual_checklist_attestation", "evidence": "report-section:Monitoring signals", "route": "market-outlook"},
+        ]}
+        rec_path, rel = _write_record_file(record_dir, "record.json", rec_payload)
+        placeholder = content.replace("report-section:Monitoring signals", f"audit-record:{rel}#r1@2026-08-18T10:00:00Z", 1)
+        placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', f'"evidence": "audit-record:{rel}#r1@2026-08-18T10:00:00Z"', 1)
+        m = re.search(r'"artifact_id"\s*:\s*"([^"]+)"', placeholder)
+        aid = m.group(1) if m else "fixture-market-outlook-pos"
+        report_tmp.write_text(placeholder, encoding="utf-8")
+        sha = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
+        for rec in rec_payload["records"]:
+            rec["artifact_sha256"] = sha
+            rec["artifact_id"] = aid
+        rec_path.write_text(json.dumps(rec_payload), encoding="utf-8")
+        proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
+        assert proc.returncode == 2, proc.stdout
+        data = json.loads(proc.stdout)
+        assert any("ambiguous" in b.lower() or "duplicate" in b.lower() for b in data["blocking"])
+        # Also test reverse order (partial first, passed second) must also fail
+        rec_payload["records"] = list(reversed(rec_payload["records"]))
+        rec_path.write_text(json.dumps(rec_payload), encoding="utf-8")
+        proc2 = _run_report(report_tmp, "--strict", "--require-contract", "--json")
+        assert proc2.returncode == 2, proc2.stdout
+        assert any("ambiguous" in b.lower() or "duplicate" in b.lower() for b in json.loads(proc2.stdout)["blocking"])
+    finally:
+        shutil.rmtree(record_dir, ignore_errors=True)
+
+
+def test_audit_record_wrong_route_cannot_pass(tmp_path: Path) -> None:
+    """P2: route binding - record for different route must not pass."""
+    record_dir = _make_record_dir()
+    try:
+        content = POS.read_text(encoding="utf-8")
+        report_tmp = tmp_path / "report.md"
+        rec_payload: dict = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "placeholder", "artifact_id": "placeholder", "executed_at": "2026-08-18T10:00:00Z", "execution_source": "manual_checklist_attestation", "evidence": "report-section:Monitoring signals", "route": "technical-deep-dive"}]}
+        rec_path, rel = _write_record_file(record_dir, "record.json", rec_payload)
+        placeholder = content.replace("report-section:Monitoring signals", f"audit-record:{rel}#r1@2026-08-18T10:00:00Z", 1)
+        placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', f'"evidence": "audit-record:{rel}#r1@2026-08-18T10:00:00Z"', 1)
+        m = re.search(r'"artifact_id"\s*:\s*"([^"]+)"', placeholder)
+        aid = m.group(1) if m else "fixture-market-outlook-pos"
+        report_tmp.write_text(placeholder, encoding="utf-8")
+        sha = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
+        rec_payload["records"][0]["artifact_sha256"] = sha
+        rec_payload["records"][0]["artifact_id"] = aid
+        rec_path.write_text(json.dumps(rec_payload), encoding="utf-8")
+        proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
+        assert proc.returncode == 2, proc.stdout
+        data = json.loads(proc.stdout)
+        assert any("route" in b.lower() and ("mismatch" in b.lower() or "does not match" in b.lower()) for b in data["blocking"])
     finally:
         shutil.rmtree(record_dir, ignore_errors=True)
 
@@ -334,13 +434,11 @@ def test_json_distinguishes_execution_sources(tmp_path: Path) -> None:
     # process_node_evidence presence: mid-research-review-audit via shared-workflow pack
     # Use a direct audit_evidence check for process
     from audit_evidence import validate_evidence_reference
-    # Simulate process record validation
     rec_dir = _make_record_dir()
     try:
-        payload = {"records": [{"record_id": "p1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "mid-research-review-audit", "status": "passed", "artifact_sha256": "b"*64, "executed_at": "2026-08-18T10:00:00Z", "execution_source": "process_node_evidence"}]}
+        payload = {"records": [{"record_id": "p1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "mid-research-review-audit", "status": "passed", "artifact_sha256": "b"*64, "executed_at": "2026-08-18T10:00:00Z", "execution_source": "process_node_evidence", "evidence": "report-section:Monitoring signals", "route": "market-outlook"}]}
         rec_path, rel = _write_record_file(rec_dir, "prec.json", payload)
-        # Validate as process
-        res = validate_evidence_reference(f"audit-record:{rel}#p1@2026-08-18T10:00:00Z", base_dir=ROOT, strict=True, execution_type="process", expected_audit_id="mid-research-review-audit", expected_artifact_sha256="b"*64)
+        res = validate_evidence_reference(f"audit-record:{rel}#p1@2026-08-18T10:00:00Z", base_dir=ROOT, strict=True, execution_type="process", expected_audit_id="mid-research-review-audit", expected_artifact_sha256="b"*64, expected_route="market-outlook", artifact_text="## Monitoring signals\n\ncontent")
         assert res.is_valid, res.errors
         assert res.provenance and res.provenance["verified"] is True
     finally:

--- a/tests/test_issue401_checklist_not_execution.py
+++ b/tests/test_issue401_checklist_not_execution.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -40,34 +41,41 @@ def _run_report(path: Path, *extra: str, pack: Path = PACK) -> subprocess.Comple
 def _write_report_with_evidence(tmp_path: Path, evidence_locator: str) -> Path:
     """Create a market-outlook report where the manual audit evidence is replaced."""
     content = POS.read_text(encoding="utf-8")
-    # Replace the first occurrence (status block) and the contract block's first matching audit
     content = content.replace("report-section:Monitoring signals", evidence_locator, 1)
-    # Contract block also contains the same locator for forward-looking etc.; leave other audits untouched
-    # For market-outlook-audit only, we replaced one; the contract still references the same locator for that audit
-    # Ensure contract's market-outlook-audit evidence is also updated if it still references the old locator
-    # The contract audit list includes market-outlook-audit as first entry; we handle both by second replace
     if content.count("report-section:Monitoring signals") >= 1:
-        # The remaining occurrences are for other audits (forward-looking, etc.); keep them as-is for positive path
-        # But for our negative test we only care about market-outlook-audit, which is the first replacement above
         pass
-    # If the evidence_locator is audit-record, also patch contract block to match (so contract validation sees same)
     if evidence_locator.startswith("audit-record:"):
-        # contract block's market-outlook-audit evidence is the first audit entry; patch it similarly
-        # Do a targeted JSON replace for that specific audit id
         content = content.replace(
             '"id": "market-outlook-audit", "status": "passed", "evidence": "report-section:Monitoring signals"',
             f'"id": "market-outlook-audit", "status": "passed", "evidence": "{evidence_locator}"',
         )
-        # Fallback for fixtures where contract formatting differs slightly
         if f'"evidence": "{evidence_locator}"' not in content:
-            # Already patched via first replace if contract used same string
             pass
     report = tmp_path / "report.md"
     report.write_text(content, encoding="utf-8")
-    # When evidence is audit-record pointing to tmp/test_record.json, we must also ensure the contract's evidence matches,
-    # otherwise contract validation will still reference report-section and pass while status block fails. That's intentional
-    # for checklist-only negatives where contract still passes but status block fails -> overall still fail.
     return report
+
+
+def _make_record_dir() -> Path:
+    """Create an isolated directory under ROOT/tmp for audit-record files.
+
+    Using a unique subdir under ROOT/tmp keeps the relative locator inside the
+    repository root (required by _safe_path) while avoiding collisions and
+    allowing safe cleanup without touching the shared tmp/ directory itself.
+    """
+    base = ROOT / "tmp"
+    base.mkdir(parents=True, exist_ok=True)
+    # mkdtemp under base gives a unique isolated folder like tmp/tmpxxx
+    tmpdir = Path(tempfile.mkdtemp(dir=base))
+    return tmpdir
+
+
+def _write_record_file(dir_path: Path, filename: str, payload: dict) -> tuple[Path, str]:
+    """Write a record JSON under dir_path and return (full_path, relative_locator)."""
+    full = dir_path / filename
+    full.write_text(json.dumps(payload), encoding="utf-8")
+    rel = full.relative_to(ROOT).as_posix()
+    return full, rel
 
 
 def test_checklist_template_marker_cannot_pass_strict(tmp_path: Path) -> None:
@@ -99,128 +107,212 @@ def test_audit_record_missing_file_cannot_pass(tmp_path: Path) -> None:
 
 
 def test_audit_record_status_not_passed_cannot_pass(tmp_path: Path) -> None:
-    # Prepare a record with status=partial and correct artifact binding
-    content = POS.read_text(encoding="utf-8")
-    report_tmp = tmp_path / "report.md"
-    # First write a placeholder report to compute sha/artifact_id
-    placeholder = content.replace("report-section:Monitoring signals", "audit-record:tmp/issue401_partial.json#r1@2026-08-18T10:00:00Z", 1)
-    report_tmp.write_text(placeholder, encoding="utf-8")
-    sha = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
-    # Extract artifact_id
-    m = re.search(r'"artifact_id"\s*:\s*"([^"]+)"', placeholder)
-    aid = m.group(1) if m else "fixture-market-outlook-pos"
-    # Write record
-    rec_path = ROOT / "tmp" / "issue401_partial.json"
-    rec_path.parent.mkdir(parents=True, exist_ok=True)
-    rec_path.write_text(json.dumps({"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "partial", "artifact_sha256": sha, "artifact_id": aid, "executed_at": "2026-08-18T10:00:00Z"}]}), encoding="utf-8")
-    # Also patch contract block to reference same record
-    placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', '"evidence": "audit-record:tmp/issue401_partial.json#r1@2026-08-18T10:00:00Z"', 1)
-    # Need to recompute sha after contract patch
-    report_tmp.write_text(placeholder, encoding="utf-8")
-    sha2 = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
-    rec_path.write_text(json.dumps({"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "partial", "artifact_sha256": sha2, "artifact_id": aid, "executed_at": "2026-08-18T10:00:00Z"}]}), encoding="utf-8")
-    proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
-    # cleanup
+    record_dir = _make_record_dir()
     try:
-        rec_path.unlink(missing_ok=True)
-        try:
-            rec_path.parent.rmdir()
-        except OSError:
-            pass
-    except Exception:
-        pass
-    assert proc.returncode == 2, proc.stdout
-    data = json.loads(proc.stdout)
-    assert data["overall"] != "pass"
-    assert any("status" in b.lower() and "not passed" in b.lower() for b in data["blocking"])
+        content = POS.read_text(encoding="utf-8")
+        report_tmp = tmp_path / "report.md"
+        placeholder = content.replace("report-section:Monitoring signals", "audit-record:tmp/placeholder#r1@2026-08-18T10:00:00Z", 1)
+        # temporary placeholder to compute aid
+        m = re.search(r'"artifact_id"\s*:\s*"([^"]+)"', placeholder)
+        aid = m.group(1) if m else "fixture-market-outlook-pos"
+        # create isolated record file
+        rec_payload = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "partial", "artifact_sha256": "x"*64, "artifact_id": aid, "executed_at": "2026-08-18T10:00:00Z"}]}
+        rec_path, rel = _write_record_file(record_dir, "record.json", rec_payload)
+        # patch placeholder to use real rel
+        placeholder = content.replace("report-section:Monitoring signals", f"audit-record:{rel}#r1@2026-08-18T10:00:00Z", 1)
+        placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', f'"evidence": "audit-record:{rel}#r1@2026-08-18T10:00:00Z"', 1)
+        report_tmp.write_text(placeholder, encoding="utf-8")
+        sha2 = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
+        rec_payload["records"][0]["artifact_sha256"] = sha2
+        rec_path.write_text(json.dumps(rec_payload), encoding="utf-8")
+        proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
+        assert proc.returncode == 2, proc.stdout
+        data = json.loads(proc.stdout)
+        assert data["overall"] != "pass"
+        assert any("status" in b.lower() and "not passed" in b.lower() for b in data["blocking"])
+    finally:
+        shutil.rmtree(record_dir, ignore_errors=True)
 
 
 def test_audit_record_wrong_artifact_cannot_pass(tmp_path: Path) -> None:
-    content = POS.read_text(encoding="utf-8")
-    report_tmp = tmp_path / "report.md"
-    placeholder = content.replace("report-section:Monitoring signals", "audit-record:tmp/issue401_wrong_artifact.json#r1@2026-08-18T10:00:00Z", 1)
-    placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', '"evidence": "audit-record:tmp/issue401_wrong_artifact.json#r1@2026-08-18T10:00:00Z"', 1)
-    report_tmp.write_text(placeholder, encoding="utf-8")
-    sha = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
-    m = re.search(r'"artifact_id"\s*:\s*"([^"]+)"', placeholder)
-    aid = m.group(1) if m else "fixture-market-outlook-pos"
-    rec_path = ROOT / "tmp" / "issue401_wrong_artifact.json"
-    rec_path.parent.mkdir(parents=True, exist_ok=True)
-    # Intentionally write a different artifact binding
-    rec_path.write_text(json.dumps({"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "0"*64, "artifact_id": "some-other-artifact", "executed_at": "2026-08-18T10:00:00Z"}]}), encoding="utf-8")
-    proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
+    record_dir = _make_record_dir()
     try:
-        rec_path.unlink(missing_ok=True)
-        try:
-            rec_path.parent.rmdir()
-        except OSError:
-            pass
-    except Exception:
-        pass
-    assert proc.returncode == 2, proc.stdout
-    data = json.loads(proc.stdout)
-    assert any("artifact" in b.lower() and "mismatch" in b.lower() for b in data["blocking"])
+        content = POS.read_text(encoding="utf-8")
+        report_tmp = tmp_path / "report.md"
+        rec_payload = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "0"*64, "artifact_id": "some-other-artifact", "executed_at": "2026-08-18T10:00:00Z"}]}
+        rec_path, rel = _write_record_file(record_dir, "record.json", rec_payload)
+        placeholder = content.replace("report-section:Monitoring signals", f"audit-record:{rel}#r1@2026-08-18T10:00:00Z", 1)
+        placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', f'"evidence": "audit-record:{rel}#r1@2026-08-18T10:00:00Z"', 1)
+        report_tmp.write_text(placeholder, encoding="utf-8")
+        proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
+        assert proc.returncode == 2, proc.stdout
+        data = json.loads(proc.stdout)
+        # Each provided artifact field is now independently fail-closed (P1)
+        assert any("artifact" in b.lower() and ("mismatch" in b.lower() or "does not match" in b.lower()) for b in data["blocking"])
+    finally:
+        shutil.rmtree(record_dir, ignore_errors=True)
 
 
 def test_audit_record_wrong_audit_id_cannot_pass(tmp_path: Path) -> None:
-    content = POS.read_text(encoding="utf-8")
-    report_tmp = tmp_path / "report.md"
-    placeholder = content.replace("report-section:Monitoring signals", "audit-record:tmp/issue401_wrong_audit.json#r1@2026-08-18T10:00:00Z", 1)
-    placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', '"evidence": "audit-record:tmp/issue401_wrong_audit.json#r1@2026-08-18T10:00:00Z"', 1)
-    report_tmp.write_text(placeholder, encoding="utf-8")
-    sha = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
-    m = re.search(r'"artifact_id"\s*:\s*"([^"]+)"', placeholder)
-    aid = m.group(1) if m else "fixture-market-outlook-pos"
-    rec_path = ROOT / "tmp" / "issue401_wrong_audit.json"
-    rec_path.parent.mkdir(parents=True, exist_ok=True)
-    rec_path.write_text(json.dumps({"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "final-audit", "status": "passed", "artifact_sha256": sha, "artifact_id": aid, "executed_at": "2026-08-18T10:00:00Z"}]}), encoding="utf-8")
-    proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
+    record_dir = _make_record_dir()
     try:
-        rec_path.unlink(missing_ok=True)
-        try:
-            rec_path.parent.rmdir()
-        except OSError:
-            pass
-    except Exception:
-        pass
-    assert proc.returncode == 2, proc.stdout
-    blocking = json.loads(proc.stdout)["blocking"]
-    assert any("audit" in b.lower() and ("mismatch" in b.lower() or "does not match" in b.lower()) for b in blocking)
+        content = POS.read_text(encoding="utf-8")
+        report_tmp = tmp_path / "report.md"
+        placeholder = content.replace("report-section:Monitoring signals", "audit-record:tmp/placeholder#r1@2026-08-18T10:00:00Z", 1)
+        m = re.search(r'"artifact_id"\s*:\s*"([^"]+)"', placeholder)
+        aid = m.group(1) if m else "fixture-market-outlook-pos"
+        # pre-write to compute sha
+        tmp_placeholder = placeholder.replace("audit-record:tmp/placeholder#r1@2026-08-18T10:00:00Z", "audit-record:tmp/dummy#r1@2026-08-18T10:00:00Z", 1)
+        report_tmp.write_text(tmp_placeholder, encoding="utf-8")
+        sha_probe = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
+        rec_payload = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "final-audit", "status": "passed", "artifact_sha256": sha_probe, "artifact_id": aid, "executed_at": "2026-08-18T10:00:00Z"}]}
+        rec_path, rel = _write_record_file(record_dir, "record.json", rec_payload)
+        placeholder = content.replace("report-section:Monitoring signals", f"audit-record:{rel}#r1@2026-08-18T10:00:00Z", 1)
+        placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', f'"evidence": "audit-record:{rel}#r1@2026-08-18T10:00:00Z"', 1)
+        report_tmp.write_text(placeholder, encoding="utf-8")
+        sha = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
+        rec_payload["records"][0]["artifact_sha256"] = sha
+        rec_path.write_text(json.dumps(rec_payload), encoding="utf-8")
+        proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
+        assert proc.returncode == 2, proc.stdout
+        blocking = json.loads(proc.stdout)["blocking"]
+        assert any("audit" in b.lower() and ("mismatch" in b.lower() or "does not match" in b.lower()) for b in blocking)
+    finally:
+        shutil.rmtree(record_dir, ignore_errors=True)
 
 
 def test_valid_audit_record_with_binding_passes(tmp_path: Path) -> None:
-    content = POS.read_text(encoding="utf-8")
-    report_tmp = tmp_path / "report.md"
-    # Use a unique tmp record path under repo tmp so base_dir resolution works
-    rec_rel = "tmp/issue401_valid.json"
-    placeholder = content.replace("report-section:Monitoring signals", f"audit-record:{rec_rel}#r1@2026-08-18T10:00:00Z", 1)
-    # also patch contract
-    placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', f'"evidence": "audit-record:{rec_rel}#r1@2026-08-18T10:00:00Z"', 1)
-    report_tmp.write_text(placeholder, encoding="utf-8")
-    sha = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
-    m = re.search(r'"artifact_id"\s*:\s*"([^"]+)"', placeholder)
-    aid = m.group(1) if m else "fixture-market-outlook-pos"
-    rec_path = ROOT / rec_rel
-    rec_path.parent.mkdir(parents=True, exist_ok=True)
-    rec_path.write_text(json.dumps({"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": sha, "artifact_id": aid, "executed_at": "2026-08-18T10:00:00Z", "execution_source": "manual_checklist_attestation"}]}), encoding="utf-8")
-    # Recompute after ensuring report content final (sha already matches)
-    proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
+    record_dir = _make_record_dir()
     try:
-        rec_path.unlink(missing_ok=True)
-        try:
-            rec_path.parent.rmdir()
-        except OSError:
-            pass
-    except Exception:
-        pass
-    assert proc.returncode == 0, proc.stdout
-    data = json.loads(proc.stdout)
-    assert data["overall"] == "pass"
-    audit = next(a for a in data["audits"] if a["audit_id"] == "market-outlook-audit")
-    assert audit["status"] == "pass"
-    assert audit["execution_source"] == "manual_checklist_attestation"
-    assert audit["evidence_provenance"][0]["verified"] is True
-    assert audit["evidence_provenance"][0]["kind"] == "audit_record"
+        content = POS.read_text(encoding="utf-8")
+        report_tmp = tmp_path / "report.md"
+        rec_payload: dict = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "placeholder", "artifact_id": "fixture-market-outlook-pos", "executed_at": "2026-08-18T10:00:00Z", "execution_source": "manual_checklist_attestation"}]}
+        rec_path, rel = _write_record_file(record_dir, "record.json", rec_payload)
+        placeholder = content.replace("report-section:Monitoring signals", f"audit-record:{rel}#r1@2026-08-18T10:00:00Z", 1)
+        placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', f'"evidence": "audit-record:{rel}#r1@2026-08-18T10:00:00Z"', 1)
+        # Extract aid
+        m = re.search(r'"artifact_id"\s*:\s*"([^"]+)"', placeholder)
+        aid = m.group(1) if m else "fixture-market-outlook-pos"
+        report_tmp.write_text(placeholder, encoding="utf-8")
+        sha = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
+        rec_payload["records"][0]["artifact_sha256"] = sha
+        rec_payload["records"][0]["artifact_id"] = aid
+        rec_path.write_text(json.dumps(rec_payload), encoding="utf-8")
+        proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
+        assert proc.returncode == 0, proc.stdout
+        data = json.loads(proc.stdout)
+        assert data["overall"] == "pass"
+        audit = next(a for a in data["audits"] if a["audit_id"] == "market-outlook-audit")
+        assert audit["status"] == "pass"
+        assert audit["execution_source"] == "manual_checklist_attestation"
+        assert audit["evidence_provenance"][0]["verified"] is True
+        assert audit["evidence_provenance"][0]["kind"] == "audit_record"
+    finally:
+        shutil.rmtree(record_dir, ignore_errors=True)
+
+
+def test_audit_record_hash_mismatch_even_if_id_matches_cannot_pass(tmp_path: Path) -> None:
+    """P1 regression: id correct but hash wrong must still fail (AND semantics)."""
+    record_dir = _make_record_dir()
+    try:
+        content = POS.read_text(encoding="utf-8")
+        report_tmp = tmp_path / "report.md"
+        rec_payload: dict = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "0"*64, "artifact_id": "fixture-market-outlook-pos", "executed_at": "2026-08-18T10:00:00Z"}]}
+        rec_path, rel = _write_record_file(record_dir, "record.json", rec_payload)
+        placeholder = content.replace("report-section:Monitoring signals", f"audit-record:{rel}#r1@2026-08-18T10:00:00Z", 1)
+        placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', f'"evidence": "audit-record:{rel}#r1@2026-08-18T10:00:00Z"', 1)
+        m = re.search(r'"artifact_id"\s*:\s*"([^"]+)"', placeholder)
+        aid = m.group(1) if m else "fixture-market-outlook-pos"
+        placeholder = placeholder.replace("some-other-artifact", aid)  # ensure id will match
+        report_tmp.write_text(placeholder, encoding="utf-8")
+        sha = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
+        # Intentionally keep wrong hash (0*64) but correct id
+        rec_payload["records"][0]["artifact_sha256"] = "0"*64
+        rec_payload["records"][0]["artifact_id"] = aid
+        rec_path.write_text(json.dumps(rec_payload), encoding="utf-8")
+        proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
+        assert proc.returncode == 2, proc.stdout
+        data = json.loads(proc.stdout)
+        # Should fail on sha mismatch even though id matched
+        assert any("artifact_sha256" in b or "artifact" in b.lower() for b in data["blocking"])
+        assert any("does not match" in b for b in data["blocking"])
+    finally:
+        shutil.rmtree(record_dir, ignore_errors=True)
+
+
+def test_audit_record_id_mismatch_even_if_hash_matches_cannot_pass(tmp_path: Path) -> None:
+    """P1 regression: hash correct but id wrong must still fail."""
+    record_dir = _make_record_dir()
+    try:
+        content = POS.read_text(encoding="utf-8")
+        report_tmp = tmp_path / "report.md"
+        # First compute real sha
+        rec_payload: dict = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "placeholder", "artifact_id": "wrong-id", "executed_at": "2026-08-18T10:00:00Z"}]}
+        rec_path, rel = _write_record_file(record_dir, "record.json", rec_payload)
+        placeholder = content.replace("report-section:Monitoring signals", f"audit-record:{rel}#r1@2026-08-18T10:00:00Z", 1)
+        placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', f'"evidence": "audit-record:{rel}#r1@2026-08-18T10:00:00Z"', 1)
+        report_tmp.write_text(placeholder, encoding="utf-8")
+        sha = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
+        rec_payload["records"][0]["artifact_sha256"] = sha
+        rec_payload["records"][0]["artifact_id"] = "wrong-id"
+        rec_path.write_text(json.dumps(rec_payload), encoding="utf-8")
+        proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
+        assert proc.returncode == 2, proc.stdout
+        data = json.loads(proc.stdout)
+        assert any("artifact_id" in b or "artifact" in b.lower() for b in data["blocking"])
+    finally:
+        shutil.rmtree(record_dir, ignore_errors=True)
+
+
+def test_audit_record_execution_source_mismatch_cannot_pass(tmp_path: Path) -> None:
+    """P2 regression: manual audit cannot be backed by process record."""
+    record_dir = _make_record_dir()
+    try:
+        content = POS.read_text(encoding="utf-8")
+        report_tmp = tmp_path / "report.md"
+        rec_payload: dict = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "placeholder", "artifact_id": "placeholder", "executed_at": "2026-08-18T10:00:00Z", "execution_source": "process_node_evidence"}]}
+        rec_path, rel = _write_record_file(record_dir, "record.json", rec_payload)
+        placeholder = content.replace("report-section:Monitoring signals", f"audit-record:{rel}#r1@2026-08-18T10:00:00Z", 1)
+        placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', f'"evidence": "audit-record:{rel}#r1@2026-08-18T10:00:00Z"', 1)
+        m = re.search(r'"artifact_id"\s*:\s*"([^"]+)"', placeholder)
+        aid = m.group(1) if m else "fixture-market-outlook-pos"
+        report_tmp.write_text(placeholder, encoding="utf-8")
+        sha = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
+        rec_payload["records"][0]["artifact_sha256"] = sha
+        rec_payload["records"][0]["artifact_id"] = aid
+        # keep process source (mismatch for manual)
+        rec_path.write_text(json.dumps(rec_payload), encoding="utf-8")
+        proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
+        assert proc.returncode == 2, proc.stdout
+        data = json.loads(proc.stdout)
+        assert any("execution_source" in b for b in data["blocking"])
+    finally:
+        shutil.rmtree(record_dir, ignore_errors=True)
+
+
+def test_audit_record_legacy_source_cannot_pass(tmp_path: Path) -> None:
+    """P2 regression: legacy_self_attested record must not be trusted in strict."""
+    record_dir = _make_record_dir()
+    try:
+        content = POS.read_text(encoding="utf-8")
+        report_tmp = tmp_path / "report.md"
+        rec_payload: dict = {"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "placeholder", "artifact_id": "placeholder", "executed_at": "2026-08-18T10:00:00Z", "execution_source": "legacy_self_attested"}]}
+        rec_path, rel = _write_record_file(record_dir, "record.json", rec_payload)
+        placeholder = content.replace("report-section:Monitoring signals", f"audit-record:{rel}#r1@2026-08-18T10:00:00Z", 1)
+        placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', f'"evidence": "audit-record:{rel}#r1@2026-08-18T10:00:00Z"', 1)
+        m = re.search(r'"artifact_id"\s*:\s*"([^"]+)"', placeholder)
+        aid = m.group(1) if m else "fixture-market-outlook-pos"
+        report_tmp.write_text(placeholder, encoding="utf-8")
+        sha = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
+        rec_payload["records"][0]["artifact_sha256"] = sha
+        rec_payload["records"][0]["artifact_id"] = aid
+        rec_path.write_text(json.dumps(rec_payload), encoding="utf-8")
+        proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
+        assert proc.returncode == 2, proc.stdout
+        data = json.loads(proc.stdout)
+        assert any("execution_source" in b for b in data["blocking"])
+    finally:
+        shutil.rmtree(record_dir, ignore_errors=True)
 
 
 def test_json_distinguishes_execution_sources(tmp_path: Path) -> None:
@@ -239,3 +331,17 @@ def test_json_distinguishes_execution_sources(tmp_path: Path) -> None:
     data2 = json.loads(proc2.stdout)
     manual = next(a for a in data2["audits"] if a["audit_id"] == "market-outlook-audit")
     assert manual["execution_source"] == "legacy_self_attested"
+    # process_node_evidence presence: mid-research-review-audit via shared-workflow pack
+    # Use a direct audit_evidence check for process
+    from audit_evidence import validate_evidence_reference
+    # Simulate process record validation
+    rec_dir = _make_record_dir()
+    try:
+        payload = {"records": [{"record_id": "p1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "mid-research-review-audit", "status": "passed", "artifact_sha256": "b"*64, "executed_at": "2026-08-18T10:00:00Z", "execution_source": "process_node_evidence"}]}
+        rec_path, rel = _write_record_file(rec_dir, "prec.json", payload)
+        # Validate as process
+        res = validate_evidence_reference(f"audit-record:{rel}#p1@2026-08-18T10:00:00Z", base_dir=ROOT, strict=True, execution_type="process", expected_audit_id="mid-research-review-audit", expected_artifact_sha256="b"*64)
+        assert res.is_valid, res.errors
+        assert res.provenance and res.provenance["verified"] is True
+    finally:
+        shutil.rmtree(rec_dir, ignore_errors=True)

--- a/tests/test_issue401_checklist_not_execution.py
+++ b/tests/test_issue401_checklist_not_execution.py
@@ -1,0 +1,241 @@
+"""Issue #401 negatives: checklist definition cannot masquerade as execution evidence.
+
+Covers the acceptance criteria:
+
+- checklist marker alone (even if exists) cannot obtain trusted pass in strict
+- forged item id, missing checklist, unchecked template (all strict) -> partial/not_run
+- audit-record missing / status != passed / artifact mismatch / audit_id mismatch -> fail closed
+- valid audit-record with artifact binding -> pass
+- JSON distinguishes 4 execution sources
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "audit_report.py"
+POS = ROOT / "tests" / "fixtures" / "audit" / "market-outlook-pos.md"
+PACK = ROOT / "tests" / "fixtures" / "audit" / "research-pack-pos.md"
+
+sys.path.insert(0, str(ROOT / "scripts"))
+
+
+def _run_report(path: Path, *extra: str, pack: Path = PACK) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(path), "--research-pack", str(pack), *extra],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_report_with_evidence(tmp_path: Path, evidence_locator: str) -> Path:
+    """Create a market-outlook report where the manual audit evidence is replaced."""
+    content = POS.read_text(encoding="utf-8")
+    # Replace the first occurrence (status block) and the contract block's first matching audit
+    content = content.replace("report-section:Monitoring signals", evidence_locator, 1)
+    # Contract block also contains the same locator for forward-looking etc.; leave other audits untouched
+    # For market-outlook-audit only, we replaced one; the contract still references the same locator for that audit
+    # Ensure contract's market-outlook-audit evidence is also updated if it still references the old locator
+    # The contract audit list includes market-outlook-audit as first entry; we handle both by second replace
+    if content.count("report-section:Monitoring signals") >= 1:
+        # The remaining occurrences are for other audits (forward-looking, etc.); keep them as-is for positive path
+        # But for our negative test we only care about market-outlook-audit, which is the first replacement above
+        pass
+    # If the evidence_locator is audit-record, also patch contract block to match (so contract validation sees same)
+    if evidence_locator.startswith("audit-record:"):
+        # contract block's market-outlook-audit evidence is the first audit entry; patch it similarly
+        # Do a targeted JSON replace for that specific audit id
+        content = content.replace(
+            '"id": "market-outlook-audit", "status": "passed", "evidence": "report-section:Monitoring signals"',
+            f'"id": "market-outlook-audit", "status": "passed", "evidence": "{evidence_locator}"',
+        )
+        # Fallback for fixtures where contract formatting differs slightly
+        if f'"evidence": "{evidence_locator}"' not in content:
+            # Already patched via first replace if contract used same string
+            pass
+    report = tmp_path / "report.md"
+    report.write_text(content, encoding="utf-8")
+    # When evidence is audit-record pointing to tmp/test_record.json, we must also ensure the contract's evidence matches,
+    # otherwise contract validation will still reference report-section and pass while status block fails. That's intentional
+    # for checklist-only negatives where contract still passes but status block fails -> overall still fail.
+    return report
+
+
+def test_checklist_template_marker_cannot_pass_strict(tmp_path: Path) -> None:
+    report = _write_report_with_evidence(tmp_path, "checklist-item:checklists/final-audit.md#FA-001")
+    proc = _run_report(report, "--strict", "--require-contract", "--json")
+    assert proc.returncode == 2, proc.stdout
+    data = json.loads(proc.stdout)
+    assert data["overall"] != "pass"
+    audit = next(a for a in data["audits"] if a["audit_id"] == "market-outlook-audit")
+    assert audit["status"] != "pass"
+    haystack = " ".join([audit.get("reason") or ""] + data["blocking"])
+    assert "definition-only" in haystack or "audit-record" in haystack
+
+
+def test_forged_checklist_item_cannot_pass_strict(tmp_path: Path) -> None:
+    report = _write_report_with_evidence(tmp_path, "checklist-item:checklists/final-audit.md#NO_SUCH_ITEM")
+    proc = _run_report(report, "--strict", "--require-contract", "--json")
+    assert proc.returncode == 2
+    data = json.loads(proc.stdout)
+    assert data["overall"] != "pass"
+
+
+def test_audit_record_missing_file_cannot_pass(tmp_path: Path) -> None:
+    report = _write_report_with_evidence(tmp_path, "audit-record:tmp/no-such.json#r1@2026-08-18T10:00:00Z")
+    proc = _run_report(report, "--strict", "--require-contract", "--json")
+    assert proc.returncode == 2
+    data = json.loads(proc.stdout)
+    assert any("does not exist" in b or "not found" in b for b in data["blocking"])
+
+
+def test_audit_record_status_not_passed_cannot_pass(tmp_path: Path) -> None:
+    # Prepare a record with status=partial and correct artifact binding
+    content = POS.read_text(encoding="utf-8")
+    report_tmp = tmp_path / "report.md"
+    # First write a placeholder report to compute sha/artifact_id
+    placeholder = content.replace("report-section:Monitoring signals", "audit-record:tmp/issue401_partial.json#r1@2026-08-18T10:00:00Z", 1)
+    report_tmp.write_text(placeholder, encoding="utf-8")
+    sha = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
+    # Extract artifact_id
+    m = re.search(r'"artifact_id"\s*:\s*"([^"]+)"', placeholder)
+    aid = m.group(1) if m else "fixture-market-outlook-pos"
+    # Write record
+    rec_path = ROOT / "tmp" / "issue401_partial.json"
+    rec_path.parent.mkdir(parents=True, exist_ok=True)
+    rec_path.write_text(json.dumps({"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "partial", "artifact_sha256": sha, "artifact_id": aid, "executed_at": "2026-08-18T10:00:00Z"}]}), encoding="utf-8")
+    # Also patch contract block to reference same record
+    placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', '"evidence": "audit-record:tmp/issue401_partial.json#r1@2026-08-18T10:00:00Z"', 1)
+    # Need to recompute sha after contract patch
+    report_tmp.write_text(placeholder, encoding="utf-8")
+    sha2 = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
+    rec_path.write_text(json.dumps({"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "partial", "artifact_sha256": sha2, "artifact_id": aid, "executed_at": "2026-08-18T10:00:00Z"}]}), encoding="utf-8")
+    proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
+    # cleanup
+    try:
+        rec_path.unlink(missing_ok=True)
+        try:
+            rec_path.parent.rmdir()
+        except OSError:
+            pass
+    except Exception:
+        pass
+    assert proc.returncode == 2, proc.stdout
+    data = json.loads(proc.stdout)
+    assert data["overall"] != "pass"
+    assert any("status" in b.lower() and "not passed" in b.lower() for b in data["blocking"])
+
+
+def test_audit_record_wrong_artifact_cannot_pass(tmp_path: Path) -> None:
+    content = POS.read_text(encoding="utf-8")
+    report_tmp = tmp_path / "report.md"
+    placeholder = content.replace("report-section:Monitoring signals", "audit-record:tmp/issue401_wrong_artifact.json#r1@2026-08-18T10:00:00Z", 1)
+    placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', '"evidence": "audit-record:tmp/issue401_wrong_artifact.json#r1@2026-08-18T10:00:00Z"', 1)
+    report_tmp.write_text(placeholder, encoding="utf-8")
+    sha = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
+    m = re.search(r'"artifact_id"\s*:\s*"([^"]+)"', placeholder)
+    aid = m.group(1) if m else "fixture-market-outlook-pos"
+    rec_path = ROOT / "tmp" / "issue401_wrong_artifact.json"
+    rec_path.parent.mkdir(parents=True, exist_ok=True)
+    # Intentionally write a different artifact binding
+    rec_path.write_text(json.dumps({"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": "0"*64, "artifact_id": "some-other-artifact", "executed_at": "2026-08-18T10:00:00Z"}]}), encoding="utf-8")
+    proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
+    try:
+        rec_path.unlink(missing_ok=True)
+        try:
+            rec_path.parent.rmdir()
+        except OSError:
+            pass
+    except Exception:
+        pass
+    assert proc.returncode == 2, proc.stdout
+    data = json.loads(proc.stdout)
+    assert any("artifact" in b.lower() and "mismatch" in b.lower() for b in data["blocking"])
+
+
+def test_audit_record_wrong_audit_id_cannot_pass(tmp_path: Path) -> None:
+    content = POS.read_text(encoding="utf-8")
+    report_tmp = tmp_path / "report.md"
+    placeholder = content.replace("report-section:Monitoring signals", "audit-record:tmp/issue401_wrong_audit.json#r1@2026-08-18T10:00:00Z", 1)
+    placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', '"evidence": "audit-record:tmp/issue401_wrong_audit.json#r1@2026-08-18T10:00:00Z"', 1)
+    report_tmp.write_text(placeholder, encoding="utf-8")
+    sha = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
+    m = re.search(r'"artifact_id"\s*:\s*"([^"]+)"', placeholder)
+    aid = m.group(1) if m else "fixture-market-outlook-pos"
+    rec_path = ROOT / "tmp" / "issue401_wrong_audit.json"
+    rec_path.parent.mkdir(parents=True, exist_ok=True)
+    rec_path.write_text(json.dumps({"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "final-audit", "status": "passed", "artifact_sha256": sha, "artifact_id": aid, "executed_at": "2026-08-18T10:00:00Z"}]}), encoding="utf-8")
+    proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
+    try:
+        rec_path.unlink(missing_ok=True)
+        try:
+            rec_path.parent.rmdir()
+        except OSError:
+            pass
+    except Exception:
+        pass
+    assert proc.returncode == 2, proc.stdout
+    blocking = json.loads(proc.stdout)["blocking"]
+    assert any("audit" in b.lower() and ("mismatch" in b.lower() or "does not match" in b.lower()) for b in blocking)
+
+
+def test_valid_audit_record_with_binding_passes(tmp_path: Path) -> None:
+    content = POS.read_text(encoding="utf-8")
+    report_tmp = tmp_path / "report.md"
+    # Use a unique tmp record path under repo tmp so base_dir resolution works
+    rec_rel = "tmp/issue401_valid.json"
+    placeholder = content.replace("report-section:Monitoring signals", f"audit-record:{rec_rel}#r1@2026-08-18T10:00:00Z", 1)
+    # also patch contract
+    placeholder = placeholder.replace('"evidence": "report-section:Monitoring signals"', f'"evidence": "audit-record:{rec_rel}#r1@2026-08-18T10:00:00Z"', 1)
+    report_tmp.write_text(placeholder, encoding="utf-8")
+    sha = hashlib.sha256(report_tmp.read_bytes()).hexdigest()
+    m = re.search(r'"artifact_id"\s*:\s*"([^"]+)"', placeholder)
+    aid = m.group(1) if m else "fixture-market-outlook-pos"
+    rec_path = ROOT / rec_rel
+    rec_path.parent.mkdir(parents=True, exist_ok=True)
+    rec_path.write_text(json.dumps({"records": [{"record_id": "r1", "recorded_at": "2026-08-18T10:00:00Z", "audit_id": "market-outlook-audit", "status": "passed", "artifact_sha256": sha, "artifact_id": aid, "executed_at": "2026-08-18T10:00:00Z", "execution_source": "manual_checklist_attestation"}]}), encoding="utf-8")
+    # Recompute after ensuring report content final (sha already matches)
+    proc = _run_report(report_tmp, "--strict", "--require-contract", "--json")
+    try:
+        rec_path.unlink(missing_ok=True)
+        try:
+            rec_path.parent.rmdir()
+        except OSError:
+            pass
+    except Exception:
+        pass
+    assert proc.returncode == 0, proc.stdout
+    data = json.loads(proc.stdout)
+    assert data["overall"] == "pass"
+    audit = next(a for a in data["audits"] if a["audit_id"] == "market-outlook-audit")
+    assert audit["status"] == "pass"
+    assert audit["execution_source"] == "manual_checklist_attestation"
+    assert audit["evidence_provenance"][0]["verified"] is True
+    assert audit["evidence_provenance"][0]["kind"] == "audit_record"
+
+
+def test_json_distinguishes_execution_sources(tmp_path: Path) -> None:
+    # Positive fixture already distinguishes manual vs automated
+    proc = subprocess.run([sys.executable, str(SCRIPT), str(POS), "--research-pack", str(PACK), "--strict", "--require-contract", "--json"], capture_output=True, text=True)
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    sources = {a["execution_source"] for a in data["audits"]}
+    assert "manual_checklist_attestation" in sources
+    assert "automated_validator" in sources
+    # legacy in compatibility mode
+    content = POS.read_text().replace("report-section:Monitoring signals", "free-form evidence", 1)
+    report = tmp_path / "legacy.md"
+    report.write_text(content)
+    proc2 = subprocess.run([sys.executable, str(SCRIPT), str(report), "--research-pack", str(PACK), "--json"], capture_output=True, text=True)
+    data2 = json.loads(proc2.stdout)
+    manual = next(a for a in data2["audits"] if a["audit_id"] == "market-outlook-audit")
+    assert manual["execution_source"] == "legacy_self_attested"

--- a/tests/test_issue401_checklist_not_execution.py
+++ b/tests/test_issue401_checklist_not_execution.py
@@ -535,3 +535,24 @@ def test_report_context_rejects_pack_evidence_without_pack_text(tmp_path: Path) 
         assert any("pack" in e.lower() and "not allowed" in e.lower() for e in res.errors)
     finally:
         shutil.rmtree(rec_dir, ignore_errors=True)
+
+
+def test_report_template_does_not_advertise_direct_checklist_item_as_strict_valid() -> None:
+    """Regression: canonical report-template must not teach bare checklist-item as strict Passed evidence."""
+    text = (ROOT / "references" / "report-template.md").read_text(encoding="utf-8")
+    # Find the evidence row for Passed
+    passed_idx = text.find("已通过 (Passed)")
+    assert passed_idx != -1, "template must contain Passed evidence description"
+    # The next ~500 chars after that header should contain the allowed references
+    snippet = text[passed_idx : passed_idx + 800]
+    # It must mention audit-record as allowed
+    assert "audit-record:" in snippet, "template should advertise audit-record for Passed"
+    # It must NOT list checklist-item as a direct allowed Passed evidence without qualification
+    # Extract the line that lists the allowed refs (starts with ✅ or contains report-section)
+    lines = snippet.split("\n")
+    allowed_line = next((l for l in lines if "report-section" in l and "audit-record" in l), "")
+    assert allowed_line, "could not find allowed evidence line"
+    assert "checklist-item" not in allowed_line, "direct checklist-item must not be listed as standalone Passed evidence"
+    # Must contain the clarifying note that checklist-item is definition-only and must be via audit-record
+    assert "only identifies a checklist definition" in text
+    assert "must be referenced from an artifact-bound" in text


### PR DESCRIPTION
Closes #401

## 背景
`scripts/audit_evidence.py` 把 `checklist-item:checklists/final-audit.md#FA-001` 只要命中 `<!-- audit-item -->` 就判 `verified=True`，即使模板中仍是 `- [ ]` 未勾选。`audit_report.py --strict --require-contract --json` 对仅引用该 marker 的报告仍返回 `overall=pass`（已复现）。这违反 #389/#400 “静态模板不能当成已执行证据” 的要求，且会让 #402/#403 建在不可信 Pass 之上。

## 改动
- **audit_evidence**
  - `checklist-item` 在 `strict=True` 时一律 fail closed：`definition-only; strict requires audit-record`，`verified=False`，`definition_only=True`；兼容模式保持原验证
  - `audit-record` 在 `strict` 下新增绑定校验：
    - `audit_id` 必须与预期 audit 一致
    - `status` 必须为 `passed`
    - `artifact_sha256` **与** `artifact_id` 各自独立 fail-closed（`audit_report` 同时提供两者时必须同时匹配；hash 错不能靠 id 抢救；`contract`/`pack` 仅提供 id 时校验 id）
    - `executed_at` 存在且非未来
    - `execution_source` 必填且必须与 `execution_type` 精确匹配（`manual↔manual_checklist_attestation`, `process↔process_node_evidence`；缺失、cross、legacy 均 fail）
    - `route` 绑定到当前 canonical route
    - `evidence` 必填且必须为可验证的 `checklist-item` 或 `report/pack-section|table`（防止 JSON 自证）；`report-*` 仅在 report 文本中验证，`pack-*` 仅在 pack 文本中验证，杜绝 `report-section` 在 pack 文本中被误验的 type confusion
    - 重复 `record_id+timestamp` 判 `ambiguous` 而非 first-match-wins
    - `validate_evidence_reference` 透传 `expected_audit_id / expected_artifact_sha256 / expected_artifact_id / expected_route / report_text / pack_text`
  - Provenance 输出 `record_evidence`, `record_evidence_provenance`, `record_route`, `record_execution_source` 等
- **audit_report**
  - 计算 `expected_artifact_sha256=_sha256(report)` 与 `expected_artifact_id=contract.artifact_id` 及 `expected_route=route_id`，传入 manual/process 及 `secondary-hard-fail` 的 evidence 校验
  - `checklist-only` 在 strict 下自动降级为 `partial` 并阻塞
  - 缺失 `execution_source` 的 record 不再被自动伪造为 `manual_checklist_attestation`（置为 `unknown`，`partial`）
- **validate_contract / validate_research_pack**
  - 复用同一语义：合约传入 `expected_artifact_id` + `primary_route`，Pack 同时传入 `artifact_id`、`route`、`report_text`/`pack_text` 以正确验证嵌套 evidence

- **references/report-template.md**
  - 同步 strict 协议：`✅ Passed` 仅列 `report-section/table` 与 `audit-record`，`checklist-item` 改为说明性注释“only identifies a definition, must be referenced from artifact-bound audit-record”

- **tests**
  - 更新 `tests/test_audit_evidence_provenance.py`：`test_real_checklist_item_is_verified` 改为 strict 拒绝 + compat 通过；`test_audit_record_requires_matching_record_content` 补齐 `evidence`/`route`/`execution_source`
  - 新增 `tests/test_issue401_checklist_not_execution.py` **20 例**：
    - 未勾选模板 `FA-001`、伪造 `NO_SUCH_ITEM`、缺失文件、`status=partial`、`artifact` 错绑、`audit_id` 错绑、`hash对/id错`、`id对/hash错`、`execution_source` cross/legacy/missing、`missing evidence`、`duplicate`（正反序）、`wrong route` 均 `exit 2 / partial`
    - `report-section` 仅在 pack 存在、`pack-section` 仅在 report 存在、report 上下文里 `pack-section` 不带 `pack_text` 均正确 fail（type confusion 回归）
    - 合法 `audit-record`（含 `evidence:report-section:Monitoring signals` + `route:market-outlook` + 双 artifact 绑定）可在 strict 下 `pass`
    - `report-template` 回归：裸 `checklist-item` 不得再被列为 standalone Passed 合法 evidence
    - JSON 区分 4 类 `execution_source` 并验证 `process_node_evidence`

## 验证
- 复现：`checklist-item:checklists/final-audit.md#FA-001` 在 `[ ]` 时，改前 `rc=0 pass`，改后 `rc=2 fail [market-outlook-audit] partial — checklist-item is definition-only`
- 正例：`python scripts/audit_report.py tests/fixtures/audit/market-outlook-pos.md --research-pack tests/fixtures/audit/research-pack-pos.md --strict --require-contract --json` 仍 `pass`
- `python -m pytest -q` 全量： **1583 passed**（新增 20 例 #401 专项，无回归）
- `python scripts/validate_research_pack.py <pack>.md --strict` 仍通过

## 风险与边界
- **Breaking**：原先用 `checklist-item` 单独在 strict 下可 Pass 的报告，改后需改为 `audit-record`（含 `artifact` 双绑定 + `evidence` + `route` + `execution_source`）或改用 `report-section`/`report-table`（仍有效，因已绑定到当前 artifact 文本）
- **不做**：未改 route taxonomy / checklist 业务内容 / PDF 主题；未引入关键词匹配；未改 forward metrics 口径（属 #403）；未将所有 checklist 自动化

## 验收对应
- [x] 仅引用 `[ ]` 模板 marker，strict 不得可信 pass
- [x] marker 不存在 / record 缺失 / status 非 passed / hash 错配 / audit 错配 / route 错配 / missing evidence/source / duplicate → `exit 2 / partial`
- [x] 合法 audit-record 含可定位 evidence + 当前 artifact 双绑定 + route → strict 可通过
- [x] JSON 区分 4 类 execution_source 并输出 `record_evidence` 及嵌套 provenance
- [x] 新增负例 20，现有正例/secondary-hard-fail/route mismatch 不回归
- [x] `report-template` 已与 strict 协议同步，回归测试锁定

为 #402 `validator binding` 一致性提供稳定的 evidence/provenance 字段。
