### PR TITLE
fix(#402): 强制 contract/pack audit evidence 与 audit registry validator binding 精确一致

### DIFF
--- a/schemas/route-activation-contract.json
+++ b/schemas/route-activation-contract.json
@@ -109,7 +109,7 @@
             "description": "Execution status of this audit"
           },
           "evidence": {
-            "description": "Typed reference to a concrete evidence location. Legacy free-form strings are compatibility-only and cannot pass strict validation.",
+            "description": "Typed reference to a concrete evidence location. Legacy free-form strings are compatibility-only and cannot pass strict validation. Issue #402: for an automated audit a validator reference must exactly match the audit's registry validator_binding (schemas/audit-registry.json) — a registered-but-wrong binding fails closed; a nested object's validator_binding field must agree with locator, and additional fields are rejected at runtime.",
             "oneOf": [
               {
                 "type": "string",

--- a/scripts/audit_evidence.py
+++ b/scripts/audit_evidence.py
@@ -552,17 +552,14 @@ def _validate_audit_record(
                     "(automated audit requires the registry binding)"
                 )
         elif strict:
-            # Manual/process audit: a declared validator_binding (string or
-            # non-string) claims automated support that must fail closed.
-            if isinstance(record_binding, str) and record_binding.strip():
+            # Manual/process audit: null is the only allowed validator_binding —
+            # any non-null value (string, empty string, or non-string) claims
+            # automated support and must fail closed.
+            if record_binding is not None:
                 strict_errors.append(
                     "audit record declares validator_binding for a manual/process "
-                    "audit (only automated audits execute a validator)"
-                )
-            elif record_binding is not None and not isinstance(record_binding, str):
-                strict_errors.append(
-                    "audit record validator_binding must be null for a "
-                    "manual/process audit (only automated audits execute a validator)"
+                    "audit (only automated audits execute a validator; null is "
+                    "the only allowed value)"
                 )
         # evidence binding (issue #401 P1): record must reference the actual checklist/section that was checked
         # This prevents JSON self-attestation: hash alone is not proof that a specific audit step was executed.
@@ -795,6 +792,16 @@ def validate_evidence_reference(
                     + ", ".join(sorted(extra)),
                 )
             )
+        # Issue #402 (review round 2): the JSON Schema declares every optional
+        # field as {"type": "string"} when present.  Type-check them here, at
+        # the dict layer, so a non-string value on ANY kind (e.g. a
+        # report_section with validator_binding=123) is rejected before
+        # dispatch — not only inside the automated_validator branch.
+        for field in ("record_path", "record_id", "recorded_at", "validator_binding"):
+            if field in reference and not isinstance(reference[field], str):
+                return EvidenceValidation(
+                    errors=(f"evidence {field} must be a string",),
+                )
         kind = _normalise_kind(reference.get("kind"))
         raw_locator = reference.get("locator")
         if isinstance(raw_locator, str):
@@ -905,31 +912,21 @@ def validate_evidence_reference(
             )
         # Issue #402: a nested object's validator_binding field must agree with
         # its locator (declared support must name the referenced validator).
-        if declared_binding is not None:
-            if not isinstance(declared_binding, str):
-                return EvidenceValidation(
-                    provenance={
-                        "kind": "automated_validator",
-                        "locator": locator,
-                        "validator_binding": locator,
-                        "verified": False,
-                    },
-                    errors=("evidence validator_binding must be a string",),
-                )
-            if declared_binding.strip() != locator:
-                return EvidenceValidation(
-                    provenance={
-                        "kind": "automated_validator",
-                        "locator": locator,
-                        "validator_binding": locator,
-                        "declared_binding": declared_binding,
-                        "verified": False,
-                    },
-                    errors=(
-                        f"evidence validator_binding {declared_binding!r} does "
-                        f"not match locator {locator!r}",
-                    ),
-                )
+        # Non-string values were already rejected at the dict layer.
+        if isinstance(declared_binding, str) and declared_binding.strip() != locator:
+            return EvidenceValidation(
+                provenance={
+                    "kind": "automated_validator",
+                    "locator": locator,
+                    "validator_binding": locator,
+                    "declared_binding": declared_binding,
+                    "verified": False,
+                },
+                errors=(
+                    f"evidence validator_binding {declared_binding!r} does "
+                    f"not match locator {locator!r}",
+                ),
+            )
         # Issue #402: the binding must exactly match the audit's registry
         # validator_binding.  A registered-but-wrong binding (e.g.
         # validator:report-quality for the forward-looking-claims audit) fails

--- a/scripts/audit_evidence.py
+++ b/scripts/audit_evidence.py
@@ -304,6 +304,7 @@ def _validate_audit_record(
     expected_artifact_sha256: str | None = None,
     expected_artifact_id: str | None = None,
     expected_route: str | None = None,
+    expected_validator_binding: str | None = None,
     execution_type: str | None = None,
     artifact_text: str | None = None,
     artifact_label: str = "report",
@@ -518,6 +519,21 @@ def _validate_audit_record(
                     strict_errors.append(
                         f"audit record execution_source {src!r} does not match {execution_type} audit (expected {sorted(allowed)})"
                     )
+        # validator binding (issue #402): the record must not claim support
+        # from a validator different from the audit's registry binding, and a
+        # manual/process record must not declare any validator_binding at all.
+        record_binding = matching_record.get("validator_binding")
+        if expected_validator_binding is not None:
+            if isinstance(record_binding, str) and record_binding.strip() != expected_validator_binding:
+                strict_errors.append(
+                    f"audit record validator_binding {record_binding!r} does not match "
+                    f"expected binding {expected_validator_binding!r}"
+                )
+        elif strict and isinstance(record_binding, str) and record_binding.strip():
+            strict_errors.append(
+                "audit record declares validator_binding for a manual/process "
+                "audit (only automated audits execute a validator)"
+            )
         # evidence binding (issue #401 P1): record must reference the actual checklist/section that was checked
         # This prevents JSON self-attestation: hash alone is not proof that a specific audit step was executed.
         # P1/P2 review (b1916b3): nested report-/pack- evidence must be validated against the correct artifact text.
@@ -632,6 +648,9 @@ def _validate_audit_record(
             _ev = matching_record.get("evidence") or matching_record.get("evidence_locator")
             if _ev is not None:
                 provenance["record_evidence"] = _ev
+            _binding = matching_record.get("validator_binding")
+            if _binding is not None:
+                provenance["record_validator_binding"] = _binding
             return EvidenceValidation(
                 provenance=provenance,
                 errors=tuple(strict_errors),
@@ -711,6 +730,7 @@ def validate_evidence_reference(
     expected_artifact_sha256: str | None = None,
     expected_artifact_id: str | None = None,
     expected_route: str | None = None,
+    expected_validator_binding: str | None = None,
     report_text: str | None = None,
     pack_text: str | None = None,
 ) -> EvidenceValidation:
@@ -721,14 +741,35 @@ def validate_evidence_reference(
     section/table references are resolved against visible content.  Legacy
     free-form strings are warnings outside strict mode and errors in strict
     mode; callers can still expose their provenance explicitly.
+
+    ``expected_validator_binding`` (issue #402) is the audit's registry
+    validator_binding.  An ``automated_validator`` reference must match it
+    exactly; a registered-but-wrong binding fails closed.  Nested evidence
+    objects must not carry unknown fields and their ``validator_binding``
+    field (when present) must agree with ``locator`` — matching the JSON
+    Schema in schemas/route-activation-contract.json.
     """
     kind: str | None = None
     locator: str | None = None
+    declared_binding: object | None = None
     if isinstance(reference, dict):
+        allowed_fields = {
+            "kind", "locator", "record_path", "record_id", "recorded_at",
+            "validator_binding",
+        }
+        extra = set(reference) - allowed_fields
+        if extra:
+            return EvidenceValidation(
+                errors=(
+                    "evidence object has unknown field(s): "
+                    + ", ".join(sorted(extra)),
+                )
+            )
         kind = _normalise_kind(reference.get("kind"))
         raw_locator = reference.get("locator")
         if isinstance(raw_locator, str):
             locator = raw_locator.strip()
+        declared_binding = reference.get("validator_binding")
     elif isinstance(reference, str):
         raw = reference.strip()
         match = _REFERENCE_RE.match(raw)
@@ -794,6 +835,7 @@ def validate_evidence_reference(
             expected_artifact_sha256=expected_artifact_sha256,
             expected_artifact_id=expected_artifact_id,
             expected_route=expected_route,
+            expected_validator_binding=expected_validator_binding,
             execution_type=execution_type,
             artifact_text=artifact_text,
             artifact_label=artifact_label,
@@ -829,6 +871,51 @@ def validate_evidence_reference(
                 },
                 errors=(
                     f"validator binding {locator!r} is not registered",
+                ),
+            )
+        # Issue #402: a nested object's validator_binding field must agree with
+        # its locator (declared support must name the referenced validator).
+        if declared_binding is not None:
+            if not isinstance(declared_binding, str):
+                return EvidenceValidation(
+                    provenance={
+                        "kind": "automated_validator",
+                        "locator": locator,
+                        "validator_binding": locator,
+                        "verified": False,
+                    },
+                    errors=("evidence validator_binding must be a string",),
+                )
+            if declared_binding.strip() != locator:
+                return EvidenceValidation(
+                    provenance={
+                        "kind": "automated_validator",
+                        "locator": locator,
+                        "validator_binding": locator,
+                        "declared_binding": declared_binding,
+                        "verified": False,
+                    },
+                    errors=(
+                        f"evidence validator_binding {declared_binding!r} does "
+                        f"not match locator {locator!r}",
+                    ),
+                )
+        # Issue #402: the binding must exactly match the audit's registry
+        # validator_binding.  A registered-but-wrong binding (e.g.
+        # validator:report-quality for the forward-looking-claims audit) fails
+        # closed instead of borrowing another validator's success.
+        if expected_validator_binding is not None and locator != expected_validator_binding:
+            return EvidenceValidation(
+                provenance={
+                    "kind": "automated_validator",
+                    "locator": locator,
+                    "validator_binding": locator,
+                    "expected_binding": expected_validator_binding,
+                    "verified": False,
+                },
+                errors=(
+                    f"validator binding {locator!r} does not match audit "
+                    f"binding {expected_validator_binding!r}",
                 ),
             )
         return EvidenceValidation(

--- a/scripts/audit_evidence.py
+++ b/scripts/audit_evidence.py
@@ -73,11 +73,18 @@ def _normalise_heading(value: str) -> str:
 
 
 def _normalise_kind(value: object) -> str | None:
+    """Normalise a *dict-form* evidence kind (issue #402).
+
+    The JSON Schema (schemas/route-activation-contract.json) declares an
+    exact enum for a nested evidence object's ``kind``:
+    report_section / report_table / pack_section / pack_table /
+    checklist_item / audit_record / automated_validator.  Prefix vocabulary
+    (``validator``, ``report-section``) and case/whitespace variants are
+    string-reference forms and must NOT be accepted for objects — otherwise
+    schema-rejected objects pass runtime validation.
+    """
     if not isinstance(value, str):
         return None
-    value = value.strip().lower()
-    if value in _PREFIX_TO_KIND:
-        return _PREFIX_TO_KIND[value]
     if value in _KIND_TO_PREFIX:
         return value
     return None
@@ -504,7 +511,17 @@ def _validate_audit_record(
                         )
         # execution_source must be explicitly declared and align with registry (issue #401 P2).
         # Missing source is now fail-closed; caller must not auto-fill.
-        if execution_type in {"manual", "process"}:
+        if execution_type == "automated":
+            # Issue #402: an automated audit-record is a validator execution
+            # record — it must declare the automated_validator source, never a
+            # manual attestation.  Missing source is fail-closed too.
+            src = matching_record.get("execution_source") or matching_record.get("source")
+            if not isinstance(src, str) or src.strip() != "automated_validator":
+                strict_errors.append(
+                    "audit record execution_source must be 'automated_validator' "
+                    "for an automated audit (strict requires it)"
+                )
+        elif execution_type in {"manual", "process"}:
             src = matching_record.get("execution_source") or matching_record.get("source")
             if not isinstance(src, str) or not src.strip():
                 strict_errors.append(
@@ -524,16 +541,29 @@ def _validate_audit_record(
         # manual/process record must not declare any validator_binding at all.
         record_binding = matching_record.get("validator_binding")
         if expected_validator_binding is not None:
-            if isinstance(record_binding, str) and record_binding.strip() != expected_validator_binding:
+            # Automated audit: the registry binding is the execution identity —
+            # missing / null / non-string / wrong string all fail closed.
+            if not isinstance(record_binding, str) or (
+                record_binding.strip() != expected_validator_binding
+            ):
                 strict_errors.append(
-                    f"audit record validator_binding {record_binding!r} does not match "
-                    f"expected binding {expected_validator_binding!r}"
+                    f"audit record validator_binding {record_binding!r} does not "
+                    f"match expected binding {expected_validator_binding!r} "
+                    "(automated audit requires the registry binding)"
                 )
-        elif strict and isinstance(record_binding, str) and record_binding.strip():
-            strict_errors.append(
-                "audit record declares validator_binding for a manual/process "
-                "audit (only automated audits execute a validator)"
-            )
+        elif strict:
+            # Manual/process audit: a declared validator_binding (string or
+            # non-string) claims automated support that must fail closed.
+            if isinstance(record_binding, str) and record_binding.strip():
+                strict_errors.append(
+                    "audit record declares validator_binding for a manual/process "
+                    "audit (only automated audits execute a validator)"
+                )
+            elif record_binding is not None and not isinstance(record_binding, str):
+                strict_errors.append(
+                    "audit record validator_binding must be null for a "
+                    "manual/process audit (only automated audits execute a validator)"
+                )
         # evidence binding (issue #401 P1): record must reference the actual checklist/section that was checked
         # This prevents JSON self-attestation: hash alone is not proof that a specific audit step was executed.
         # P1/P2 review (b1916b3): nested report-/pack- evidence must be validated against the correct artifact text.

--- a/scripts/audit_report.py
+++ b/scripts/audit_report.py
@@ -949,6 +949,8 @@ class ValidatorResult:
     evidence: list[str] = field(default_factory=list)
     execution_source: str = "automated_validator"
     validator_version: str | None = None
+    target: str | None = None
+    input_sha256: str | None = None
     reason: str | None = None
 
 
@@ -1207,6 +1209,14 @@ def _execution_source(execution_type: str, *, legacy: bool = False) -> str:
     return "manual_checklist_attestation"
 
 
+def _registry_version() -> str:
+    """Canonical registry version string recorded on every provenance record."""
+    return (
+        f"audit-registry-v{_AUDIT_REGISTRY.version} "
+        f"(route-manifest-v{_ROUTE_REGISTRY.version})"
+    )
+
+
 def _registered_validator_bindings() -> set[str]:
     """Return validator ids with runtime functions in this module."""
     return set(_VALIDATOR_REGISTRY) | set(_AUDIT_VALIDATOR_REGISTRY)
@@ -1439,9 +1449,13 @@ def _execute_required_audits(
             evidence = [f"{target}: no violations found by {binding}"]
         evidence_provenance = [{
             "kind": "automated_validator",
+            "audit_id": audit_id,
             "locator": binding,
             "validator_binding": binding,
+            "execution_source": "automated_validator",
             "target": str(target),
+            "input_sha256": _sha256(target),
+            "validator_version": _registry_version(),
             "verified": True,
         }]
         results.append(AuditResult(
@@ -1612,6 +1626,7 @@ def _compute_verdict(
                     errors=list(result.errors),
                     warnings=list(result.warnings),
                     evidence=evidence,
+                    target=source_path,
                 ))
             else:
                 # Fail-closed: a dispatched validator with no recorded result
@@ -1619,6 +1634,7 @@ def _compute_verdict(
                 validator_results.append(ValidatorResult(
                     validator_id=validator_id,
                     status="incomplete",
+                    target=source_path,
                     reason="validator result missing — never aggregated as pass",
                 ))
                 blocking.append(
@@ -1727,6 +1743,8 @@ def _verdict_to_json(verdict: AuditVerdict) -> str:
                 "evidence": v.evidence,
                 "execution_source": v.execution_source,
                 "validator_version": v.validator_version,
+                "target": v.target,
+                "input_sha256": v.input_sha256,
                 "reason": v.reason,
             }
             for v in verdict.validator_results
@@ -1912,15 +1930,16 @@ def _finalize_verdict(verdict: AuditVerdict, path: Path) -> AuditVerdict:
     if verdict.input_sha256 is None:
         verdict.input_sha256 = _sha256(path)
     if verdict.validator_version is None:
-        verdict.validator_version = (
-            f"audit-registry-v{_AUDIT_REGISTRY.version} "
-            f"(route-manifest-v{_ROUTE_REGISTRY.version})"
-        )
-    # Propagate the shared validator version onto each route-level validator
-    # result so JSON carries per-validator provenance (issue #393).
+        verdict.validator_version = _registry_version()
+    # Propagate the shared validator version and artifact hash onto each
+    # route-level validator result so JSON carries per-validator provenance
+    # (issue #393) and each record is bound to the audited artifact
+    # (issue #402: target, input/artifact hash, version).
     for validator in verdict.validator_results:
         if validator.validator_version is None:
             validator.validator_version = verdict.validator_version
+        if validator.input_sha256 is None:
+            validator.input_sha256 = verdict.input_sha256
     return verdict
 
 

--- a/scripts/validate_contract.py
+++ b/scripts/validate_contract.py
@@ -67,6 +67,17 @@ VALID_AUDIT_STATUSES = {"passed", "skipped", "not_run", "partial"}
 ARTIFACT_META_FIELDS = ("artifact_id", "contract_version", "created_at")
 
 
+def _execution_source(execution_type: str) -> str:
+    """Map a registry audit execution_type to the canonical provenance
+    vocabulary (issue #402).  execution_source cannot be arbitrarily
+    overridden by the report — it must be derived from the registry."""
+    if execution_type == "automated":
+        return "automated_validator"
+    if execution_type == "process":
+        return "process_node_evidence"
+    return "manual_checklist_attestation"
+
+
 # ── Data types ──────────────────────────────────────────────────────────────
 
 
@@ -694,6 +705,14 @@ def validate_contract(
             if audit_info is not None
             else "manual" if is_derived_hard_fail else None
         )
+        # Issue #402: the audit's registry validator_binding is the only
+        # binding an automated audit may claim.  Manual/process and derived
+        # hard-fail audits have no binding.
+        audit_validator_binding = (
+            audit_info.validator_binding
+            if audit_info is not None
+            else None
+        )
 
         status = audit.get("status", "")
         if not isinstance(status, str):
@@ -726,6 +745,26 @@ def validate_contract(
                 f"Audit '{audit_id}' has invalid execution_source "
                 f"'{execution_source}'"
             )
+        # Issue #402: execution_source must be derived from the registry
+        # execution_type, not arbitrarily overridden by the report.
+        # legacy_self_attested is a compatibility label allowed only on the
+        # non-strict path (where legacy free-form evidence is tolerated).
+        if execution_source is not None and audit_execution_type is not None:
+            derived_source = _execution_source(audit_execution_type)
+            if execution_source != derived_source:
+                if strict or execution_source != "legacy_self_attested":
+                    errors.append(
+                        f"Audit '{audit_id}' execution_source "
+                        f"'{execution_source}' does not match registry "
+                        f"execution_type '{audit_execution_type}' "
+                        f"(expected '{derived_source}')"
+                    )
+                else:
+                    warnings.append(
+                        f"Audit '{audit_id}' execution_source "
+                        f"'{execution_source}' is a legacy compatibility label "
+                        f"(expected '{derived_source}')"
+                    )
 
         if status not in VALID_AUDIT_STATUSES:
             errors.append(
@@ -766,6 +805,7 @@ def validate_contract(
                 expected_audit_id=audit_id,
                 expected_artifact_id=expected_aid,
                 expected_route=expected_route_for_record,
+                expected_validator_binding=audit_validator_binding,
                 report_text=report_text if strict else None,
                 pack_text=None,
             )

--- a/scripts/validate_research_pack.py
+++ b/scripts/validate_research_pack.py
@@ -655,6 +655,11 @@ def _check_audit_evidence(
                 expected_audit_id=str(audit_id) if isinstance(audit_id, str) else None,
                 expected_artifact_id=pack_artifact_id,
                 expected_route=pack_route,
+                expected_validator_binding=(
+                    audit_info.validator_binding
+                    if audit_info is not None
+                    else None
+                ),
                 report_text=report_text,
                 pack_text=artifact_text,
             )

--- a/tests/test_audit_evidence_provenance.py
+++ b/tests/test_audit_evidence_provenance.py
@@ -551,3 +551,163 @@ def test_validator_reference_matches_expected_binding() -> None:
         expected_validator_binding="forward-looking-claims",
     )
     assert result.is_valid, result.errors
+
+
+# ─── Issue #402 review round 1: automated audit-record must prove the
+# registry validator executed it ────────────────────────────────────────────
+
+
+def _automated_record(**overrides) -> dict:
+    """Base JSON record for an automated audit execution."""
+    base = {
+        "record_id": "auto-001",
+        "recorded_at": "2026-08-19T10:00:00Z",
+        "audit_id": "forward-looking-claims",
+        "status": "passed",
+        "artifact_sha256": "b" * 64,
+        "executed_at": "2026-08-19T10:00:00Z",
+        "execution_source": "automated_validator",
+        "validator_binding": "forward-looking-claims",
+        "evidence": "report-section:Monitoring signals",
+        "route": "market-outlook",
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_record(tmp_path: Path, record: dict) -> Path:
+    path = tmp_path / "audit-record.json"
+    path.write_text(json.dumps({"records": [record]}), encoding="utf-8")
+    return path
+
+
+def _validate_auto_record(record: dict, *, base_dir: Path) -> object:
+    sys.path.insert(0, str(ROOT / "scripts"))
+    from audit_evidence import validate_evidence_reference
+    return validate_evidence_reference(
+        "audit-record:audit-record.json#auto-001@2026-08-19T10:00:00Z",
+        base_dir=base_dir,
+        strict=True,
+        expected_audit_id="forward-looking-claims",
+        expected_artifact_sha256="b" * 64,
+        expected_route="market-outlook",
+        expected_validator_binding="forward-looking-claims",
+        execution_type="automated",
+        artifact_text="## Monitoring signals\n\ncontent",
+    )
+
+
+def test_automated_audit_record_with_binding_and_source_passes(tmp_path: Path) -> None:
+    """Positive: an automated audit-record that declares the registry binding
+    and automated_validator source is accepted."""
+    record_path = _write_record(tmp_path, _automated_record())
+    result = _validate_auto_record(_automated_record(), base_dir=tmp_path)
+    assert result.is_valid, result.errors
+    assert result.provenance and result.provenance["verified"] is True
+
+
+def test_automated_audit_record_missing_binding_is_rejected(tmp_path: Path) -> None:
+    """An automated audit-record without validator_binding must fail closed —
+    the registry binding is the audit's execution identity."""
+    record = _automated_record()
+    del record["validator_binding"]
+    _write_record(tmp_path, record)
+    result = _validate_auto_record(record, base_dir=tmp_path)
+    assert not result.is_valid
+    assert any("validator_binding" in error for error in result.errors)
+
+
+def test_automated_audit_record_non_string_binding_is_rejected(tmp_path: Path) -> None:
+    """A non-string validator_binding must fail closed."""
+    record = _automated_record(validator_binding=123)
+    _write_record(tmp_path, record)
+    result = _validate_auto_record(record, base_dir=tmp_path)
+    assert not result.is_valid
+    assert any("validator_binding" in error for error in result.errors)
+
+
+def test_automated_audit_record_missing_execution_source_is_rejected(tmp_path: Path) -> None:
+    """An automated audit-record must declare execution_source=automated_validator."""
+    record = _automated_record()
+    del record["execution_source"]
+    _write_record(tmp_path, record)
+    result = _validate_auto_record(record, base_dir=tmp_path)
+    assert not result.is_valid
+    assert any("execution_source" in error for error in result.errors)
+
+
+def test_automated_audit_record_wrong_execution_source_is_rejected(tmp_path: Path) -> None:
+    """execution_source=manual_checklist_attestation on an automated audit is a
+    semantic drift — the record claims a manual attestation for a validator run."""
+    record = _automated_record(execution_source="manual_checklist_attestation")
+    _write_record(tmp_path, record)
+    result = _validate_auto_record(record, base_dir=tmp_path)
+    assert not result.is_valid
+    assert any("execution_source" in error for error in result.errors)
+
+
+# ─── Issue #402 review round 1: nested object kind must be the exact schema
+# enum (schemas/route-activation-contract.json) ──────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        "validator",            # prefix vocabulary, not a schema enum value
+        "report-section",       # prefix vocabulary, not a schema enum value
+        "AUTOMATED_VALIDATOR",  # schema enum is case-sensitive
+        " automated_validator ",  # schema enum is exact, no whitespace tolerance
+    ],
+)
+def test_evidence_object_kind_must_be_exact_schema_enum(kind: str) -> None:
+    """A nested evidence object's kind must be one of the JSON Schema enum
+    values exactly — schema-rejected kinds must not be accepted at runtime."""
+    sys.path.insert(0, str(ROOT / "scripts"))
+    from audit_evidence import validate_evidence_reference
+
+    result = validate_evidence_reference(
+        {"kind": kind, "locator": "forward-looking-claims"},
+        strict=True,
+        execution_type="automated",
+        known_validator_bindings={"forward-looking-claims"},
+    )
+    assert not result.is_valid
+    assert any("kind" in error for error in result.errors)
+
+
+# ─── Issue #402 review round 1: complete JSON provenance tuple ──────────────
+
+
+def test_json_automated_audit_provenance_is_complete() -> None:
+    """The automated audit evidence_provenance must carry audit_id, binding,
+    execution_source, target, input/artifact hash and validator version —
+    not just locator/binding/verified."""
+    result = _run_report(POSITIVE, "--strict", "--require-contract", "--json")
+    assert result.returncode == 0, result.stdout
+    data = json.loads(result.stdout)
+    automated = next(
+        audit for audit in data["audits"]
+        if audit["audit_id"] == "forward-looking-claims"
+    )
+    prov = automated["evidence_provenance"][0]
+    assert prov["kind"] == "automated_validator"
+    assert prov["audit_id"] == "forward-looking-claims"
+    assert prov["validator_binding"] == "forward-looking-claims"
+    assert prov["execution_source"] == "automated_validator"
+    assert prov["target"]
+    assert prov["input_sha256"] == data["input_sha256"]
+    assert prov["validator_version"]
+    assert prov["verified"] is True
+
+
+def test_json_validator_record_has_target_and_hash() -> None:
+    """Each route-level validator record must carry target and input/artifact
+    hash alongside execution_source and validator_version."""
+    result = _run_report(POSITIVE, "--strict", "--require-contract", "--json")
+    assert result.returncode == 0, result.stdout
+    data = json.loads(result.stdout)
+    for entry in data["validators"]:
+        assert entry["execution_source"]
+        assert entry["validator_version"]
+        assert entry["target"]
+        assert entry["input_sha256"] == data["input_sha256"]

--- a/tests/test_audit_evidence_provenance.py
+++ b/tests/test_audit_evidence_provenance.py
@@ -343,3 +343,211 @@ def test_audit_record_requires_matching_record_content(tmp_path: Path) -> None:
     )
     assert not forged.is_valid
     assert any("was not found" in error for error in forged.errors)
+
+
+# ─── Issue #402: validator binding must match the audit's registry binding ──
+#
+# The registry is the single source of truth for which validator executes an
+# automated audit.  A registered-but-wrong binding (e.g. validator:report-quality
+# for the forward-looking-claims audit) must fail closed in the contract,
+# the Research Pack, and the unified audit report.  execution_source must be
+# derived from the registry execution_type, not arbitrarily overridden by the
+# report.  Nested evidence objects must match the JSON Schema
+# (schemas/route-activation-contract.json): unknown fields and a
+# validator_binding field that disagrees with locator are rejected.
+
+
+def test_registered_but_wrong_validator_binding_cannot_pass(tmp_path: Path) -> None:
+    """forward-looking-claims audit evidence = validator:report-quality
+    (registered but wrong binding) must fail strict contract validation."""
+    content = POSITIVE.read_text(encoding="utf-8")
+    content = content.replace(
+        '"id": "forward-looking-claims", "status": "passed", '
+        '"evidence": "report-section:Monitoring signals"',
+        '"id": "forward-looking-claims", "status": "passed", '
+        '"evidence": "validator:report-quality"',
+        1,
+    )
+    report = tmp_path / "wrong-binding.md"
+    report.write_text(content, encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "validate_contract.py"),
+            str(report),
+            "--strict",
+            "--require-contract",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2, result.stdout
+    assert "does not match" in result.stdout or "binding" in result.stdout.lower()
+
+
+def test_wrong_validator_binding_fails_audit_report(tmp_path: Path) -> None:
+    """The unified audit_report --strict path must reject the same forgery."""
+    content = POSITIVE.read_text(encoding="utf-8")
+    content = content.replace(
+        '"id": "forward-looking-claims", "status": "passed", '
+        '"evidence": "report-section:Monitoring signals"',
+        '"id": "forward-looking-claims", "status": "passed", '
+        '"evidence": "validator:report-quality"',
+        1,
+    )
+    report = tmp_path / "wrong-binding.md"
+    report.write_text(content, encoding="utf-8")
+
+    result = _run_report(report, "--strict", "--require-contract", "--json")
+    assert result.returncode == 2, result.stdout
+    data = json.loads(result.stdout)
+    assert data["overall"] == "fail"
+    assert any("binding" in error.lower() for error in data["blocking"])
+
+
+def test_wrong_validator_binding_fails_research_pack(tmp_path: Path) -> None:
+    """A Research Pack declaring forward-looking-claims with a registered but
+    wrong binding must fail the standalone strict pack validator."""
+    content = PACK.read_text(encoding="utf-8").replace(
+        "- forward-looking-claims — passed — pack-section:Artifact contract",
+        "- forward-looking-claims — passed — validator:report-quality",
+        1,
+    )
+    pack = tmp_path / "wrong-binding-pack.md"
+    pack.write_text(content, encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "validate_research_pack.py"),
+            str(pack),
+            "--strict",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 4, result.stdout
+    assert "does not match" in result.stdout
+
+
+def test_correct_validator_binding_passes(tmp_path: Path) -> None:
+    """The exact registry binding for forward-looking-claims is accepted
+    end-to-end (positive regression guard for #402)."""
+    content = POSITIVE.read_text(encoding="utf-8")
+    content = content.replace(
+        '"id": "forward-looking-claims", "status": "passed", '
+        '"evidence": "report-section:Monitoring signals"',
+        '"id": "forward-looking-claims", "status": "passed", '
+        '"evidence": "validator:forward-looking-claims"',
+        1,
+    )
+    report = tmp_path / "correct-binding.md"
+    report.write_text(content, encoding="utf-8")
+
+    result = _run_report(report, "--strict", "--require-contract", "--json")
+    assert result.returncode == 0, result.stdout
+    data = json.loads(result.stdout)
+    assert data["overall"] == "pass"
+
+
+def test_execution_source_mismatch_is_rejected(tmp_path: Path) -> None:
+    """A manual audit declaring execution_source=automated_validator must not
+    be accepted: execution_source is derived from the registry execution_type."""
+    content = POSITIVE.read_text(encoding="utf-8")
+    content = content.replace(
+        '"id": "market-outlook-audit", "status": "passed", '
+        '"evidence": "report-section:Monitoring signals"',
+        '"id": "market-outlook-audit", "status": "passed", '
+        '"evidence": "report-section:Monitoring signals", '
+        '"execution_source": "automated_validator"',
+        1,
+    )
+    report = tmp_path / "wrong-exec-source.md"
+    report.write_text(content, encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "validate_contract.py"),
+            str(report),
+            "--strict",
+            "--require-contract",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2, result.stdout
+    assert "execution_source" in result.stdout
+
+
+def test_evidence_object_unknown_field_is_rejected() -> None:
+    """Nested evidence object with an extra field is rejected — the JSON
+    Schema (additionalProperties: false) must not be contradicted by runtime."""
+    sys.path.insert(0, str(ROOT / "scripts"))
+    from audit_evidence import validate_evidence_reference
+
+    result = validate_evidence_reference(
+        {
+            "kind": "automated_validator",
+            "locator": "forward-looking-claims",
+            "bogus": 1,
+        },
+        strict=True,
+        execution_type="automated",
+        known_validator_bindings={"forward-looking-claims"},
+    )
+    assert not result.is_valid
+    assert any("unknown field" in error for error in result.errors)
+
+
+def test_evidence_object_wrong_validator_binding_field_is_rejected() -> None:
+    """Nested evidence object whose validator_binding field disagrees with its
+    locator is rejected (declared support must match the referenced validator)."""
+    sys.path.insert(0, str(ROOT / "scripts"))
+    from audit_evidence import validate_evidence_reference
+
+    result = validate_evidence_reference(
+        {
+            "kind": "automated_validator",
+            "locator": "forward-looking-claims",
+            "validator_binding": "report-quality",
+        },
+        strict=True,
+        execution_type="automated",
+        known_validator_bindings={"forward-looking-claims", "report-quality"},
+    )
+    assert not result.is_valid
+    assert any("validator_binding" in error for error in result.errors)
+
+
+def test_validator_reference_must_match_expected_binding() -> None:
+    """A registered-but-wrong validator reference must fail exact-match against
+    the audit's registry validator_binding."""
+    sys.path.insert(0, str(ROOT / "scripts"))
+    from audit_evidence import validate_evidence_reference
+
+    result = validate_evidence_reference(
+        "validator:report-quality",
+        strict=True,
+        execution_type="automated",
+        known_validator_bindings={"forward-looking-claims", "report-quality"},
+        expected_validator_binding="forward-looking-claims",
+    )
+    assert not result.is_valid
+    assert any("does not match" in error for error in result.errors)
+
+
+def test_validator_reference_matches_expected_binding() -> None:
+    """The exact registry binding satisfies the expected-binding check."""
+    sys.path.insert(0, str(ROOT / "scripts"))
+    from audit_evidence import validate_evidence_reference
+
+    result = validate_evidence_reference(
+        "validator:forward-looking-claims",
+        strict=True,
+        execution_type="automated",
+        known_validator_bindings={"forward-looking-claims"},
+        expected_validator_binding="forward-looking-claims",
+    )
+    assert result.is_valid, result.errors

--- a/tests/test_audit_evidence_provenance.py
+++ b/tests/test_audit_evidence_provenance.py
@@ -711,3 +711,71 @@ def test_json_validator_record_has_target_and_hash() -> None:
         assert entry["validator_version"]
         assert entry["target"]
         assert entry["input_sha256"] == data["input_sha256"]
+
+
+# ─── Issue #402 review round 2: nested object optional-field types must match
+# the JSON Schema (all are {"type": "string"} when present) ──────────────────
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("validator_binding", 123),
+        ("record_path", 123),
+        ("record_id", []),
+        ("recorded_at", {}),
+    ],
+)
+def test_evidence_object_optional_fields_must_be_strings(
+    field: str, value: object
+) -> None:
+    """The schema declares record_path/record_id/recorded_at/validator_binding
+    as strings when present.  A non-string value on ANY kind must fail closed
+    at the dict layer, not only in the automated_validator branch."""
+    sys.path.insert(0, str(ROOT / "scripts"))
+    from audit_evidence import validate_evidence_reference
+
+    result = validate_evidence_reference(
+        {"kind": "report_section", "locator": "Findings", field: value},
+        strict=True,
+        artifact_text="## Findings\n\ncontent",
+    )
+    assert not result.is_valid
+    assert any("must be a string" in error for error in result.errors)
+
+
+def test_manual_audit_record_empty_binding_is_rejected(tmp_path: Path) -> None:
+    """A manual/process audit-record with validator_binding='' must fail
+    closed: null is the only allowed value (it claims no validator)."""
+    sys.path.insert(0, str(ROOT / "scripts"))
+    from audit_evidence import validate_evidence_reference
+
+    record = {
+        "record_id": "manual-001",
+        "recorded_at": "2026-08-18T10:00:00Z",
+        "audit_id": "market-outlook-audit",
+        "status": "passed",
+        "artifact_sha256": "a" * 64,
+        "executed_at": "2026-08-18T10:00:00Z",
+        "execution_source": "manual_checklist_attestation",
+        "evidence": "report-section:Monitoring signals",
+        "route": "market-outlook",
+        "validator_binding": "",
+    }
+    record_path = tmp_path / "audit-record.json"
+    record_path.write_text(
+        json.dumps({"records": [record]}), encoding="utf-8"
+    )
+
+    result = validate_evidence_reference(
+        "audit-record:audit-record.json#manual-001@2026-08-18T10:00:00Z",
+        base_dir=tmp_path,
+        strict=True,
+        expected_audit_id="market-outlook-audit",
+        expected_artifact_sha256="a" * 64,
+        expected_route="market-outlook",
+        execution_type="manual",
+        artifact_text="## Monitoring signals\n\ncontent",
+    )
+    assert not result.is_valid
+    assert any("validator_binding" in error for error in result.errors)


### PR DESCRIPTION
## 背景

本 PR 实现 #402（#400 第 2 步，依赖已合入的 #401）。

修复的 fail-open 缺口（已复现）：

- contract 中 `forward-looking-claims` audit 的 evidence 改成 `validator:report-quality`（已注册但错误 binding），`validate_contract.py --strict` 和 `audit_report.py --strict` 之前返回 `rc=0 / overall=pass`；
- Research Pack 里同样的错误 binding，`validate_research_pack.py --strict` 之前返回 exit 0；
- manual audit 声明 `execution_source: automated_validator`，strict contract 之前返回 exit 0；
- nested evidence object 带未知字段 / 非字符串可选字段，runtime 之前接受，而 JSON Schema 会拒绝（schema/runtime 不一致）。

## 改动

- `scripts/audit_evidence.py`：`validate_evidence_reference` 新增 `expected_validator_binding` 参数；`automated_validator` 引用必须精确等于 audit 的 registry binding；nested evidence object 在 dict 层统一拒绝未知字段和非字符串可选字段（`record_path`/`record_id`/`recorded_at`/`validator_binding` 出现即必须为 string），`validator_binding` 字段必须等于 locator；`_validate_audit_record` automated 路径强制 `execution_source == automated_validator` 且 `validator_binding` 必须精确等于 registry binding（缺失/null/非字符串/错误字符串均 fail closed），manual/process 记录仅允许 null binding。
- `scripts/validate_contract.py`：每个 audit 按 registry 传入 expected binding；`execution_source` 按 registry `execution_type` 校准（automated→automated_validator、manual→manual_checklist_attestation、process→process_node_evidence），`legacy_self_attested` 仅非 strict 兼容路径。
- `scripts/validate_research_pack.py`：`_check_audit_evidence` 按 registry 传入 expected binding。
- `scripts/audit_report.py`：`ValidatorResult` 增加 `target`/`input_sha256`，`_finalize_verdict` 按 `verdict.input_sha256` 填充；automated audit 的 `evidence_provenance` 补 `audit_id`/`execution_source`/`input_sha256`/`validator_version`；新增 `_registry_version()` 统一版本串。
- `schemas/route-activation-contract.json`：evidence 描述更新运行时 binding 规则（文档说明，不做不可移植的 JSON Schema 交叉引用）。
- `tests/test_audit_evidence_provenance.py`：负例（wrong-binding contract/pack/audit_report 三条路径、nested object 未知字段/非字符串可选字段/错误 kind/错误 validator_binding、execution_source mismatch、automated audit-record 缺失/非字符串 binding 与缺失/错误 source、manual record 空字符串 binding）+ 正例（正确 binding、完整 provenance tuple）。

## Review 轮次

- Round 1（REQUEST CHANGES → 已修 `951314b`）：P1 automated audit-record 强制 registry binding/source；P2 object kind 精确 schema enum；P2 完整 JSON provenance（target/hash/version）。
- Round 2（REQUEST CHANGES → 已修 `21c9d51`）：P2 dict evidence 可选字段类型在 dict 层统一按 schema 校验（不再只在 automated_validator 分支）；manual/process record 的 `validator_binding` 仅允许 null（空字符串也 fail closed）。

## 验证

- `tests/test_audit_evidence_provenance.py` 41 passed
- 建议命令三文件：248 passed
- 全量 `python3 -m pytest -q` → 1608 passed，0 失败
- 正例 `audit_report.py --strict --require-contract --research-pack` → exit 0
- 负例 contract → exit 2，负例 pack → exit 4，报错 `validator binding 'report-quality' does not match audit binding 'forward-looking-claims'`
- `run_forward_evals.py --offline --check-baseline --json` → 11/11，baseline 通过

## 边界

- 未改 route validator 业务规则、未加新 audit/route、未改 #392 structured replay 指标、未自动化人工 checklist（issue 非目标）。
- JSON `schema_version` 不 bump：新增字段是 additive，forward runner 只校验必填字段、不拒额外字段（已用实际 runner 验证）。
- 回归风险低：当前无 fixture 使用 `validator:` 引用、`execution_source` 字段或 dict-form evidence。